### PR TITLE
Fix build warning about maven-source-plugin missing version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.vscode
 =======
 .classpath
 .project

--- a/.project
+++ b/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1651285147242</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/src/main/java/org/brackit/xquery/atomic/Flt.java
+++ b/src/main/java/org/brackit/xquery/atomic/Flt.java
@@ -28,6 +28,7 @@
 package org.brackit.xquery.atomic;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryException;
@@ -136,9 +137,9 @@ public class Flt extends AbstractNumeric implements FltNumeric {
       return Double.compare(v, ((Numeric) other).doubleValue());
     }
     throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
-                             "Cannot compare '%s' with '%s'",
-                             type(),
-                             other.type());
+        "Cannot compare '%s' with '%s'",
+        type(),
+        other.type());
   }
 
   @Override
@@ -158,8 +159,8 @@ public class Flt extends AbstractNumeric implements FltNumeric {
     if (v == 0)
       return (1 / v == 1 / 0.0f) ? "0" : "-0";
     return killTrailingZeros(((v > 0) && (v >= 1e-6) && (v < 1e6) || (-v >= 1e-6) && (-v < 1e6))
-                                 ? DF.format(v)
-                                 : SF.format(v));
+        ? DF.format(v)
+        : SF.format(v));
   }
 
   @Override
@@ -283,7 +284,10 @@ public class Flt extends AbstractNumeric implements FltNumeric {
     if (Float.isInfinite((float) scaled)) {
       BigDecimal bd = new BigDecimal(v);
       bd = bd.scaleByPowerOfTen(precision);
-      bd = bd.setScale(0, BigDecimal.ROUND_HALF_EVEN);
+      // Previously we used BigDecimal setScale(int, int) version. However, since that
+      // is deprecated
+      // the recommended approach is to use BigDecimal.setScale(int, RoundingMode)
+      bd = bd.setScale(0, RoundingMode.HALF_EVEN);
       bd = bd.scaleByPowerOfTen(-precision);
       return new Flt(bd.floatValue());
     }


### PR DESCRIPTION
I noticed that while running ```mvn package``` it would complain that
``` [WARNING] 'build.plugins.plugin.version'
for org.apache.maven.plugins:maven-source-plugin is missing.```. This
commit aims to reolve that warning by specifying the most recent version
of the maven-source-plugin in pom.xml. According to
https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-source-plugin,
the latest version of the maven-source-plugin is 3.2.1