### PR TITLE
fix: AbstractTimeInstant.subtract returns bogus +29d24h on equal-hour…

### DIFF
--- a/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
@@ -257,7 +257,6 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
   }
 
   protected DTD subtract(AbstractTimeInstant b) {
-    boolean negative = false;
     AbstractTimeInstant a = this;
 
     if (a.getTimezone() != null) {
@@ -267,89 +266,52 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
       b = b.canonicalize();
     }
 
-    if (a.cmp(b) <= 0) {
+    // Ensure a >= b so the rest of the routine computes |a - b|; remember the sign.
+    boolean negative = false;
+    if (a.cmp(b) < 0) {
+      AbstractTimeInstant tmp = a;
       a = b;
-      b = this;
+      b = tmp;
       negative = true;
     }
 
-    int carry = 0;
+    // Date subtraction via Julian Day Numbers — eliminates the field-by-field borrow logic
+    // (and its bugs) for the y/m/d component. Time-of-day is handled with a simple borrow.
+    long dayDiff = julianDayNumber(a.getYear(), a.getMonth(), a.getDay()) - julianDayNumber(b.getYear(),
+                                                                                            b.getMonth(),
+                                                                                            b.getDay());
+
     int micros = a.getMicros() - b.getMicros();
+    int minutes = a.getMinutes() - b.getMinutes();
+    int hours = a.getHours() - b.getHours();
+
     if (micros < 0) {
-      micros *= -1;
-      carry = 1;
+      micros += 60_000_000;
+      minutes -= 1;
     }
-    int minutes = a.getMinutes() - b.getMinutes() + carry;
     if (minutes < 0) {
-      minutes *= -1;
-      carry = 1;
-    } else {
-      carry = 0;
+      minutes += 60;
+      hours -= 1;
     }
-
-    short days = 0;
-    int hours;
-    int ehour = b.getHours() + carry;
-    int eyear = b.getYear();
-    int emonth = b.getMonth();
-    int eday = b.getDay();
-
-    if (ehour < a.getHours()) {
-      hours = a.getHours() - ehour;
-    } else {
-      hours = 24 - ehour + a.getHours();
-      if (eday == maxDayInMonth(eyear, emonth)) {
-        if (emonth == 12) {
-          eyear++;
-          emonth = 1;
-        } else {
-          emonth++;
-        }
-        eday = 1;
-      } else {
-        eday++;
-      }
+    if (hours < 0) {
+      hours += 24;
+      dayDiff -= 1;
     }
+    // dayDiff cannot go negative here because a >= b after the swap.
 
-    if (eyear < a.getYear()) {
-      // advance days to 1st. of next month
-      byte maxDayInMonth = maxDayInMonth(eyear, emonth);
-      days += maxDayInMonth - eday + 1;
-      eday = 1;
+    return new DTD(negative, (short) dayDiff, (byte) hours, (byte) minutes, micros);
+  }
 
-      // advance months to next year
-      while (++emonth <= 12) {
-        byte maxDayInMonth2 = maxDayInMonth(eyear, emonth);
-        days += maxDayInMonth2;
-      }
-      emonth = 1;
-
-      // advance years
-      while (++eyear < a.getYear()) {
-        boolean isLeap = eyear % 400 == 0 || eyear % 100 != 0 && eyear % 4 == 0;
-        days += isLeap ? 366 : 365;
-      }
-    }
-
-    if (emonth < a.getMonth()) {
-      // advance days to 1st. of next month
-      byte maxDayInMonth = maxDayInMonth(eyear, emonth);
-      days += maxDayInMonth - eday + 1;
-      eday = 1;
-
-      // advance months
-      while (++emonth < a.getMonth()) {
-        byte maxDayInMonth2 = maxDayInMonth(eyear, emonth);
-        days += maxDayInMonth2;
-      }
-    }
-
-    if (eday < a.getDay()) {
-      // advance days
-      days += a.getDay() - eday;
-    }
-
-    return new DTD(negative, days, (byte) hours, (byte) minutes, micros);
+  /**
+   * Convert a proleptic Gregorian (year, month, day) to a Julian Day Number.
+   * Uses the Fliegel–Van Flandern algorithm. Valid for any date in the proleptic
+   * Gregorian calendar.
+   */
+  private static long julianDayNumber(int year, int month, int day) {
+    int a = (14 - month) / 12;
+    long y = (long) year + 4800L - a;
+    int m = month + 12 * a - 3;
+    return day + (153L * m + 2) / 5 + 365L * y + y / 4 - y / 100 + y / 400 - 32045L;
   }
 
   private static int fQuotient(int a, int low, int high) {

--- a/src/test/java/io/brackit/query/atomic/DateTimeTest.java
+++ b/src/test/java/io/brackit/query/atomic/DateTimeTest.java
@@ -2,9 +2,103 @@ package io.brackit.query.atomic;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public final class DateTimeTest {
   @Test
   public void testParseString() {
     new DateTime("2020-05-06T11:07:21");
+  }
+
+  /**
+   * Regression: pre-fix, subtracting two dateTimes that fell on the same day with the
+   * same hour added a phantom +29 days +24 hours to the result, because the borrow logic
+   * landed in the wrong branch when {@code ehour == a.getHours()}. Verify the small-gap
+   * cases explicitly.
+   */
+  @Test
+  public void subtractSameDaySameHour_subSecondGap() throws Exception {
+    DateTime a = new DateTime("2026-04-30T16:33:26.047000Z");
+    DateTime b = new DateTime("2026-04-30T16:33:25.607367Z");
+    DTD diff = a.subtract(b);
+    assertEquals("PT0.439633S", diff.toString());
+  }
+
+  @Test
+  public void subtractSameDaySameHour_oneSecondGap() throws Exception {
+    DateTime a = new DateTime("2026-04-30T16:33:26Z");
+    DateTime b = new DateTime("2026-04-30T16:33:25Z");
+    DTD diff = a.subtract(b);
+    assertEquals("PT1S", diff.toString());
+  }
+
+  @Test
+  public void subtractSameInstant_isZero() throws Exception {
+    DateTime a = new DateTime("2026-04-30T16:33:26Z");
+    DateTime b = new DateTime("2026-04-30T16:33:26Z");
+    DTD diff = a.subtract(b);
+    assertEquals("PT0S", diff.toString());
+  }
+
+  /**
+   * Regression: minute borrow used to be {@code minutes *= -1}, which only happens to
+   * give the right answer for borrowed values that are exactly half the modulus. For a
+   * 35-minute gap (10 - 35 = -25 → should become 35), the negate yielded 25.
+   */
+  @Test
+  public void subtractAcrossHour_minuteBorrowIsCorrect() throws Exception {
+    DateTime a = new DateTime("2026-04-30T16:10:00Z");
+    DateTime b = new DateTime("2026-04-30T15:35:00Z");
+    DTD diff = a.subtract(b);
+    assertEquals("PT35M", diff.toString());
+  }
+
+  @Test
+  public void subtractAcrossDayBoundary() throws Exception {
+    DateTime a = new DateTime("2026-05-01T01:00:00Z");
+    DateTime b = new DateTime("2026-04-30T23:00:00Z");
+    DTD diff = a.subtract(b);
+    assertEquals("PT2H", diff.toString());
+  }
+
+  @Test
+  public void subtractAcrossYearBoundary() throws Exception {
+    DateTime a = new DateTime("2026-04-30T16:00:00Z");
+    DateTime b = new DateTime("2025-04-30T16:00:00Z");
+    DTD diff = a.subtract(b);
+    assertEquals("P365D", diff.toString());
+  }
+
+  @Test
+  public void subtractAcrossLeapYear() throws Exception {
+    // 2024 is a leap year; 2024-03-01 minus 2024-02-01 should be 29 days, not 28.
+    DateTime a = new DateTime("2024-03-01T00:00:00Z");
+    DateTime b = new DateTime("2024-02-01T00:00:00Z");
+    DTD diff = a.subtract(b);
+    assertEquals("P29D", diff.toString());
+  }
+
+  @Test
+  public void subtractNegative_keepsAbsoluteMagnitudeAndSign() throws Exception {
+    // a < b, so the result should be negative.
+    DateTime a = new DateTime("2026-04-30T15:35:00Z");
+    DateTime b = new DateTime("2026-04-30T16:10:00Z");
+    DTD diff = a.subtract(b);
+    assertTrue(diff.toString().startsWith("-"), "expected negative duration, got " + diff);
+    assertEquals("-PT35M", diff.toString());
+  }
+
+  /**
+   * The xs:dayTimeDuration P7D comparison from the use-case fraud-detection query.
+   * A sub-second gap must NOT compare greater than 7 days.
+   */
+  @Test
+  public void subSecondGap_isNotGreaterThan7Days() throws Exception {
+    DateTime a = new DateTime("2026-04-30T16:33:26.047000Z");
+    DateTime b = new DateTime("2026-04-30T16:33:25.607367Z");
+    DTD diff = a.subtract(b);
+    DTD sevenDays = new DTD(false, (short) 7, (byte) 0, (byte) 0, 0);
+    assertTrue(diff.cmp(sevenDays) < 0, "sub-second diff should be less than P7D, got " + diff);
   }
 }


### PR DESCRIPTION
… cases

Two real bugs in the field-by-field borrow logic of `AbstractTimeInstant.subtract(AbstractTimeInstant b)`:

1. Hour-component branch: `if (ehour < a.getHours())` failed to handle the equality case. When `b.getHours() == a.getHours()` and there was no minute borrow (carry == 0), `ehour == a.getHours()` would fall into the else branch — which sets `hours = 24 - ehour + a.getHours() = 24` and rolls the day forward. The rest of the routine then "subtracts" the rolled-forward day, leaving a phantom 29-day, 24-hour spike on any same-day, same-hour subtraction. A sub-second gap would render as `P29DT24H0.439633S` instead of `PT0.439633S`.

   This is exactly what broke sirixdb/sirix's UseCasesDocQueryTest: `sdb:timestamp(rev) - sdb:valid-from(record) gt P7D` was true for records with validFrom set to "now", because the bug added 30 days to every same-day diff — flagging legitimate transactions as backdated by more than a week.

2. Minute / micros borrow used `*= -1` instead of `+= 60` (or `+= 60_000_000`). For values like minutes = -25, negate yields 25 while a proper borrow yields 35. The negate only happens to give the right answer when the negative value is exactly half the modulus — for everything else it silently corrupts the result.

Replace the field-by-field branching with the standard textbook approach: convert each (year, month, day) to a Julian Day Number, subtract those once for the date component, then apply borrow arithmetic for hours/minutes/seconds. Both bugs disappear; the routine becomes ~50% smaller and easier to read.

Adds nine regression tests in DateTimeTest covering same-instant, sub-second, one-second, minute-borrow, day-boundary, year-boundary, leap-year, and negative-result cases. All 1030 existing Brackit tests continue to pass.