### PR TITLE
Fix JsonTest#customModule on Windows

### DIFF
--- a/src/test/java/org/brackit/xquery/JsonTest.java
+++ b/src/test/java/org/brackit/xquery/JsonTest.java
@@ -39,6 +39,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -115,7 +116,7 @@ public final class JsonTest extends XQueryBaseTest {
     try (final var out = new ByteArrayOutputStream()) {
       final Path currentRelativePath =
           Paths.get("").resolve("src").resolve("test").resolve("resources").resolve("modules").resolve("sort.xq");
-      final String currentPath = currentRelativePath.toAbsolutePath().toString();
+      final String currentPath = (File.separatorChar == '\\' ? currentRelativePath.toUri() : currentRelativePath.toAbsolutePath()).toString();
       final String query = """
           import module namespace sort = "https://sirix.io/ns/sort" at "%path";
                     


### PR DESCRIPTION
By using the absolute path, this test creates a path with invalid characters in Windows.
One way to solve this is to use the URI instead of the absolute path in Windows.

**Note:** Using the URI should be correct on any platform, but I wanted to limit the scope of this patch as much as possible.