### PR TITLE
Fix potential resource leak on some StringSerializer usages

### DIFF
--- a/src/main/java/org/brackit/xquery/compiler/analyzer/ExprAnalyzer.java
+++ b/src/main/java/org/brackit/xquery/compiler/analyzer/ExprAnalyzer.java
@@ -95,7 +95,8 @@ public class ExprAnalyzer extends AbstractAnalyzer {
         /* End XQuery Update Facility 1.0 */
         /* Begin JSONiq Update Facility */
         insertJsonExpr(expr) || deleteJsonExpr(expr) || renameJsonExpr(expr) || replaceJsonExpr(expr) || appendJsonExpr(
-        expr) ||
+            expr)
+        ||
         /* End JSONiq Update Facility */
         orExpr(expr));
   }
@@ -282,8 +283,8 @@ public class ExprAnalyzer extends AbstractAnalyzer {
       } catch (QueryException e) {
         if (e.getCode().equals(ErrorCode.ERR_DUPLICATE_VARIABLE_DECL)) {
           throw new QueryException(ErrorCode.ERR_FOR_VAR_AND_POS_VAR_EQUAL,
-                                   "Bound variable '%s' and its associated positional variable have the same name",
-                                   forVar);
+              "Bound variable '%s' and its associated positional variable have the same name",
+              forVar);
         }
         throw e;
       }
@@ -300,12 +301,12 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     QNm expanded = expand(name, DefaultNS.EMPTY);
     name = bind(expanded);
     binding.getChild(0).setValue(name);
-    //		SequenceType stype;
-    //		if (binding.getChildCount() >= 2) {
-    //			stype = typeDeclaration(binding.getChild(1));
-    //		} else {
-    //			stype = new SequenceType(AnyItemType.ANY, Cardinality.ZeroOrMany);
-    //		}
+    // SequenceType stype;
+    // if (binding.getChildCount() >= 2) {
+    // stype = typeDeclaration(binding.getChild(1));
+    // } else {
+    // stype = new SequenceType(AnyItemType.ANY, Cardinality.ZeroOrMany);
+    // }
     return expanded;
   }
 
@@ -319,7 +320,7 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     QNm expanded = expand(name, DefaultNS.EMPTY);
     name = bind(expanded);
     binding.getChild(0).setValue(name);
-    //		SequenceType stype = new SequenceType(AtomicType.INR, Cardinality.One);
+    // SequenceType stype = new SequenceType(AtomicType.INR, Cardinality.One);
     return expanded;
   }
 
@@ -430,8 +431,8 @@ public class ExprAnalyzer extends AbstractAnalyzer {
         String col = groupBySpec.getChild(1).getStringValue();
         if (!col.equals(StaticContext.UNICODE_COLLATION)) {
           throw new QueryException(ErrorCode.ERR_UNKNOWN_COLLATION_IN_FLWOR_CLAUSE,
-                                   "Unknown collation in group-by clause: %s",
-                                   col);
+              "Unknown collation in group-by clause: %s",
+              col);
         }
       }
     }
@@ -450,8 +451,8 @@ public class ExprAnalyzer extends AbstractAnalyzer {
           String col = orderBySpec.getChild(j).getStringValue();
           if (!col.equals(StaticContext.UNICODE_COLLATION)) {
             throw new QueryException(ErrorCode.ERR_UNKNOWN_COLLATION_IN_FLWOR_CLAUSE,
-                                     "Unknown collation in order-by clause: %s",
-                                     col);
+                "Unknown collation in order-by clause: %s",
+                col);
           }
         }
       }
@@ -667,8 +668,8 @@ public class ExprAnalyzer extends AbstractAnalyzer {
   }
 
   protected boolean additiveExpr(AST expr) throws QueryException {
-    if ((expr.getType() != XQ.ArithmeticExpr) || ((expr.getChild(0).getType() != XQ.AddOp) && (
-        expr.getChild(0).getType() != XQ.SubtractOp))) {
+    if ((expr.getType() != XQ.ArithmeticExpr)
+        || ((expr.getChild(0).getType() != XQ.AddOp) && (expr.getChild(0).getType() != XQ.SubtractOp))) {
       return multiplicativeExpr(expr);
     }
     additiveExpr(expr.getChild(1));
@@ -993,9 +994,9 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     if ((name.equals(Functions.FN_POSITION)) || (name.equals(Functions.FN_LAST))) {
       if (argc != 0) {
         throw new QueryException(ErrorCode.ERR_UNDEFINED_FUNCTION,
-                                 "Illegal number of parameters for function %s() : %s'",
-                                 name,
-                                 argc);
+            "Illegal number of parameters for function %s() : %s'",
+            name,
+            argc);
       }
       // change expr to variable reference
       expr.setType(XQ.VariableRef);
@@ -1006,9 +1007,9 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     if ((name.equals(Functions.FN_TRUE) || name.equals(Functions.FN_FALSE))) {
       if (argc != 0) {
         throw new QueryException(ErrorCode.ERR_UNDEFINED_FUNCTION,
-                                 "Illegal number of parameters for function %s() : %s'",
-                                 name,
-                                 argc);
+            "Illegal number of parameters for function %s() : %s'",
+            name,
+            argc);
       }
       // change expr to boolean literal
       expr.setType(XQ.Bool);
@@ -1019,9 +1020,9 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     if (name.equals(Functions.FN_DEFAULT_COLLATION)) {
       if (argc != 0) {
         throw new QueryException(ErrorCode.ERR_UNDEFINED_FUNCTION,
-                                 "Illegal number of parameters for function %s() : %s'",
-                                 name,
-                                 argc);
+            "Illegal number of parameters for function %s() : %s'",
+            name,
+            argc);
       }
       // change expr to string literal
       expr.setType(XQ.Str);
@@ -1031,9 +1032,9 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     if (name.equals(Functions.FN_STATIC_BASE_URI)) {
       if (argc != 0) {
         throw new QueryException(ErrorCode.ERR_UNDEFINED_FUNCTION,
-                                 "Illegal number of parameters for function %s() : %s'",
-                                 name,
-                                 argc);
+            "Illegal number of parameters for function %s() : %s'",
+            name,
+            argc);
       }
       AnyURI baseURI = sctx.getBaseURI();
       if (baseURI != null) {
@@ -1050,9 +1051,9 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     if (name.equals(JSONFun.JSON_NULL)) {
       if (argc != 0) {
         throw new QueryException(ErrorCode.ERR_UNDEFINED_FUNCTION,
-                                 "Illegal number of parameters for function %s() : %s'",
-                                 name,
-                                 argc);
+            "Illegal number of parameters for function %s() : %s'",
+            name,
+            argc);
       }
       expr.setType(XQ.Null);
       return true;
@@ -1207,7 +1208,7 @@ public class ExprAnalyzer extends AbstractAnalyzer {
       AST c = content.getChild(i);
       if (c.getType() == XQ.EnclosedExpr) {
         throw new QueryException(ErrorCode.ERR_ENCLOSED_EXPR_IN_NS_ATTRIBUTE,
-                                 "Illegal enclosed expression in direct namespace attribute");
+            "Illegal enclosed expression in direct namespace attribute");
       }
       uri.append(c.getStringValue());
     }
@@ -1220,18 +1221,18 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     if (Namespaces.XML_PREFIX.equals(prefix)) {
       if (Namespaces.XML_NSURI.equals(uri)) {
         throw new QueryException(ErrorCode.ERR_ILLEGAL_NAMESPACE_DECL,
-                                 "Illegal mapping of the prefix '%s' to the namespace URI '%s'",
-                                 Namespaces.XML_PREFIX,
-                                 uri);
+            "Illegal mapping of the prefix '%s' to the namespace URI '%s'",
+            Namespaces.XML_PREFIX,
+            uri);
       }
     } else if (Namespaces.XMLNS_PREFIX.equals(prefix)) {
       throw new QueryException(ErrorCode.ERR_ILLEGAL_NAMESPACE_DECL,
-                               "Illegal namespace prefix '%s'",
-                               Namespaces.XMLNS_PREFIX);
+          "Illegal namespace prefix '%s'",
+          Namespaces.XMLNS_PREFIX);
     } else if (Namespaces.XML_NSURI.equals(uri)) {
       throw new QueryException(ErrorCode.ERR_ILLEGAL_NAMESPACE_DECL,
-                               "Illegal namespace URI '%s'",
-                               Namespaces.XMLNS_NSURI);
+          "Illegal namespace URI '%s'",
+          Namespaces.XMLNS_NSURI);
     }
   }
 
@@ -1382,7 +1383,6 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     // expand and update AST
     name = expand(name, DefaultNS.FUNCTION);
     expr.getChild(0).setValue(name);
-    int argc = ((Numeric) expr.getChild(1).getValue()).intValue();
     // TODO lookup and checks
     return true;
   }
@@ -1402,26 +1402,29 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     // expand and update AST
     name = expand(name, null);
     child.getChild(0).setValue(name);
-//    if (name.getNamespaceURI().isEmpty()) {
-//      throw new QueryException(ErrorCode.ERR_FUNCTION_DECL_NOT_IN_NS, "Function %s is not in a namespace", name);
-//    }
+    // if (name.getNamespaceURI().isEmpty()) {
+    // throw new QueryException(ErrorCode.ERR_FUNCTION_DECL_NOT_IN_NS, "Function %s
+    // is not in a namespace", name);
+    // }
 
-//    String targetNS = module.getTargetNS();
-//    if ((targetNS != null) && (!targetNS.equals(name.getNamespaceURI()))) {
-//      throw new QueryException(ErrorCode.ERR_FUN_OR_VAR_NOT_IN_TARGET_NS,
-//                               "Declared function %s is not in library module namespace: %s",
-//                               name,
-//                               targetNS);
-//    }
-//
-//    String uri = name.getNamespaceURI();
-//    if ((uri.equals(Namespaces.XML_NSURI)) || (uri.equals(Namespaces.XS_NSURI)) || (uri.equals(Namespaces.XSI_NSURI))
-//        || (uri.equals(Namespaces.FN_NSURI)) || (uri.equals(Namespaces.FNMATH_NSURI))) {
-//      throw new QueryException(ErrorCode.ERR_FUNCTION_DECL_IN_ILLEGAL_NAMESPACE,
-//                               "Declared function %s is in illegal namespace: %s",
-//                               name,
-//                               uri);
-//    }
+    // String targetNS = module.getTargetNS();
+    // if ((targetNS != null) && (!targetNS.equals(name.getNamespaceURI()))) {
+    // throw new QueryException(ErrorCode.ERR_FUN_OR_VAR_NOT_IN_TARGET_NS,
+    // "Declared function %s is not in library module namespace: %s",
+    // name,
+    // targetNS);
+    // }
+    //
+    // String uri = name.getNamespaceURI();
+    // if ((uri.equals(Namespaces.XML_NSURI)) || (uri.equals(Namespaces.XS_NSURI))
+    // || (uri.equals(Namespaces.XSI_NSURI))
+    // || (uri.equals(Namespaces.FN_NSURI)) ||
+    // (uri.equals(Namespaces.FNMATH_NSURI))) {
+    // throw new QueryException(ErrorCode.ERR_FUNCTION_DECL_IN_ILLEGAL_NAMESPACE,
+    // "Declared function %s is in illegal namespace: %s",
+    // name,
+    // uri);
+    // }
 
     // parameters
     int noOfParameters = expr.getChildCount() - 2;
@@ -1436,9 +1439,9 @@ public class ExprAnalyzer extends AbstractAnalyzer {
       for (int j = 0; j < i; j++) {
         if (pNames[i].atomicCmp(pNames[j]) == 0) {
           throw new QueryException(ErrorCode.ERR_DUPLICATE_FUN_PARAMETER,
-                                   "Duplicate parameter in declared function %s: %s",
-                                   name,
-                                   pNames[j]);
+              "Duplicate parameter in declared function %s: %s",
+              name,
+              pNames[j]);
         }
       }
       if (child.getChildCount() == 2) {
@@ -1459,7 +1462,8 @@ public class ExprAnalyzer extends AbstractAnalyzer {
     sctx.getFunctions().declare(udf);
 
     return true;
-    //throw new QueryException(ErrorCode.BIT_DYN_RT_NOT_IMPLEMENTED_YET_ERROR, "Inline functions not implemented yet.");
+    // throw new QueryException(ErrorCode.BIT_DYN_RT_NOT_IMPLEMENTED_YET_ERROR,
+    // "Inline functions not implemented yet.");
   }
 
   boolean enclosedExpr(AST expr) throws QueryException {

--- a/src/main/java/org/brackit/xquery/compiler/analyzer/ForwardDeclaration.java
+++ b/src/main/java/org/brackit/xquery/compiler/analyzer/ForwardDeclaration.java
@@ -37,7 +37,6 @@ import org.brackit.xquery.compiler.AST;
 import org.brackit.xquery.compiler.Target;
 import org.brackit.xquery.compiler.Unit;
 import org.brackit.xquery.compiler.XQ;
-import org.brackit.xquery.compiler.analyzer.AbstractAnalyzer.DefaultNS;
 import org.brackit.xquery.expr.DeclVariable;
 import org.brackit.xquery.function.UDF;
 import org.brackit.xquery.module.Module;

--- a/src/main/java/org/brackit/xquery/function/DynamicFunctionExpr.java
+++ b/src/main/java/org/brackit/xquery/function/DynamicFunctionExpr.java
@@ -46,8 +46,6 @@ import org.brackit.xquery.xdm.json.Array;
 import org.brackit.xquery.xdm.json.Object;
 import org.magicwerk.brownies.collections.GapList;
 
-import javax.management.Query;
-
 /**
  * @author Johannes Lichtenberger
  */
@@ -83,9 +81,9 @@ public class DynamicFunctionExpr implements Expr {
 
         if (!(indexItem instanceof IntNumeric)) {
           throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
-                                   "Illegal operand type '%s' where '%s' is expected",
-                                   indexItem.itemType(),
-                                   Type.INR);
+              "Illegal operand type '%s' where '%s' is expected",
+              indexItem.itemType(),
+              Type.INR);
         }
 
         final int index = ((IntNumeric) indexItem).intValue();

--- a/src/main/java/org/brackit/xquery/function/bit/ArrayValues.java
+++ b/src/main/java/org/brackit/xquery/function/bit/ArrayValues.java
@@ -32,7 +32,6 @@ import java.util.Deque;
 import java.util.List;
 
 import org.brackit.xquery.QueryContext;
-import org.brackit.xquery.QueryException;
 import org.brackit.xquery.atomic.QNm;
 import org.brackit.xquery.compiler.Bits;
 import org.brackit.xquery.function.AbstractFunction;

--- a/src/main/java/org/brackit/xquery/function/bit/Eval.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Eval.java
@@ -75,9 +75,9 @@ public class Eval extends AbstractFunction {
         vQuery = ((Atomic) args[0]).stringValue();
       } else {
         PrintStream buf = IOUtils.createBuffer();
-        StringSerializer ser = new StringSerializer(buf);
-        ser.serialize(args[0]);
-        ser.close();
+        try (StringSerializer ser = new StringSerializer(buf)) {
+          ser.serialize(args[0]);
+        }
         vQuery = buf.toString();
       }
       XQuery x = new XQuery(vQuery);

--- a/src/main/java/org/brackit/xquery/function/bit/Eval.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Eval.java
@@ -62,9 +62,9 @@ public class Eval extends AbstractFunction {
 
   public Eval(QNm name) {
     super(name,
-          new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
-                        new SequenceType(AnyItemType.ANY, Cardinality.One)),
-          true);
+        new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+            new SequenceType(AnyItemType.ANY, Cardinality.One)),
+        true);
   }
 
   @Override
@@ -77,6 +77,7 @@ public class Eval extends AbstractFunction {
         PrintStream buf = IOUtils.createBuffer();
         StringSerializer ser = new StringSerializer(buf);
         ser.serialize(args[0]);
+        ser.close();
         vQuery = buf.toString();
       }
       XQuery x = new XQuery(vQuery);

--- a/src/main/java/org/brackit/xquery/function/bit/Partition.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Partition.java
@@ -1,0 +1,59 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.brackit.xquery.function.bit;
+
+import org.brackit.xquery.QueryContext;
+import org.brackit.xquery.atomic.QNm;
+import org.brackit.xquery.compiler.Bits;
+import org.brackit.xquery.function.AbstractFunction;
+import org.brackit.xquery.module.StaticContext;
+import org.brackit.xquery.xdm.Sequence;
+import org.brackit.xquery.xdm.Signature;
+import org.brackit.xquery.xdm.type.Cardinality;
+import org.brackit.xquery.xdm.type.AtomicType;
+import org.brackit.xquery.xdm.type.DocumentType;
+import org.brackit.xquery.xdm.type.SequenceType;
+
+public class Partition extends AbstractFunction {
+    public static final QNm PARTITION = new QNm(Bits.BIT_NSURI, Bits.BIT_PREFIX, "partition");
+
+    public Partition() {
+        super(PARTITION,
+                new Signature(new SequenceType(DocumentType.DOC, Cardinality.One),
+                        new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne)),
+                true);
+    }
+
+    @Override
+    public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/src/main/java/org/brackit/xquery/function/bit/Serialize.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Serialize.java
@@ -72,9 +72,9 @@ public class Serialize extends AbstractFunction {
       return Int32.ZERO;
     }
     final PrintStream buf = IOUtils.createBuffer();
-    StringSerializer serializer = new StringSerializer(buf);
-    serializer.serialize(sequence);
-    serializer.close();
+    try (StringSerializer serializer = new StringSerializer(buf)) {
+      serializer.serialize(sequence);
+    }
     return new Str(buf.toString());
   }
 }

--- a/src/main/java/org/brackit/xquery/function/bit/Serialize.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Serialize.java
@@ -72,7 +72,9 @@ public class Serialize extends AbstractFunction {
       return Int32.ZERO;
     }
     final PrintStream buf = IOUtils.createBuffer();
-    new StringSerializer(buf).serialize(sequence);
+    StringSerializer serializer = new StringSerializer(buf);
+    serializer.serialize(sequence);
+    serializer.close();
     return new Str(buf.toString());
   }
 }

--- a/src/main/java/org/brackit/xquery/function/bit/Silent.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Silent.java
@@ -77,9 +77,9 @@ public class Silent extends AbstractFunction {
       return Int32.ZERO;
     }
     CountStream out = new CountStream();
-    StringSerializer serializer = new StringSerializer(new PrintWriter(out));
-    serializer.serialize(sequence);
-    serializer.close();
+    try (StringSerializer serializer = new StringSerializer(new PrintWriter(out))) {
+      serializer.serialize(sequence);
+    }
     return new Int64(out.count);
   }
 }

--- a/src/main/java/org/brackit/xquery/function/bit/Silent.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Silent.java
@@ -77,7 +77,9 @@ public class Silent extends AbstractFunction {
       return Int32.ZERO;
     }
     CountStream out = new CountStream();
-    new StringSerializer(new PrintWriter(out)).serialize(sequence);
+    StringSerializer serializer = new StringSerializer(new PrintWriter(out));
+    serializer.serialize(sequence);
+    serializer.close();
     return new Int64(out.count);
   }
 }

--- a/src/main/java/org/brackit/xquery/function/io/Read.java
+++ b/src/main/java/org/brackit/xquery/function/io/Read.java
@@ -35,7 +35,6 @@ import org.brackit.xquery.atomic.Atomic;
 import org.brackit.xquery.atomic.QNm;
 import org.brackit.xquery.atomic.Str;
 import org.brackit.xquery.function.AbstractFunction;
-import org.brackit.xquery.function.bit.BitFun;
 import org.brackit.xquery.module.StaticContext;
 import org.brackit.xquery.util.annotation.FunctionAnnotation;
 import org.brackit.xquery.util.io.IOUtils;
@@ -60,9 +59,9 @@ public class Read extends AbstractFunction {
 
   public Read(QNm name) {
     super(name,
-          new Signature(new SequenceType(AtomicType.STR, Cardinality.One),
-                        new SequenceType(AtomicType.STR, Cardinality.One)),
-          true);
+        new Signature(new SequenceType(AtomicType.STR, Cardinality.One),
+            new SequenceType(AtomicType.STR, Cardinality.One)),
+        true);
   }
 
   @Override

--- a/src/main/java/org/brackit/xquery/function/io/Write.java
+++ b/src/main/java/org/brackit/xquery/function/io/Write.java
@@ -31,7 +31,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
-import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryContext;
 import org.brackit.xquery.QueryException;
 import org.brackit.xquery.atomic.Atomic;
@@ -62,10 +61,10 @@ public class Write extends AbstractFunction {
 
   public Write(QNm name) {
     super(name,
-          new Signature(new SequenceType(AtomicType.INR, Cardinality.One),
-                        new SequenceType(AtomicType.STR, Cardinality.One),
-                        new SequenceType(AnyItemType.ANY, Cardinality.ZeroOrMany)),
-          true);
+        new Signature(new SequenceType(AtomicType.INR, Cardinality.One),
+            new SequenceType(AtomicType.STR, Cardinality.One),
+            new SequenceType(AnyItemType.ANY, Cardinality.ZeroOrMany)),
+        true);
   }
 
   @Override

--- a/src/main/java/org/brackit/xquery/function/json/JSONParser.java
+++ b/src/main/java/org/brackit/xquery/function/json/JSONParser.java
@@ -1,14 +1,8 @@
 /*
  * [New BSD License]
-<<<<<<< HEAD
  * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
  * All rights reserved.
  *
-=======
- * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
- * All rights reserved.
- *
->>>>>>> upstream/master
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -19,11 +13,7 @@
  *     * Neither the name of the Brackit Project Team nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
-<<<<<<< HEAD
  *
-=======
- *
->>>>>>> upstream/master
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -166,10 +156,10 @@ public class JSONParser extends Tokenizer {
       if (la2 != null) {
         consume(la2);
         return Int32.parse(minus == null ? la2.string() : "-" + la2.string());
-      } else if ((la2 = laDecimal( true)) != null) {
+      } else if ((la2 = laDecimal(true)) != null) {
         consume(la2);
         return new Dec(minus == null ? la2.string() : "-" + la2.string());
-      } else if ((la2 = laDouble( true)) != null) {
+      } else if ((la2 = laDouble(true)) != null) {
         consume(la2);
         return new Dbl(minus == null ? la2.string() : "-" + la2.string());
       }
@@ -213,14 +203,15 @@ public class JSONParser extends Tokenizer {
   }
 
   public static void main(String[] args) throws Exception {
-    String s =
-        "{\"bindings\": [        {\"ircEvent\": \"PRIVMSG\", \"method\": \"newURI\", \"regex\": \"^http://.*\"},        {\"ircEvent\": \"PRIVMSG\", \"method\": \"deleteURI\", \"regex\": \"^delete.*\"},        {\"ircEvent\": \"PRIVMSG\", \"method\": \"randomURI\", \"regex\": \"^random.*\"}    ]}";
+    String s = "{\"bindings\": [        {\"ircEvent\": \"PRIVMSG\", \"method\": \"newURI\", \"regex\": \"^http://.*\"},        {\"ircEvent\": \"PRIVMSG\", \"method\": \"deleteURI\", \"regex\": \"^delete.*\"},        {\"ircEvent\": \"PRIVMSG\", \"method\": \"randomURI\", \"regex\": \"^random.*\"}    ]}";
     Item item = new JSONParser(s).parse();
-    new StringSerializer(System.out).serialize(item);
+    try (StringSerializer ser = new StringSerializer(System.out)) {
+      ser.serialize(item);
+      s = "[]";
 
-    s = "[]";
+      item = new JSONParser(s).parse();
+      ser.serialize(item);
 
-    item = new JSONParser(s).parse();
-    new StringSerializer(System.out).serialize(item);
+    }
   }
 }


### PR DESCRIPTION
There were some warnings about a potential resource leak when using the StringSerializer class. This was due to forgetting to call ```close()``` after using the serializer. 