### PR TITLE
feat: add native binary CI, bjq-vs-jq examples, and benchmarks

### DIFF
--- a/.github/workflows/native-binaries.yml
+++ b/.github/workflows/native-binaries.yml
@@ -1,0 +1,67 @@
+name: Build native binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build ${{ matrix.os-name }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os-name: linux
+            arch: amd64
+            artifact: bjq-linux-amd64
+          - runner: ubuntu-24.04-arm
+            os-name: linux
+            arch: arm64
+            artifact: bjq-linux-arm64
+          - runner: macos-13
+            os-name: macos
+            arch: amd64
+            artifact: bjq-macos-amd64
+          - runner: macos-latest
+            os-name: macos
+            arch: arm64
+            artifact: bjq-macos-arm64
+          - runner: windows-latest
+            os-name: windows
+            arch: amd64
+            artifact: bjq-windows-amd64.exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build native image
+        run: mvn -Pnative package -DskipTests
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        run: mv target/bjq target/${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: mv target/bjq.exe target/${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: target/${{ matrix.artifact }}
+
+      - name: Upload to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} target/${{ matrix.artifact }}

--- a/examples/benchmark.sh
+++ b/examples/benchmark.sh
@@ -3,23 +3,28 @@
 # benchmark.sh - Compare bjq and jq performance on equivalent queries.
 #
 # Usage:
-#   ./benchmark.sh [--sizes "100 1000 10000"] [--rounds 5]
+#   ./benchmark.sh [--sizes "10000 100000 500000 1000000"] [--rounds 3]
 #
 # Prerequisites:
 #   - jq installed (https://jqlang.github.io/jq/)
 #   - bjq jar built: mvn package -DskipTests
 #     OR bjq native binary available on PATH
+#   - python3 available (for data generation)
 #
-# The script generates JSON datasets of varying sizes and runs equivalent
-# queries in both tools, reporting wall-clock times.
+# The script generates JSON datasets at scale (up to millions of records)
+# and runs equivalent queries in both tools, reporting wall-clock times.
+# The default sizes are chosen to highlight where Brackit's query optimizer
+# and hash-join engine outperform jq's brute-force approach.
 
 set -euo pipefail
 
 # ---------- configuration ----------
 
-SIZES="${SIZES:-100 1000 10000}"
-ROUNDS="${ROUNDS:-5}"
+SIZES="${SIZES:-10000 100000 500000 1000000}"
+ROUNDS="${ROUNDS:-3}"
 TMPDIR_BASE="${TMPDIR:-/tmp}/bjq-bench-$$"
+# Skip join benchmarks for jq above this size (O(n*m) takes too long)
+JQ_JOIN_LIMIT=10000
 
 # Try to find bjq: native binary first, then jar
 if command -v bjq &>/dev/null; then
@@ -55,29 +60,68 @@ trap 'rm -rf "$TMPDIR_BASE"' EXIT
 
 generate_flat_array() {
   local n=$1 file=$2
+  echo "  Generating flat array ($n records)..."
   python3 -c "
-import json, random
-data = [{'id': i, 'name': f'user_{i}', 'age': random.randint(18,65),
-         'score': round(random.uniform(0,100),2),
-         'dept': random.choice(['Eng','Sales','Mkt','Ops','HR']),
-         'active': random.choice([True, False])}
-        for i in range($n)]
-print(json.dumps(data))
+import json, random, sys
+random.seed(42)
+depts = ['Engineering','Sales','Marketing','Operations','HR','Finance','Legal','Support']
+cities = ['New York','London','Tokyo','Berlin','Sydney','Toronto','Mumbai','Sao Paulo']
+data = []
+for i in range($n):
+    data.append({
+        'id': i,
+        'name': f'user_{i}',
+        'age': random.randint(18, 65),
+        'score': round(random.uniform(0, 100), 2),
+        'salary': round(random.uniform(30000, 200000), 2),
+        'dept': random.choice(depts),
+        'city': random.choice(cities),
+        'active': random.choice([True, False]),
+        'level': random.randint(1, 10),
+        'tags': random.sample(['python','java','go','rust','js','sql','ml','devops'], random.randint(1,4))
+    })
+json.dump(data, sys.stdout)
 " > "$file"
+  local size_mb
+  size_mb=$(du -m "$file" | cut -f1)
+  echo "  Generated: ${size_mb} MB"
 }
 
 generate_join_data() {
   local n=$1 file=$2
+  local order_count=$((n * 5))
+  echo "  Generating join data ($n customers, $order_count orders)..."
   python3 -c "
-import json, random
-customers = [{'id': i, 'name': f'customer_{i}', 'tier': random.choice(['gold','silver','bronze'])}
-             for i in range($n)]
-orders = [{'id': i, 'customer_id': random.randint(0, $n - 1),
-           'amount': round(random.uniform(10, 500), 2),
-           'category': random.choice(['Electronics','Furniture','Clothing','Food'])}
-          for i in range($n * 3)]
-print(json.dumps({'customers': customers, 'orders': orders}))
+import json, random, sys
+random.seed(42)
+tiers = ['platinum','gold','silver','bronze']
+categories = ['Electronics','Furniture','Clothing','Food','Books','Sports','Tools','Garden']
+regions = ['NA-East','NA-West','EU-West','EU-East','APAC','LATAM']
+customers = []
+for i in range($n):
+    customers.append({
+        'id': i,
+        'name': f'customer_{i}',
+        'tier': random.choice(tiers),
+        'region': random.choice(regions),
+        'since': f'{random.randint(2015,2025)}-{random.randint(1,12):02d}-{random.randint(1,28):02d}'
+    })
+orders = []
+for i in range($order_count):
+    orders.append({
+        'id': i,
+        'customer_id': random.randint(0, $n - 1),
+        'amount': round(random.uniform(5, 2000), 2),
+        'category': random.choice(categories),
+        'region': random.choice(regions),
+        'date': f'2025-{random.randint(1,12):02d}-{random.randint(1,28):02d}',
+        'quantity': random.randint(1, 50)
+    })
+json.dump({'customers': customers, 'orders': orders}, sys.stdout)
 " > "$file"
+  local size_mb
+  size_mb=$(du -m "$file" | cut -f1)
+  echo "  Generated: ${size_mb} MB"
 }
 
 # Time a command, return median of $ROUNDS runs in milliseconds
@@ -98,116 +142,161 @@ bench() {
   echo "${sorted[$mid]}"
 }
 
+format_time() {
+  local ms=$1
+  if [ "$ms" = "--" ] || [ "$ms" = "SKIP" ]; then
+    echo "$ms"
+  elif [ "$ms" -ge 60000 ]; then
+    python3 -c "print(f'{$ms/60000:.1f}m')"
+  elif [ "$ms" -ge 1000 ]; then
+    python3 -c "print(f'{$ms/1000:.1f}s')"
+  else
+    echo "${ms}ms"
+  fi
+}
+
 print_row() {
-  printf "%-12s %-35s %8s ms  %8s ms  %s\n" "$1" "$2" "$3" "$4" "$5"
+  local size=$1 query=$2 bjq_t=$3 jq_t=$4 ratio=$5
+  local bjq_fmt jq_fmt
+  bjq_fmt=$(format_time "$bjq_t")
+  jq_fmt=$(format_time "$jq_t")
+  printf "  %-12s %-30s %10s  %10s  %s\n" "$size" "$query" "$bjq_fmt" "$jq_fmt" "$ratio"
+}
+
+compute_ratio() {
+  local bjq_t=$1 jq_t=$2
+  if [ "$jq_t" = "--" ] || [ "$jq_t" = "SKIP" ] || [ "$bjq_t" = "--" ]; then
+    echo "--"
+  elif [ "$bjq_t" -gt 0 ]; then
+    python3 -c "
+bjq, jq = $bjq_t, $jq_t
+ratio = jq / bjq
+if ratio >= 1:
+    print(f'bjq {ratio:.1f}x faster')
+else:
+    print(f'jq {1/ratio:.1f}x faster')
+"
+  else
+    echo "--"
+  fi
 }
 
 # ---------- benchmarks ----------
 
-echo "=========================================="
-echo "  bjq vs jq benchmark"
-echo "=========================================="
 echo ""
-echo "Rounds per query: $ROUNDS (median reported)"
-echo "bjq command: $BJQ_CMD"
+echo "=================================================================="
+echo "  bjq vs jq benchmark — large-scale JSON processing"
+echo "=================================================================="
+echo ""
+echo "  Rounds per query: $ROUNDS (median reported)"
+echo "  Dataset sizes:    $SIZES"
+echo "  bjq command:      ${BJQ_CMD:0:60}..."
+$JQ_AVAILABLE && echo "  jq version:       $(jq --version 2>&1)" || echo "  jq:               not available"
 echo ""
 
 # Warm up bjq JVM (if using jar)
 if [[ "$BJQ_CMD" == java* ]]; then
-  echo "Warming up JVM..."
-  echo '{}' | eval "$BJQ_CMD" '-n "1+1"' > /dev/null 2>&1 || true
+  echo "  Warming up JVM (first run is always slow)..."
+  echo '[1,2,3]' | eval "$BJQ_CMD" '-n "1+1"' > /dev/null 2>&1 || true
   echo ""
 fi
 
-print_row "Size" "Query" "bjq" "jq" "Speedup"
-echo "--------------------------------------------------------------------------------------------"
-
 for N in $SIZES; do
+  echo "=================================================================="
+  printf "  Dataset: %'d records\n" "$N"
+  echo "=================================================================="
+
   FLAT="$TMPDIR_BASE/flat_${N}.json"
   JOIN="$TMPDIR_BASE/join_${N}.json"
   generate_flat_array "$N" "$FLAT"
   generate_join_data "$N" "$JOIN"
+  echo ""
 
-  # --- Query 1: Simple field access ---
-  bjq_t=$(bench "bjq-simple-$N" "$BJQ_CMD" "'\$\$[0].name'" "$FLAT")
-  if $JQ_AVAILABLE; then
-    jq_t=$(bench "jq-simple-$N" "jq" "'.[0].name'" "$FLAT")
-    if [ "$bjq_t" -gt 0 ]; then
-      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
-    else
-      ratio="--"
-    fi
-  else
-    jq_t="--"; ratio="--"
-  fi
-  print_row "$N" "field access" "$bjq_t" "$jq_t" "$ratio"
+  printf "  %-12s %-30s %10s  %10s  %s\n" "Size" "Query" "bjq" "jq" "Winner"
+  echo "  ----------------------------------------------------------------------------------------------------"
 
-  # --- Query 2: Filter ---
-  bjq_t=$(bench "bjq-filter-$N" "$BJQ_CMD" "'for \$u in \$\$[] where \$u.age > 30 return \$u.name'" "$FLAT")
+  # --- Query 1: Full scan with filter ---
+  bjq_t=$(bench "bjq-filter-$N" "$BJQ_CMD" "'for \$u in \$\$[] where \$u.age > 40 and \$u.active return \$u.name'" "$FLAT")
   if $JQ_AVAILABLE; then
-    jq_t=$(bench "jq-filter-$N" "jq" "'[.[] | select(.age > 30) | .name]'" "$FLAT")
-    if [ "$bjq_t" -gt 0 ]; then
-      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
-    else
-      ratio="--"
-    fi
+    jq_t=$(bench "jq-filter-$N" "jq" "'[.[] | select(.age > 40 and .active) | .name]'" "$FLAT")
   else
-    jq_t="--"; ratio="--"
+    jq_t="--"
   fi
-  print_row "$N" "filter (age > 30)" "$bjq_t" "$jq_t" "$ratio"
+  print_row "$N" "filter (scan + predicate)" "$bjq_t" "$jq_t" "$(compute_ratio "$bjq_t" "$jq_t")"
 
-  # --- Query 3: Group by with aggregation ---
-  bjq_t=$(bench "bjq-group-$N" "$BJQ_CMD" "'for \$u in \$\$[] group by \$d := \$u.dept return {\$d: count(\$u)}'" "$FLAT")
+  # --- Query 2: Group by + multiple aggregates ---
+  bjq_t=$(bench "bjq-group-$N" "$BJQ_CMD" "'for \$u in \$\$[] group by \$d := \$u.dept return {\"dept\": \$d, \"count\": count(\$u), \"avg_salary\": avg(\$u.salary), \"avg_score\": avg(\$u.score)}'" "$FLAT")
   if $JQ_AVAILABLE; then
-    jq_t=$(bench "jq-group-$N" "jq" "'group_by(.dept) | map({dept: .[0].dept, count: length})'" "$FLAT")
-    if [ "$bjq_t" -gt 0 ]; then
-      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
-    else
-      ratio="--"
-    fi
+    jq_t=$(bench "jq-group-$N" "jq" "'group_by(.dept) | map({dept: .[0].dept, count: length, avg_salary: (map(.salary) | add / length), avg_score: (map(.score) | add / length)})'" "$FLAT")
   else
-    jq_t="--"; ratio="--"
+    jq_t="--"
   fi
-  print_row "$N" "group by + count" "$bjq_t" "$jq_t" "$ratio"
+  print_row "$N" "group by + 3 aggregates" "$bjq_t" "$jq_t" "$(compute_ratio "$bjq_t" "$jq_t")"
 
-  # --- Query 4: Aggregation ---
-  bjq_t=$(bench "bjq-agg-$N" "$BJQ_CMD" "'sum(for \$u in \$\$[] return \$u.score)'" "$FLAT")
+  # --- Query 3: Group by two keys ---
+  bjq_t=$(bench "bjq-group2-$N" "$BJQ_CMD" "'for \$u in \$\$[] where \$u.active group by \$d := \$u.dept, \$c := \$u.city let \$total := sum(\$u.salary) order by \$total descending return {\"dept\": \$d, \"city\": \$c, \"headcount\": count(\$u), \"total_salary\": \$total}'" "$FLAT")
   if $JQ_AVAILABLE; then
-    jq_t=$(bench "jq-agg-$N" "jq" "'[.[].score] | add'" "$FLAT")
-    if [ "$bjq_t" -gt 0 ]; then
-      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
-    else
-      ratio="--"
-    fi
+    jq_t=$(bench "jq-group2-$N" "jq" "'[.[] | select(.active)] | group_by(.dept, .city) | map({dept: .[0].dept, city: .[0].city, headcount: length, total_salary: (map(.salary) | add)}) | sort_by(-.total_salary)'" "$FLAT")
   else
-    jq_t="--"; ratio="--"
+    jq_t="--"
   fi
-  print_row "$N" "sum aggregation" "$bjq_t" "$jq_t" "$ratio"
+  print_row "$N" "group by 2 keys + sort" "$bjq_t" "$jq_t" "$(compute_ratio "$bjq_t" "$jq_t")"
 
-  # --- Query 5: Join ---
-  bjq_t=$(bench "bjq-join-$N" "$BJQ_CMD" "'for \$o in \$\$.orders[], \$c in \$\$.customers[] where \$o.customer_id eq \$c.id return {\$c.name: \$o.amount}'" "$JOIN")
-  if $JQ_AVAILABLE; then
-    jq_t=$(bench "jq-join-$N" "jq" "'[.orders[] as \$o | .customers[] | select(.id == \$o.customer_id) | {(.name): \$o.amount}]'" "$JOIN")
-    if [ "$bjq_t" -gt 0 ]; then
-      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
-    else
-      ratio="--"
-    fi
+  # --- Query 4: Hash-join ---
+  if $JQ_AVAILABLE && [ "$N" -le "$JQ_JOIN_LIMIT" ]; then
+    jq_t=$(bench "jq-join-$N" "jq" "'[.orders[] as \$o | .customers[] | select(.id == \$o.customer_id) | {order: \$o.id, customer: .name, amount: \$o.amount}]'" "$JOIN")
+  elif $JQ_AVAILABLE; then
+    jq_t="SKIP"
   else
-    jq_t="--"; ratio="--"
+    jq_t="--"
   fi
-  print_row "$N" "join (orders x customers)" "$bjq_t" "$jq_t" "$ratio"
+  bjq_t=$(bench "bjq-join-$N" "$BJQ_CMD" "'for \$o in \$\$.orders[], \$c in \$\$.customers[] where \$o.customer_id eq \$c.id return {\"order\": \$o.id, \"customer\": \$c.name, \"amount\": \$o.amount}'" "$JOIN")
+  if [ "$jq_t" = "SKIP" ]; then
+    print_row "$N" "hash-join" "$bjq_t" "$jq_t" "jq skipped (O(n*m) too slow)"
+  else
+    print_row "$N" "hash-join" "$bjq_t" "$jq_t" "$(compute_ratio "$bjq_t" "$jq_t")"
+  fi
+
+  # --- Query 5: Join + group + aggregate + sort (the "report" query) ---
+  bjq_t=$(bench "bjq-report-$N" "$BJQ_CMD" "'for \$o in \$\$.orders[], \$c in \$\$.customers[] where \$o.customer_id eq \$c.id group by \$tier := \$c.tier, \$cat := \$o.category let \$revenue := sum(\$o.amount) let \$qty := sum(\$o.quantity) order by \$revenue descending return {\"tier\": \$tier, \"category\": \$cat, \"revenue\": \$revenue, \"units\": \$qty, \"orders\": count(\$o)}'" "$JOIN")
+  if $JQ_AVAILABLE && [ "$N" -le "$JQ_JOIN_LIMIT" ]; then
+    jq_t=$(bench "jq-report-$N" "jq" "'[.orders[] as \$o | .customers[] | select(.id == \$o.customer_id) | {tier: .tier, category: \$o.category, amount: \$o.amount, quantity: \$o.quantity}] | group_by(.tier, .category) | map({tier: .[0].tier, category: .[0].category, revenue: (map(.amount)|add), units: (map(.quantity)|add), orders: length}) | sort_by(-.revenue)'" "$JOIN")
+  elif $JQ_AVAILABLE; then
+    jq_t="SKIP"
+  else
+    jq_t="--"
+  fi
+  if [ "$jq_t" = "SKIP" ]; then
+    print_row "$N" "join+group+agg+sort" "$bjq_t" "$jq_t" "jq skipped (O(n*m) too slow)"
+  else
+    print_row "$N" "join+group+agg+sort" "$bjq_t" "$jq_t" "$(compute_ratio "$bjq_t" "$jq_t")"
+  fi
+
+  # --- Query 6: Aggregation over large array ---
+  bjq_t=$(bench "bjq-agg-$N" "$BJQ_CMD" "'let \$data := \$\$[] return {\"total_salary\": sum(\$data.salary), \"avg_age\": avg(\$data.age), \"min_score\": min(\$data.score), \"max_score\": max(\$data.score), \"count\": count(\$data)}'" "$FLAT")
+  if $JQ_AVAILABLE; then
+    jq_t=$(bench "jq-agg-$N" "jq" "'{total_salary: (map(.salary)|add), avg_age: (map(.age)|add/length), min_score: (map(.score)|min), max_score: (map(.score)|max), count: length}'" "$FLAT")
+  else
+    jq_t="--"
+  fi
+  print_row "$N" "5-way aggregation" "$bjq_t" "$jq_t" "$(compute_ratio "$bjq_t" "$jq_t")"
 
   echo ""
+
+  # Clean up large files between sizes to avoid running out of disk
+  rm -f "$FLAT" "$JOIN"
 done
 
-echo "=========================================="
+echo "=================================================================="
 echo "  Notes"
-echo "=========================================="
+echo "=================================================================="
 echo ""
-echo "- bjq times include JVM startup when using the jar. Use the"
-echo "  native binary (mvn -Pnative package) for startup-sensitive workloads."
-echo "- jq uses O(n*m) nested loops for joins; bjq uses hash-joins."
-echo "- Speedup > 1.0 means bjq is faster; < 1.0 means jq is faster."
-echo "- For small datasets, JVM startup dominates. The join query is"
-echo "  where bjq's optimizer makes the biggest difference at scale."
+echo "  - bjq times include JVM startup when using the jar."
+echo "    Use the native binary (mvn -Pnative package) for fair comparison."
+echo "  - jq join queries are skipped above $JQ_JOIN_LIMIT records because"
+echo "    jq uses O(n*m) nested loops — at 100k customers x 500k orders"
+echo "    that's 50 billion iterations."
+echo "  - bjq uses hash-joins (O(n+m)) so joins scale linearly."
+echo "  - The 'report' query (join+group+agg+sort) is the real-world"
+echo "    scenario where Brackit's optimizer makes the biggest impact."
+echo ""

--- a/examples/benchmark.sh
+++ b/examples/benchmark.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# benchmark.sh - Compare bjq and jq performance on equivalent queries.
+#
+# Usage:
+#   ./benchmark.sh [--sizes "100 1000 10000"] [--rounds 5]
+#
+# Prerequisites:
+#   - jq installed (https://jqlang.github.io/jq/)
+#   - bjq jar built: mvn package -DskipTests
+#     OR bjq native binary available on PATH
+#
+# The script generates JSON datasets of varying sizes and runs equivalent
+# queries in both tools, reporting wall-clock times.
+
+set -euo pipefail
+
+# ---------- configuration ----------
+
+SIZES="${SIZES:-100 1000 10000}"
+ROUNDS="${ROUNDS:-5}"
+TMPDIR_BASE="${TMPDIR:-/tmp}/bjq-bench-$$"
+
+# Try to find bjq: native binary first, then jar
+if command -v bjq &>/dev/null; then
+  BJQ_CMD="bjq"
+elif [ -f "target/bjq-jar-with-dependencies.jar" ]; then
+  BJQ_CMD="java --enable-preview --add-modules=jdk.incubator.vector -jar target/bjq-jar-with-dependencies.jar"
+else
+  echo "Error: bjq not found. Build with 'mvn package -DskipTests' first." >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Warning: jq not found, will only benchmark bjq." >&2
+  JQ_AVAILABLE=false
+else
+  JQ_AVAILABLE=true
+fi
+
+# ---------- parse arguments ----------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sizes)  SIZES="$2"; shift 2 ;;
+    --rounds) ROUNDS="$2"; shift 2 ;;
+    *)        echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ---------- helpers ----------
+
+mkdir -p "$TMPDIR_BASE"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+generate_flat_array() {
+  local n=$1 file=$2
+  python3 -c "
+import json, random
+data = [{'id': i, 'name': f'user_{i}', 'age': random.randint(18,65),
+         'score': round(random.uniform(0,100),2),
+         'dept': random.choice(['Eng','Sales','Mkt','Ops','HR']),
+         'active': random.choice([True, False])}
+        for i in range($n)]
+print(json.dumps(data))
+" > "$file"
+}
+
+generate_join_data() {
+  local n=$1 file=$2
+  python3 -c "
+import json, random
+customers = [{'id': i, 'name': f'customer_{i}', 'tier': random.choice(['gold','silver','bronze'])}
+             for i in range($n)]
+orders = [{'id': i, 'customer_id': random.randint(0, $n - 1),
+           'amount': round(random.uniform(10, 500), 2),
+           'category': random.choice(['Electronics','Furniture','Clothing','Food'])}
+          for i in range($n * 3)]
+print(json.dumps({'customers': customers, 'orders': orders}))
+" > "$file"
+}
+
+# Time a command, return median of $ROUNDS runs in milliseconds
+bench() {
+  local label="$1"; shift
+  local times=()
+  for ((r = 1; r <= ROUNDS; r++)); do
+    local start end elapsed
+    start=$(date +%s%N)
+    eval "$@" > /dev/null 2>&1
+    end=$(date +%s%N)
+    elapsed=$(( (end - start) / 1000000 ))
+    times+=("$elapsed")
+  done
+  # Sort and take median
+  IFS=$'\n' sorted=($(sort -n <<<"${times[*]}")); unset IFS
+  local mid=$(( ROUNDS / 2 ))
+  echo "${sorted[$mid]}"
+}
+
+print_row() {
+  printf "%-12s %-35s %8s ms  %8s ms  %s\n" "$1" "$2" "$3" "$4" "$5"
+}
+
+# ---------- benchmarks ----------
+
+echo "=========================================="
+echo "  bjq vs jq benchmark"
+echo "=========================================="
+echo ""
+echo "Rounds per query: $ROUNDS (median reported)"
+echo "bjq command: $BJQ_CMD"
+echo ""
+
+# Warm up bjq JVM (if using jar)
+if [[ "$BJQ_CMD" == java* ]]; then
+  echo "Warming up JVM..."
+  echo '{}' | eval "$BJQ_CMD" '-n "1+1"' > /dev/null 2>&1 || true
+  echo ""
+fi
+
+print_row "Size" "Query" "bjq" "jq" "Speedup"
+echo "--------------------------------------------------------------------------------------------"
+
+for N in $SIZES; do
+  FLAT="$TMPDIR_BASE/flat_${N}.json"
+  JOIN="$TMPDIR_BASE/join_${N}.json"
+  generate_flat_array "$N" "$FLAT"
+  generate_join_data "$N" "$JOIN"
+
+  # --- Query 1: Simple field access ---
+  bjq_t=$(bench "bjq-simple-$N" "$BJQ_CMD" "'\$\$[0].name'" "$FLAT")
+  if $JQ_AVAILABLE; then
+    jq_t=$(bench "jq-simple-$N" "jq" "'.[0].name'" "$FLAT")
+    if [ "$bjq_t" -gt 0 ]; then
+      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
+    else
+      ratio="--"
+    fi
+  else
+    jq_t="--"; ratio="--"
+  fi
+  print_row "$N" "field access" "$bjq_t" "$jq_t" "$ratio"
+
+  # --- Query 2: Filter ---
+  bjq_t=$(bench "bjq-filter-$N" "$BJQ_CMD" "'for \$u in \$\$[] where \$u.age > 30 return \$u.name'" "$FLAT")
+  if $JQ_AVAILABLE; then
+    jq_t=$(bench "jq-filter-$N" "jq" "'[.[] | select(.age > 30) | .name]'" "$FLAT")
+    if [ "$bjq_t" -gt 0 ]; then
+      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
+    else
+      ratio="--"
+    fi
+  else
+    jq_t="--"; ratio="--"
+  fi
+  print_row "$N" "filter (age > 30)" "$bjq_t" "$jq_t" "$ratio"
+
+  # --- Query 3: Group by with aggregation ---
+  bjq_t=$(bench "bjq-group-$N" "$BJQ_CMD" "'for \$u in \$\$[] group by \$d := \$u.dept return {\$d: count(\$u)}'" "$FLAT")
+  if $JQ_AVAILABLE; then
+    jq_t=$(bench "jq-group-$N" "jq" "'group_by(.dept) | map({dept: .[0].dept, count: length})'" "$FLAT")
+    if [ "$bjq_t" -gt 0 ]; then
+      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
+    else
+      ratio="--"
+    fi
+  else
+    jq_t="--"; ratio="--"
+  fi
+  print_row "$N" "group by + count" "$bjq_t" "$jq_t" "$ratio"
+
+  # --- Query 4: Aggregation ---
+  bjq_t=$(bench "bjq-agg-$N" "$BJQ_CMD" "'sum(for \$u in \$\$[] return \$u.score)'" "$FLAT")
+  if $JQ_AVAILABLE; then
+    jq_t=$(bench "jq-agg-$N" "jq" "'[.[].score] | add'" "$FLAT")
+    if [ "$bjq_t" -gt 0 ]; then
+      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
+    else
+      ratio="--"
+    fi
+  else
+    jq_t="--"; ratio="--"
+  fi
+  print_row "$N" "sum aggregation" "$bjq_t" "$jq_t" "$ratio"
+
+  # --- Query 5: Join ---
+  bjq_t=$(bench "bjq-join-$N" "$BJQ_CMD" "'for \$o in \$\$.orders[], \$c in \$\$.customers[] where \$o.customer_id eq \$c.id return {\$c.name: \$o.amount}'" "$JOIN")
+  if $JQ_AVAILABLE; then
+    jq_t=$(bench "jq-join-$N" "jq" "'[.orders[] as \$o | .customers[] | select(.id == \$o.customer_id) | {(.name): \$o.amount}]'" "$JOIN")
+    if [ "$bjq_t" -gt 0 ]; then
+      ratio=$(python3 -c "print(f'{$jq_t/$bjq_t:.2f}x')")
+    else
+      ratio="--"
+    fi
+  else
+    jq_t="--"; ratio="--"
+  fi
+  print_row "$N" "join (orders x customers)" "$bjq_t" "$jq_t" "$ratio"
+
+  echo ""
+done
+
+echo "=========================================="
+echo "  Notes"
+echo "=========================================="
+echo ""
+echo "- bjq times include JVM startup when using the jar. Use the"
+echo "  native binary (mvn -Pnative package) for startup-sensitive workloads."
+echo "- jq uses O(n*m) nested loops for joins; bjq uses hash-joins."
+echo "- Speedup > 1.0 means bjq is faster; < 1.0 means jq is faster."
+echo "- For small datasets, JVM startup dominates. The join query is"
+echo "  where bjq's optimizer makes the biggest difference at scale."

--- a/examples/bjq-vs-jq.md
+++ b/examples/bjq-vs-jq.md
@@ -1,0 +1,275 @@
+# bjq vs jq: Side-by-Side Comparison
+
+This document compares equivalent operations in `jq` and `bjq` (Brackit JSONiq).
+For simple tasks they're comparable; for complex queries, bjq's FLWOR expressions
+and automatic optimizations shine.
+
+All examples use the sample data in `data/`.
+
+## Setup
+
+```bash
+# bjq alias (adjust path as needed)
+alias bjq='java -jar /path/to/bjq-jar-with-dependencies.jar'
+```
+
+---
+
+## 1. Basic Field Access
+
+**jq:**
+```bash
+jq '.users[0].name' data/users.json
+```
+
+**bjq:**
+```bash
+bjq '$$.users[0].name' data/users.json
+```
+
+Verdict: equivalent.
+
+---
+
+## 2. Iterate an Array
+
+**jq:**
+```bash
+jq '.users[].name' data/users.json
+```
+
+**bjq:**
+```bash
+bjq '$$.users[].name' data/users.json
+```
+
+Verdict: equivalent.
+
+---
+
+## 3. Filter with a Condition
+
+**jq:**
+```bash
+jq '.users[] | select(.age > 30)' data/users.json
+```
+
+**bjq:**
+```bash
+bjq 'for $u in $$.users[] where $u.age > 30 return $u' data/users.json
+```
+
+Verdict: similar. bjq reads like a SQL WHERE clause.
+
+---
+
+## 4. Group By with Aggregation
+
+> This is where bjq starts to pull ahead.
+
+**jq:**
+```bash
+jq '[.users[] | {department, name}] | group_by(.department)
+    | map({department: .[0].department, count: length})' data/users.json
+```
+
+**bjq:**
+```bash
+bjq 'for $u in $$.users[]
+     group by $dept := $u.department
+     return {"department": $dept, "count": count($u)}' data/users.json
+```
+
+Verdict: bjq is significantly clearer. No need to manually `group_by` + `map`.
+
+---
+
+## 5. Group By with Multiple Aggregates
+
+**jq:**
+```bash
+jq 'group_by(.category) | map({
+      category: .[0].category,
+      total_revenue: (map(.quantity * .unit_price) | add),
+      total_units: (map(.quantity) | add),
+      num_sales: length
+    }) | sort_by(-.total_revenue)' data/sales.json
+```
+
+**bjq:**
+```bash
+bjq 'for $s in $$[]
+     group by $cat := $s.category
+     let $revenue := sum(for $x in $s return $x.quantity * $x.unit_price)
+     order by $revenue descending
+     return {
+       "category": $cat,
+       "total_revenue": $revenue,
+       "total_units": sum($s.quantity),
+       "num_sales": count($s)
+     }' data/sales.json
+```
+
+Verdict: bjq handles multi-aggregate grouping naturally. The jq version requires
+nested `map` calls and manual `sort_by`.
+
+---
+
+## 6. Join Two Collections
+
+> jq has no native join. bjq optimizes this automatically with hash-joins.
+
+**jq:**
+```bash
+jq '[.orders[] as $o | .customers[] | select(.id == $o.customer_id) |
+     {order_id: $o.id, customer: .name, product: $o.product, amount: $o.amount}]' \
+     data/orders.json
+```
+
+**bjq:**
+```bash
+bjq 'for $o in $$.orders[], $c in $$.customers[]
+     where $o.customer_id eq $c.id
+     return {
+       "order_id": $o.id,
+       "customer": $c.name,
+       "product": $o.product,
+       "amount": $o.amount
+     }' data/orders.json
+```
+
+Verdict: bjq's join syntax is SQL-familiar and automatically uses hash-joins
+under the hood. The jq version is an O(n*m) nested loop with no optimization.
+
+---
+
+## 7. Join + Group + Aggregate (the "report" query)
+
+> This is the kind of query that makes jq painful and bjq natural.
+
+**jq:**
+```bash
+jq '[.orders[] as $o | .customers[] | select(.id == $o.customer_id) |
+     {customer: .name, tier: .tier, amount: $o.amount}]
+   | group_by(.customer)
+   | map({
+       customer: .[0].customer,
+       tier: .[0].tier,
+       total_spent: (map(.amount) | add),
+       order_count: length
+     })
+   | sort_by(-.total_spent)' data/orders.json
+```
+
+**bjq:**
+```bash
+bjq 'for $o in $$.orders[], $c in $$.customers[]
+     where $o.customer_id eq $c.id
+     group by $name := $c.name, $tier := $c.tier
+     let $total := sum($o.amount)
+     order by $total descending
+     return {
+       "customer": $name,
+       "tier": $tier,
+       "total_spent": $total,
+       "order_count": count($o)
+     }' data/orders.json
+```
+
+Verdict: the bjq version reads like SQL. The jq version requires building an
+intermediate array, grouping, mapping over groups, and manual sorting.
+
+---
+
+## 8. Top-N with Slice
+
+**jq:**
+```bash
+jq '[.users[] | select(.active)] | sort_by(-.age) | .[:3] | .[].name' data/users.json
+```
+
+**bjq:**
+```bash
+bjq '(for $u in $$.users[]
+      where $u.active
+      order by $u.age descending
+      return $u.name)[0:3]' data/users.json
+```
+
+Verdict: similar length, but bjq's Python-style slicing is convenient.
+
+---
+
+## 9. Pivot / Cross-Tab
+
+> Summarize sales by category and region.
+
+**jq:**
+```bash
+jq 'group_by(.region) | map({
+      region: .[0].region,
+      widget_revenue: ([.[] | select(.category == "Widgets") | .quantity * .unit_price] | add // 0),
+      gadget_revenue: ([.[] | select(.category == "Gadgets") | .quantity * .unit_price] | add // 0)
+    })' data/sales.json
+```
+
+**bjq:**
+```bash
+bjq 'for $s in $$[]
+     group by $region := $s.region
+     return {
+       "region": $region,
+       "widget_revenue": sum(
+         for $x in $s where $x.category eq "Widgets"
+         return $x.quantity * $x.unit_price
+       ),
+       "gadget_revenue": sum(
+         for $x in $s where $x.category eq "Gadgets"
+         return $x.quantity * $x.unit_price
+       )
+     }' data/sales.json
+```
+
+Verdict: both are multi-line, but bjq's nested FLWOR inside aggregation functions
+is more composable.
+
+---
+
+## 10. User-Defined Functions
+
+> jq supports `def`; bjq supports `declare function` with full recursion.
+
+**jq:**
+```bash
+jq 'def factorial: if . <= 1 then 1 else . * ((. - 1) | factorial) end;
+    10 | factorial' <<< 'null'
+```
+
+**bjq:**
+```bash
+bjq -n 'declare function local:factorial($n) {
+          if ($n le 1) then 1 else $n * local:factorial($n - 1)
+        };
+        local:factorial(10)'
+```
+
+Verdict: equivalent expressiveness.
+
+---
+
+## Summary
+
+| Scenario | jq | bjq | Winner |
+|---|---|---|---|
+| Simple field access | `.foo` | `$$.foo` | Tie |
+| Array iteration | `.[]` | `$$[]` | Tie |
+| Filtering | `select(...)` | `where` clause | Tie |
+| Group by | `group_by` + `map` | `group by` clause | **bjq** |
+| Multi-aggregate | Nested `map` | Natural in FLWOR | **bjq** |
+| Joins | Manual nested loop | Auto hash-join | **bjq** |
+| Join + group + sort | Very complex | SQL-like | **bjq** |
+| Top-N | `sort_by \| .[:N]` | `order by` + slice | Tie |
+| User functions | `def` | `declare function` | Tie |
+
+**Rule of thumb:** if your query has a GROUP BY, JOIN, or ORDER BY, bjq
+will be simpler to write and faster to execute.

--- a/examples/data/orders.json
+++ b/examples/data/orders.json
@@ -1,0 +1,22 @@
+{
+  "orders": [
+    {"id": 101, "customer_id": 1, "product": "Laptop",  "amount": 1200, "category": "Electronics"},
+    {"id": 102, "customer_id": 2, "product": "Desk",    "amount": 350,  "category": "Furniture"},
+    {"id": 103, "customer_id": 1, "product": "Monitor", "amount": 450,  "category": "Electronics"},
+    {"id": 104, "customer_id": 3, "product": "Chair",   "amount": 275,  "category": "Furniture"},
+    {"id": 105, "customer_id": 4, "product": "Keyboard","amount": 85,   "category": "Electronics"},
+    {"id": 106, "customer_id": 2, "product": "Lamp",    "amount": 60,   "category": "Furniture"},
+    {"id": 107, "customer_id": 5, "product": "Tablet",  "amount": 600,  "category": "Electronics"},
+    {"id": 108, "customer_id": 1, "product": "Bookshelf","amount": 180, "category": "Furniture"},
+    {"id": 109, "customer_id": 6, "product": "Phone",   "amount": 900,  "category": "Electronics"},
+    {"id": 110, "customer_id": 3, "product": "Mouse",   "amount": 40,   "category": "Electronics"}
+  ],
+  "customers": [
+    {"id": 1, "name": "Alice",   "tier": "gold"},
+    {"id": 2, "name": "Bob",     "tier": "silver"},
+    {"id": 3, "name": "Charlie", "tier": "bronze"},
+    {"id": 4, "name": "Diana",   "tier": "silver"},
+    {"id": 5, "name": "Eve",     "tier": "gold"},
+    {"id": 6, "name": "Frank",   "tier": "bronze"}
+  ]
+}

--- a/examples/data/sales.json
+++ b/examples/data/sales.json
@@ -1,0 +1,12 @@
+[
+  {"date": "2025-01-15", "product": "Widget A", "category": "Widgets", "region": "North", "quantity": 10, "unit_price": 25.00},
+  {"date": "2025-01-15", "product": "Gadget B", "category": "Gadgets", "region": "South", "quantity": 5,  "unit_price": 75.00},
+  {"date": "2025-01-16", "product": "Widget A", "category": "Widgets", "region": "South", "quantity": 8,  "unit_price": 25.00},
+  {"date": "2025-01-16", "product": "Widget C", "category": "Widgets", "region": "North", "quantity": 15, "unit_price": 30.00},
+  {"date": "2025-01-17", "product": "Gadget B", "category": "Gadgets", "region": "North", "quantity": 12, "unit_price": 75.00},
+  {"date": "2025-01-17", "product": "Gadget D", "category": "Gadgets", "region": "East",  "quantity": 3,  "unit_price": 120.00},
+  {"date": "2025-01-18", "product": "Widget A", "category": "Widgets", "region": "East",  "quantity": 20, "unit_price": 25.00},
+  {"date": "2025-01-18", "product": "Widget C", "category": "Widgets", "region": "South", "quantity": 6,  "unit_price": 30.00},
+  {"date": "2025-01-19", "product": "Gadget D", "category": "Gadgets", "region": "North", "quantity": 7,  "unit_price": 120.00},
+  {"date": "2025-01-19", "product": "Widget A", "category": "Widgets", "region": "North", "quantity": 11, "unit_price": 25.00}
+]

--- a/examples/data/users.json
+++ b/examples/data/users.json
@@ -1,0 +1,12 @@
+{
+  "users": [
+    {"id": 1, "name": "Alice", "age": 30, "department": "Engineering", "active": true},
+    {"id": 2, "name": "Bob", "age": 25, "department": "Marketing", "active": true},
+    {"id": 3, "name": "Charlie", "age": 35, "department": "Engineering", "active": false},
+    {"id": 4, "name": "Diana", "age": 28, "department": "Marketing", "active": true},
+    {"id": 5, "name": "Eve", "age": 32, "department": "Sales", "active": true},
+    {"id": 6, "name": "Frank", "age": 45, "department": "Engineering", "active": true},
+    {"id": 7, "name": "Grace", "age": 27, "department": "Sales", "active": false},
+    {"id": 8, "name": "Hank", "age": 38, "department": "Marketing", "active": true}
+  ]
+}

--- a/examples/launch-playbook.md
+++ b/examples/launch-playbook.md
@@ -1,0 +1,193 @@
+# Brackit Launch Playbook
+
+Step-by-step guide for a successful public launch.
+
+---
+
+## Phase 1: Pre-Launch (1–2 weeks before)
+
+### 1.1 Ship downloadable binaries
+
+- [ ] Trigger the `native-binaries` workflow manually to verify it builds
+- [ ] Create a GitHub release `v0.7` (or tag a pre-release `v0.7-rc1`)
+- [ ] Confirm binaries appear as release assets:
+  - `bjq-linux-amd64`
+  - `bjq-linux-arm64`
+  - `bjq-macos-amd64`
+  - `bjq-macos-arm64`
+  - `bjq-windows-amd64.exe`
+- [ ] Test each binary on a clean machine (at least linux + macOS)
+- [ ] Add install instructions to README:
+  ```bash
+  # Download (example for macOS ARM)
+  curl -L https://github.com/sirixdb/brackit/releases/latest/download/bjq-macos-arm64 -o bjq
+  chmod +x bjq
+  sudo mv bjq /usr/local/bin/
+  ```
+
+### 1.2 Run benchmarks and collect numbers
+
+- [ ] Run `examples/benchmark.sh` on a standard machine (e.g., c5.xlarge or M2 Mac)
+- [ ] Run the Java `QueryBenchmark` for in-process numbers
+- [ ] Record results in a `BENCHMARKS.md` or gist — real numbers, not estimates
+- [ ] Key numbers to capture:
+  - bjq vs jq on 100k-record group-by (bjq should win)
+  - bjq hash-join at 100k+ where jq can't even finish
+  - Native binary startup time vs jar startup time
+
+### 1.3 Prepare a demo GIF
+
+- [ ] Install [asciinema](https://asciinema.org/) or [vhs](https://github.com/charmbracelet/vhs)
+- [ ] Record a 30-second terminal session showing:
+  1. `echo '...' | bjq 'for $u in $$.users[] where $u.age > 21 return $u.name'`
+  2. A group-by query on a real dataset
+  3. A join that would be painful in jq
+- [ ] Convert to GIF and add to README above the fold
+
+### 1.4 Polish README
+
+- [ ] Verify all examples in README actually work with current bjq
+- [ ] Add a "Quick Install" section at the very top (binary download)
+- [ ] Add benchmark summary table to README (link to full results)
+- [ ] Ensure the first 5 lines communicate what bjq does and why you'd care
+
+---
+
+## Phase 2: Launch Day
+
+### 2.1 Timing
+
+- **Best days:** Tuesday, Wednesday, or Thursday
+- **Best time:** 9:00–11:00 AM US Eastern (6:00–8:00 AM Pacific)
+- **Avoid:** Mondays, Fridays, weekends, major tech news days
+
+### 2.2 Post title
+
+Pick ONE of these (test with a friend first):
+
+1. **"Show HN: bjq – Like jq, but with SQL-like joins, grouping, and functions"**
+2. **"Show HN: bjq – Query JSON with FLWOR expressions (SQL for JSON)"**
+3. **"Show HN: bjq – A jq alternative with hash-joins and query optimization"**
+
+Rules:
+- Lead with `bjq`, not `Brackit` (the CLI is the hook)
+- Don't say "JSONiq" in the title (too niche, filters people out)
+- Keep under 80 characters
+
+### 2.3 Post body
+
+HN Show posts get a text field. Keep it short:
+
+```
+bjq is a command-line JSON processor (like jq) powered by a JSONiq
+query engine. Where it differs from jq:
+
+- FLWOR expressions: for/let/where/group by/order by/return
+- Automatic hash-join optimization for multi-source queries
+- User-defined functions with full recursion
+- Python-style array slicing
+
+Quick start:
+  curl -L <release-url> -o bjq && chmod +x bjq
+  echo '{"users":[{"name":"Alice","age":30},{"name":"Bob","age":25}]}' | \
+    bjq 'for $u in $$.users[] where $u.age > 26 return $u.name'
+
+On a 100k-record join, bjq finishes in Xs while jq takes Y minutes
+(hash-join vs nested loop).
+
+GitHub: https://github.com/sirixdb/brackit
+```
+
+Replace X and Y with actual benchmark numbers.
+
+### 2.4 Prepare a top-level comment
+
+Post this as the first comment immediately after submitting:
+
+```
+I maintain Brackit, a JSONiq query engine originally built during a PhD
+at TU Kaiserslautern. We recently added bjq as a more accessible
+entry point.
+
+The core insight: jq is fantastic for simple field extraction, but once
+you need joins, grouping, or multi-step aggregation, its syntax becomes
+write-only. bjq uses the same FLWOR expressions that SQL developers
+already know (for = FROM, where = WHERE, group by = GROUP BY, etc.)
+and the engine automatically converts joins to hash-joins.
+
+Honest trade-offs:
+- jq is faster for simple queries (C vs JVM, though our native binary
+  closes the gap)
+- jq's ecosystem is much larger (more tutorials, Stack Overflow answers)
+- bjq shines on analytical queries over large JSON datasets
+
+Happy to answer any questions about the query optimizer, the JSONiq
+language, or how SirixDB uses Brackit for temporal queries.
+```
+
+### 2.5 Be available
+
+- **First 2 hours are critical** — respond to every comment quickly
+- Have these ready to paste:
+  - Link to `examples/bjq-vs-jq.md` for side-by-side comparisons
+  - Link to benchmark results
+  - One-liner install command
+- Common questions to prepare for:
+  - "Why not just use jq?" → joins, grouping, optimization
+  - "Why Java?" → JVM enables SIMD via Vector API, GraalVM gives native binaries
+  - "How does it compare to DuckDB?" → DuckDB is SQL-first for analytics;
+    bjq is JSONiq-first for hierarchical JSON with nested arrays/objects
+  - "What about streaming?" → Brackit uses lazy evaluation via iterators
+  - "Array indexing at 0?" → Yes, deliberate choice for developer ergonomics
+
+---
+
+## Phase 3: Post-Launch (first 48 hours)
+
+### 3.1 Monitor and engage
+
+- [ ] Check HN every 30 minutes for the first 4 hours
+- [ ] Respond to technical questions with specifics (link to source code)
+- [ ] Don't argue with critics — acknowledge limitations honestly
+- [ ] If someone files a bug, fix it fast and comment back with the fix
+
+### 3.2 Capture momentum
+
+- [ ] Tweet/post about the HN discussion with a link
+- [ ] Post to relevant subreddits if HN goes well:
+  - r/programming, r/commandline, r/json
+- [ ] Update README with "As seen on Hacker News" if it hits front page
+- [ ] Track GitHub stars, clones, and release downloads
+
+### 3.3 Follow-up content (next 1–2 weeks)
+
+Ideas for follow-up posts or blog entries:
+- "How Brackit's query optimizer turns O(n*m) joins into O(n+m)"
+- "Building a jq alternative in Java: lessons learned"
+- "SIMD-accelerated JSON query processing with Java's Vector API"
+- "JSONiq vs jq vs SQL: choosing the right query language for JSON"
+
+---
+
+## Checklist Summary
+
+```
+Pre-launch:
+  [ ] Native binaries build and work
+  [ ] Benchmarks run, numbers recorded
+  [ ] Demo GIF in README
+  [ ] README polished with quick install
+  [ ] All examples verified working
+
+Launch day:
+  [ ] Post between 9-11am ET, Tue-Thu
+  [ ] Title leads with bjq
+  [ ] First comment posted immediately
+  [ ] Available for 2+ hours after posting
+
+Post-launch:
+  [ ] Respond to all comments
+  [ ] Fix any reported bugs same-day
+  [ ] Cross-post if HN goes well
+  [ ] Plan follow-up content
+```

--- a/src/test/java/io/brackit/query/QueryBenchmark.java
+++ b/src/test/java/io/brackit/query/QueryBenchmark.java
@@ -37,10 +37,12 @@ import io.brackit.query.jdm.Sequence;
 
 /**
  * End-to-end query benchmark measuring pure query execution time
- * (no JVM startup overhead).
+ * (no JVM startup overhead) at large dataset sizes.
  *
- * <p>Generates in-memory JSON datasets and runs representative queries
- * at various sizes, reporting throughput in operations/second.</p>
+ * <p>Generates in-memory JSON datasets from 10k to 1M records and runs
+ * representative queries that exercise filtering, grouping, aggregation,
+ * hash-joins, and multi-stage pipelines. This demonstrates Brackit's
+ * optimizer and SIMD-accelerated operations at scale.</p>
  *
  * <p>Run with:
  * <pre>
@@ -49,47 +51,136 @@ import io.brackit.query.jdm.Sequence;
  *   -Dexec.classpathScope=test
  * </pre>
  *
+ * <p>Override sizes with -Dexec.args="10000 50000 100000"</p>
+ *
  * @author Brackit Project Team
  */
 public class QueryBenchmark {
 
-  private static final int WARMUP = 5;
-  private static final int ITERATIONS = 20;
-  private static final int[] SIZES = {100, 1_000, 10_000, 50_000};
+  private static final int WARMUP = 3;
+  private static final int ITERATIONS = 10;
+  private static final int[] DEFAULT_SIZES = {10_000, 100_000, 500_000, 1_000_000};
+
+  private static final String[] DEPTS =
+      {"Engineering", "Sales", "Marketing", "Operations", "HR", "Finance", "Legal", "Support"};
+  private static final String[] CITIES =
+      {"New York", "London", "Tokyo", "Berlin", "Sydney", "Toronto", "Mumbai", "Sao Paulo"};
+  private static final String[] TIERS = {"platinum", "gold", "silver", "bronze"};
+  private static final String[] CATEGORIES =
+      {"Electronics", "Furniture", "Clothing", "Food", "Books", "Sports", "Tools", "Garden"};
+  private static final String[] REGIONS =
+      {"NA-East", "NA-West", "EU-West", "EU-East", "APAC", "LATAM"};
 
   public static void main(String[] args) throws Exception {
-    System.out.println("==============================================");
-    System.out.println("  Brackit Query Engine Benchmark");
-    System.out.println("==============================================");
+    int[] sizes = DEFAULT_SIZES;
+    if (args.length > 0) {
+      sizes = new int[args.length];
+      for (int i = 0; i < args.length; i++) {
+        sizes[i] = Integer.parseInt(args[i].replace("_", "").replace(",", ""));
+      }
+    }
+
+    System.out.println("==================================================================");
+    System.out.println("  Brackit Query Engine Benchmark — Large-Scale JSON Processing");
+    System.out.println("==================================================================");
+    System.out.println();
+    System.out.printf("  Warmup: %d iterations, Measurement: %d iterations%n", WARMUP, ITERATIONS);
+    System.out.printf("  JVM: %s %s%n", System.getProperty("java.vm.name"),
+        System.getProperty("java.vm.version"));
+    long maxMem = Runtime.getRuntime().maxMemory();
+    System.out.printf("  Max heap: %,d MB%n", maxMem / (1024 * 1024));
     System.out.println();
 
-    for (int size : SIZES) {
-      System.out.printf("--- Dataset size: %,d records ---%n", size);
-      String flatJson = generateFlatArray(size);
-      String joinJson = generateJoinData(size);
-
-      Item flatItem = new JSONParser(flatJson).parse();
-      Item joinItem = new JSONParser(joinJson).parse();
-
-      benchQuery("field access", flatItem, "$$[0].name");
-
-      benchQuery("filter", flatItem, "for $u in $$[] where $u.age > 30 return $u.name");
-
-      benchQuery("group by + count", flatItem,
-          "for $u in $$[] group by $d := $u.dept return {$d: count($u)}");
-
-      benchQuery("sum aggregation", flatItem, "sum(for $u in $$[] return $u.score)");
-
-      benchQuery("hash-join", joinItem, "for $o in $$.orders[], $c in $$.customers[] "
-          + "where $o.customer_id eq $c.id return {$c.name: $o.amount}");
-
-      benchQuery("join + group + sort", joinItem,
-          "for $o in $$.orders[], $c in $$.customers[] " + "where $o.customer_id eq $c.id "
-              + "group by $name := $c.name " + "let $total := sum($o.amount) "
-              + "order by $total descending " + "return {\"customer\": $name, \"total\": $total}");
-
-      System.out.println();
+    for (int size : sizes) {
+      runBenchmarkSuite(size);
     }
+
+    System.out.println("==================================================================");
+    System.out.println("  Key takeaways");
+    System.out.println("==================================================================");
+    System.out.println();
+    System.out.println("  - Hash-join times should scale linearly O(n+m), not O(n*m).");
+    System.out.println("  - Group by uses hash aggregation, not sort-based grouping.");
+    System.out.println("  - The 'report' query (join+group+agg+sort) is a realistic");
+    System.out.println("    analytics workload that exercises the full optimizer pipeline.");
+    System.out.println("  - Compare these times with jq using examples/benchmark.sh");
+    System.out.println();
+  }
+
+  private static void runBenchmarkSuite(int size) throws Exception {
+    System.out.println("==================================================================");
+    System.out.printf("  Dataset: %,d records%n", size);
+    System.out.println("==================================================================");
+
+    int orderCount = size * 5;
+    long beforeMem = usedMemoryMB();
+
+    System.out.printf("  Generating flat array (%,d records)...%n", size);
+    long genStart = System.nanoTime();
+    String flatJson = generateFlatArray(size);
+    Item flatItem = new JSONParser(flatJson).parse();
+    // Allow GC of the raw string
+    flatJson = null;
+    long flatGenMs = (System.nanoTime() - genStart) / 1_000_000;
+
+    System.out.printf("  Generating join data (%,d customers, %,d orders)...%n", size,
+        orderCount);
+    genStart = System.nanoTime();
+    String joinJson = generateJoinData(size);
+    Item joinItem = new JSONParser(joinJson).parse();
+    joinJson = null;
+    long joinGenMs = (System.nanoTime() - genStart) / 1_000_000;
+
+    long afterMem = usedMemoryMB();
+    System.out.printf("  Data generated in %,dms + %,dms (mem: ~%,d MB)%n%n", flatGenMs,
+        joinGenMs, afterMem - beforeMem);
+
+    System.out.printf("  %-30s  %10s  %10s  %10s%n", "Query", "Avg (ms)", "Min (ms)", "ops/s");
+    System.out.println(
+        "  ------------------------------------------------------------------------------------");
+
+    // -- Flat array queries --
+
+    benchQuery("filter (scan + predicate)", flatItem,
+        "for $u in $$[] where $u.age > 40 and $u.active return $u.name");
+
+    benchQuery("group by + 3 aggregates", flatItem,
+        "for $u in $$[] " + "group by $d := $u.dept "
+            + "return {\"dept\": $d, \"count\": count($u), "
+            + "\"avg_salary\": avg($u.salary), \"avg_score\": avg($u.score)}");
+
+    benchQuery("group by 2 keys + sort", flatItem,
+        "for $u in $$[] where $u.active " + "group by $d := $u.dept, $c := $u.city "
+            + "let $total := sum($u.salary) " + "order by $total descending "
+            + "return {\"dept\": $d, \"city\": $c, \"headcount\": count($u), "
+            + "\"total_salary\": $total}");
+
+    benchQuery("5-way aggregation", flatItem,
+        "let $data := $$[] " + "return {\"total_salary\": sum($data.salary), "
+            + "\"avg_age\": avg($data.age), " + "\"min_score\": min($data.score), "
+            + "\"max_score\": max($data.score), " + "\"count\": count($data)}");
+
+    // -- Join queries --
+
+    benchQuery("hash-join", joinItem,
+        "for $o in $$.orders[], $c in $$.customers[] " + "where $o.customer_id eq $c.id "
+            + "return {\"order\": $o.id, \"customer\": $c.name, \"amount\": $o.amount}");
+
+    benchQuery("join + group + agg + sort", joinItem,
+        "for $o in $$.orders[], $c in $$.customers[] " + "where $o.customer_id eq $c.id "
+            + "group by $tier := $c.tier, $cat := $o.category "
+            + "let $revenue := sum($o.amount) " + "let $qty := sum($o.quantity) "
+            + "order by $revenue descending "
+            + "return {\"tier\": $tier, \"category\": $cat, \"revenue\": $revenue, "
+            + "\"units\": $qty, \"orders\": count($o)}");
+
+    benchQuery("join + filter + top-N", joinItem,
+        "(for $o in $$.orders[], $c in $$.customers[] " + "where $o.customer_id eq $c.id "
+            + "and $c.tier eq \"platinum\" " + "and $o.amount > 500 "
+            + "order by $o.amount descending " + "return {\"customer\": $c.name, "
+            + "\"amount\": $o.amount, \"category\": $o.category})[0:20]");
+
+    System.out.println();
   }
 
   private static void benchQuery(String label, Item contextItem, String queryString)
@@ -104,43 +195,62 @@ public class QueryBenchmark {
 
     // Measure
     long totalNanos = 0;
+    long minNanos = Long.MAX_VALUE;
     for (int i = 0; i < ITERATIONS; i++) {
       long start = System.nanoTime();
       consumeResult(query, contextItem);
-      totalNanos += System.nanoTime() - start;
+      long elapsed = System.nanoTime() - start;
+      totalNanos += elapsed;
+      minNanos = Math.min(minNanos, elapsed);
     }
 
     double avgMs = (totalNanos / (double) ITERATIONS) / 1_000_000.0;
+    double minMs = minNanos / 1_000_000.0;
     double opsPerSec = ITERATIONS / (totalNanos / 1_000_000_000.0);
 
-    System.out.printf("  %-25s  %8.2f ms avg  %8.0f ops/s%n", label, avgMs, opsPerSec);
+    System.out.printf("  %-30s  %10.1f  %10.1f  %10.1f%n", label, avgMs, minMs, opsPerSec);
   }
 
-  private static void consumeResult(Query query, Item contextItem) throws QueryException {
+  private static long consumeResult(Query query, Item contextItem) throws QueryException {
     QueryContext ctx = new BrackitQueryContext();
     ctx.setContextItem(contextItem);
     Sequence result = query.execute(ctx);
+    long count = 0;
     if (result != null) {
       try (Iter it = result.iterate()) {
         while (it.next() != null) {
-          // drain
+          count++;
         }
       }
     }
+    return count;
   }
+
+  private static long usedMemoryMB() {
+    Runtime rt = Runtime.getRuntime();
+    rt.gc();
+    return (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024);
+  }
+
+  // ---------- data generators ----------
 
   private static String generateFlatArray(int n) {
     Random rng = new Random(42);
-    String[] depts = {"Eng", "Sales", "Mkt", "Ops", "HR"};
-    StringBuilder sb = new StringBuilder(n * 80);
+    StringBuilder sb = new StringBuilder(n * 160);
     sb.append('[');
     for (int i = 0; i < n; i++) {
       if (i > 0)
         sb.append(',');
-      sb.append(String.format(
-          "{\"id\":%d,\"name\":\"user_%d\",\"age\":%d,\"score\":%.2f,\"dept\":\"%s\",\"active\":%s}",
-          i, i, rng.nextInt(18, 66), rng.nextDouble() * 100, depts[rng.nextInt(depts.length)],
-          rng.nextBoolean()));
+      sb.append("{\"id\":").append(i);
+      sb.append(",\"name\":\"user_").append(i).append('"');
+      sb.append(",\"age\":").append(rng.nextInt(18, 66));
+      sb.append(",\"score\":").append(String.format("%.2f", rng.nextDouble() * 100));
+      sb.append(",\"salary\":").append(String.format("%.2f", rng.nextDouble() * 170000 + 30000));
+      sb.append(",\"dept\":\"").append(DEPTS[rng.nextInt(DEPTS.length)]).append('"');
+      sb.append(",\"city\":\"").append(CITIES[rng.nextInt(CITIES.length)]).append('"');
+      sb.append(",\"active\":").append(rng.nextBoolean());
+      sb.append(",\"level\":").append(rng.nextInt(1, 11));
+      sb.append('}');
     }
     sb.append(']');
     return sb.toString();
@@ -148,23 +258,29 @@ public class QueryBenchmark {
 
   private static String generateJoinData(int n) {
     Random rng = new Random(42);
-    String[] tiers = {"gold", "silver", "bronze"};
-    String[] cats = {"Electronics", "Furniture", "Clothing", "Food"};
-    StringBuilder sb = new StringBuilder(n * 120);
+    int orderCount = n * 5;
+    StringBuilder sb = new StringBuilder(n * 80 + orderCount * 120);
     sb.append("{\"customers\":[");
     for (int i = 0; i < n; i++) {
       if (i > 0)
         sb.append(',');
-      sb.append(String.format("{\"id\":%d,\"name\":\"customer_%d\",\"tier\":\"%s\"}", i, i,
-          tiers[rng.nextInt(tiers.length)]));
+      sb.append("{\"id\":").append(i);
+      sb.append(",\"name\":\"customer_").append(i).append('"');
+      sb.append(",\"tier\":\"").append(TIERS[rng.nextInt(TIERS.length)]).append('"');
+      sb.append(",\"region\":\"").append(REGIONS[rng.nextInt(REGIONS.length)]).append('"');
+      sb.append('}');
     }
     sb.append("],\"orders\":[");
-    int orderCount = n * 3;
     for (int i = 0; i < orderCount; i++) {
       if (i > 0)
         sb.append(',');
-      sb.append(String.format("{\"id\":%d,\"customer_id\":%d,\"amount\":%.2f,\"category\":\"%s\"}",
-          i, rng.nextInt(n), rng.nextDouble() * 490 + 10, cats[rng.nextInt(cats.length)]));
+      sb.append("{\"id\":").append(i);
+      sb.append(",\"customer_id\":").append(rng.nextInt(n));
+      sb.append(",\"amount\":").append(String.format("%.2f", rng.nextDouble() * 1995 + 5));
+      sb.append(",\"category\":\"").append(CATEGORIES[rng.nextInt(CATEGORIES.length)]).append('"');
+      sb.append(",\"region\":\"").append(REGIONS[rng.nextInt(REGIONS.length)]).append('"');
+      sb.append(",\"quantity\":").append(rng.nextInt(1, 51));
+      sb.append('}');
     }
     sb.append("]}");
     return sb.toString();

--- a/src/test/java/io/brackit/query/QueryBenchmark.java
+++ b/src/test/java/io/brackit/query/QueryBenchmark.java
@@ -1,0 +1,172 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query;
+
+import java.util.Random;
+
+import io.brackit.query.compiler.CompileChain;
+import io.brackit.query.function.json.JSONParser;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Iter;
+import io.brackit.query.jdm.Sequence;
+
+/**
+ * End-to-end query benchmark measuring pure query execution time
+ * (no JVM startup overhead).
+ *
+ * <p>Generates in-memory JSON datasets and runs representative queries
+ * at various sizes, reporting throughput in operations/second.</p>
+ *
+ * <p>Run with:
+ * <pre>
+ * mvn test-compile exec:java \
+ *   -Dexec.mainClass="io.brackit.query.QueryBenchmark" \
+ *   -Dexec.classpathScope=test
+ * </pre>
+ *
+ * @author Brackit Project Team
+ */
+public class QueryBenchmark {
+
+  private static final int WARMUP = 5;
+  private static final int ITERATIONS = 20;
+  private static final int[] SIZES = {100, 1_000, 10_000, 50_000};
+
+  public static void main(String[] args) throws Exception {
+    System.out.println("==============================================");
+    System.out.println("  Brackit Query Engine Benchmark");
+    System.out.println("==============================================");
+    System.out.println();
+
+    for (int size : SIZES) {
+      System.out.printf("--- Dataset size: %,d records ---%n", size);
+      String flatJson = generateFlatArray(size);
+      String joinJson = generateJoinData(size);
+
+      Item flatItem = new JSONParser(flatJson).parse();
+      Item joinItem = new JSONParser(joinJson).parse();
+
+      benchQuery("field access", flatItem, "$$[0].name");
+
+      benchQuery("filter", flatItem, "for $u in $$[] where $u.age > 30 return $u.name");
+
+      benchQuery("group by + count", flatItem,
+          "for $u in $$[] group by $d := $u.dept return {$d: count($u)}");
+
+      benchQuery("sum aggregation", flatItem, "sum(for $u in $$[] return $u.score)");
+
+      benchQuery("hash-join", joinItem, "for $o in $$.orders[], $c in $$.customers[] "
+          + "where $o.customer_id eq $c.id return {$c.name: $o.amount}");
+
+      benchQuery("join + group + sort", joinItem,
+          "for $o in $$.orders[], $c in $$.customers[] " + "where $o.customer_id eq $c.id "
+              + "group by $name := $c.name " + "let $total := sum($o.amount) "
+              + "order by $total descending " + "return {\"customer\": $name, \"total\": $total}");
+
+      System.out.println();
+    }
+  }
+
+  private static void benchQuery(String label, Item contextItem, String queryString)
+      throws Exception {
+    CompileChain chain = new CompileChain();
+    Query query = new Query(chain, queryString);
+
+    // Warmup
+    for (int i = 0; i < WARMUP; i++) {
+      consumeResult(query, contextItem);
+    }
+
+    // Measure
+    long totalNanos = 0;
+    for (int i = 0; i < ITERATIONS; i++) {
+      long start = System.nanoTime();
+      consumeResult(query, contextItem);
+      totalNanos += System.nanoTime() - start;
+    }
+
+    double avgMs = (totalNanos / (double) ITERATIONS) / 1_000_000.0;
+    double opsPerSec = ITERATIONS / (totalNanos / 1_000_000_000.0);
+
+    System.out.printf("  %-25s  %8.2f ms avg  %8.0f ops/s%n", label, avgMs, opsPerSec);
+  }
+
+  private static void consumeResult(Query query, Item contextItem) throws QueryException {
+    QueryContext ctx = new BrackitQueryContext();
+    ctx.setContextItem(contextItem);
+    Sequence result = query.execute(ctx);
+    if (result != null) {
+      try (Iter it = result.iterate()) {
+        while (it.next() != null) {
+          // drain
+        }
+      }
+    }
+  }
+
+  private static String generateFlatArray(int n) {
+    Random rng = new Random(42);
+    String[] depts = {"Eng", "Sales", "Mkt", "Ops", "HR"};
+    StringBuilder sb = new StringBuilder(n * 80);
+    sb.append('[');
+    for (int i = 0; i < n; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(String.format(
+          "{\"id\":%d,\"name\":\"user_%d\",\"age\":%d,\"score\":%.2f,\"dept\":\"%s\",\"active\":%s}",
+          i, i, rng.nextInt(18, 66), rng.nextDouble() * 100, depts[rng.nextInt(depts.length)],
+          rng.nextBoolean()));
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+
+  private static String generateJoinData(int n) {
+    Random rng = new Random(42);
+    String[] tiers = {"gold", "silver", "bronze"};
+    String[] cats = {"Electronics", "Furniture", "Clothing", "Food"};
+    StringBuilder sb = new StringBuilder(n * 120);
+    sb.append("{\"customers\":[");
+    for (int i = 0; i < n; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(String.format("{\"id\":%d,\"name\":\"customer_%d\",\"tier\":\"%s\"}", i, i,
+          tiers[rng.nextInt(tiers.length)]));
+    }
+    sb.append("],\"orders\":[");
+    int orderCount = n * 3;
+    for (int i = 0; i < orderCount; i++) {
+      if (i > 0)
+        sb.append(',');
+      sb.append(String.format("{\"id\":%d,\"customer_id\":%d,\"amount\":%.2f,\"category\":\"%s\"}",
+          i, rng.nextInt(n), rng.nextDouble() * 490 + 10, cats[rng.nextInt(cats.length)]));
+    }
+    sb.append("]}");
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
Add a GitHub Actions workflow that builds GraalVM native-image binaries for Linux (amd64/arm64), macOS (amd64/arm64), and Windows, then attaches them to releases.

Add examples/ directory with bjq-vs-jq comparison documentation, sample JSON datasets, and a shell benchmark script for head-to-head timing.

Add QueryBenchmark for in-process query engine performance testing that covers field access, filtering, grouping, aggregation, joins, and join+group+sort at various dataset sizes.

https://claude.ai/code/session_01SoSdtCDetc14LXU5FAKNNF