### PR TITLE
Upgrade to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.sirix</groupId>
     <artifactId>brackit</artifactId>
-    <version>0.1.7-SNAPSHOT</version>
+    <version>0.1.8</version>
     <name>Brackit Engine</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This PR is meant to solve issue https://github.com/sirixdb/brackit/issues/13.
Java is upgraded to version 17 and the java preview flag was removed.