### PR TITLE
fix: DTD/YMD/dateTime arithmetic — sign-bit collisions and day-borrow…

### DIFF
--- a/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
@@ -232,19 +232,40 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
     byte maxDayInMonth = maxDayInMonth(newYear, newMonth);
     int newDays = (getDay() > maxDayInMonth ? maxDayInMonth : getDay() < 1 ? 1 : getDay()) + durationDays + carry;
 
+    // Day-of-month is 1..maxDayInMonth (NOT 0..maxDayInMonth-1). Two pre-fix bugs:
+    //
+    //  * `newDays < 0` let newDays == 0 escape the loop, producing invalid 0th-of-month
+    //    dates (e.g. `2026-05-01 - PT2H` came out as `2026-05-00T23:00:00`).
+    //  * `maxDayInMonth(newYear, newMonth - 1)` computed the previous month's day count
+    //    before adjusting for January, where newMonth-1 == 0 — undefined month index.
+    //    The newYear/newMonth update happened AFTER the lookup, so a borrow at January
+    //    of any year sampled month 0 of the same year.
+    //
+    // Compute the previous/next (year, month) FIRST, then look up its day count.
     while (true) {
-      if (newDays < 0) {
-        newDays += maxDayInMonth(newYear, newMonth - 1);
-        carry = -1;
+      if (newDays < 1) {
+        int prevMonth = newMonth - 1;
+        int prevYear = newYear;
+        if (prevMonth < 1) {
+          prevMonth = 12;
+          prevYear -= 1;
+        }
+        newDays += maxDayInMonth(prevYear, prevMonth);
+        newMonth = prevMonth;
+        newYear = prevYear;
       } else if (newDays > maxDayInMonth(newYear, newMonth)) {
         newDays -= maxDayInMonth(newYear, newMonth);
-        carry = 1;
+        int nextMonth = newMonth + 1;
+        int nextYear = newYear;
+        if (nextMonth > 12) {
+          nextMonth = 1;
+          nextYear += 1;
+        }
+        newMonth = nextMonth;
+        newYear = nextYear;
       } else {
         break;
       }
-      temp = newMonth + carry;
-      newMonth = modulo(temp, 1, 13);
-      newYear += fQuotient(temp, 1, 13);
     }
 
     return create((short) newYear,

--- a/src/main/java/io/brackit/query/atomic/DTD.java
+++ b/src/main/java/io/brackit/query/atomic/DTD.java
@@ -391,51 +391,45 @@ public class DTD extends AbstractDuration {
   }
 
   private DTD addInternal(boolean n2, short d2, byte h2, byte m2, int mic2) throws QueryException {
-    boolean n1 = isNegative();
-    int mic1 = getMicros();
-    byte m1 = getMinutes();
-    byte h1 = getHours();
-    short d1 = getDays();
+    // Convert each operand to a signed total-micros count, add, then renormalize. The
+    // previous field-by-field implementation determined the result's sign from the
+    // sign of newDays alone — incorrectly when the days components cancelled but the
+    // sub-day components didn't (e.g. PT1H - PT2H = -PT1H), and it relied on `*= -1`
+    // on a `byte` which truncated negative-hour values into the DTD's high-bit-encoded
+    // sign field, producing `-PT127H`. This rewrite avoids both pitfalls — total-micros
+    // arithmetic is unconditionally correct for any input within long range.
+    final long total1 = totalMicros(isNegative(), getDays(), getHours(), getMinutes(), getMicros());
+    final long total2 = totalMicros(n2, d2, h2, m2, mic2);
+    long sum = total1 + total2;
 
-    if (n1) {
-      d1 *= -1;
-      h1 *= -1;
-      m1 *= -1;
-      mic1 *= -1;
-    }
-    if (n2) {
-      d2 *= -1;
-      h2 *= -1;
-      m2 *= -1;
-      mic2 *= -1;
-    }
-
-    int newDays = d1 + d2;
-    int newHours = h1 + h2;
-    int newMinutes = m1 + m2;
-    int newMicros = mic1 + mic2;
-    boolean newNegative = newDays < 0;
-
+    final boolean newNegative = sum < 0;
     if (newNegative) {
-      newDays *= -1;
-      newHours *= -1;
-      newMinutes *= -1;
-      newMicros *= -1;
+      sum = -sum;
     }
 
-    newMinutes += newMicros / 60000000;
-    newMicros %= 60000000;
-    newHours += newMinutes / 60;
-    newMinutes %= 60;
-    newDays += newHours / 24;
-    newHours %= 24;
+    final long newMicros = sum % MICROS_PER_MINUTE;
+    final long newMinutes = (sum / MICROS_PER_MINUTE) % 60L;
+    final long newHours = (sum / MICROS_PER_HOUR) % 24L;
+    final long newDays = sum / MICROS_PER_DAY;
 
     if (newDays > Short.MAX_VALUE) {
       throw new QueryException(ErrorCode.ERR_OVERFLOW_UNDERFLOW_IN_DURATION);
     }
 
-    return new DTD(newNegative, (short) newDays, (byte) newHours, (byte) newMinutes, newMicros);
+    return new DTD(newNegative, (short) newDays, (byte) newHours, (byte) newMinutes, (int) newMicros);
   }
+
+  /** Convert a (negative, days, hours, minutes, micros) tuple into total signed micros. */
+  private static long totalMicros(final boolean negative, final short days, final byte hours, final byte minutes,
+      final int micros) {
+    final long total = (long) days * MICROS_PER_DAY + (long) hours * MICROS_PER_HOUR + (long) minutes
+        * MICROS_PER_MINUTE + micros;
+    return negative ? -total : total;
+  }
+
+  private static final long MICROS_PER_MINUTE = 60_000_000L;
+  private static final long MICROS_PER_HOUR = MICROS_PER_MINUTE * 60L;
+  private static final long MICROS_PER_DAY = MICROS_PER_HOUR * 24L;
 
   @Override
   public boolean isNegative() {

--- a/src/main/java/io/brackit/query/atomic/YMD.java
+++ b/src/main/java/io/brackit/query/atomic/YMD.java
@@ -261,36 +261,35 @@ public class YMD extends AbstractDuration {
   }
 
   private YMD addInternal(boolean n2, short y2, byte m2) throws QueryException {
-    boolean n1 = isNegative();
-    byte m1 = getMonths();
-    short y1 = getYears();
+    // Convert each operand to a signed total-months count, add, then renormalize. The
+    // previous field-by-field implementation chose the result's sign by looking only at
+    // newYears — incorrect when the years components cancelled but the months didn't
+    // (e.g. P6M - P1Y) — and `*= -1` on a `byte` truncated the negated months into the
+    // YMD's high-bit-encoded sign field, producing nonsense like `-P1Y122M`. Total-
+    // months arithmetic sidesteps both pitfalls.
+    final long total1 = totalMonths(isNegative(), getYears(), getMonths());
+    final long total2 = totalMonths(n2, y2, m2);
+    long sum = total1 + total2;
 
-    if (n1) {
-      m1 *= -1;
-      y1 *= -1;
-    }
-    if (n2) {
-      m2 *= -1;
-      y2 *= -1;
-    }
-
-    int newMonths = m1 + m2;
-    int newYears = y1 + y2;
-    boolean newNegative = newYears < 0;
-
+    final boolean newNegative = sum < 0;
     if (newNegative) {
-      newYears *= -1;
-      newMonths *= -1;
+      sum = -sum;
     }
 
-    newYears += (newMonths / 12);
-    newMonths %= 12;
+    final long newYears = sum / 12L;
+    final long newMonths = sum % 12L;
 
     if (newYears > Short.MAX_VALUE) {
       throw new QueryException(ErrorCode.ERR_OVERFLOW_UNDERFLOW_IN_DURATION);
     }
 
     return new YMD(newNegative, (short) newYears, (byte) newMonths);
+  }
+
+  /** Convert a (negative, years, months) tuple into total signed months. */
+  private static long totalMonths(final boolean negative, final short years, final byte months) {
+    final long total = (long) years * 12L + months;
+    return negative ? -total : total;
   }
 
   @Override

--- a/src/test/java/io/brackit/query/atomic/DateTimeTest.java
+++ b/src/test/java/io/brackit/query/atomic/DateTimeTest.java
@@ -101,4 +101,79 @@ public final class DateTimeTest {
     DTD sevenDays = new DTD(false, (short) 7, (byte) 0, (byte) 0, 0);
     assertTrue(diff.cmp(sevenDays) < 0, "sub-second diff should be less than P7D, got " + diff);
   }
+
+  // =========================================================================
+  // DTD subtract regressions (addInternal sign-bit corruption + wrong newNegative)
+  // =========================================================================
+
+  /**
+   * Pre-fix this returned {@code -PT127H} because {@code newNegative} was decided only
+   * by the sign of {@code newDays}. When the days components cancelled, the routine
+   * stored the negative {@code newHours} byte directly in the DTD's high-bit-encoded
+   * sign field, producing {@code 0xFF & 0x7F == 127}.
+   */
+  @Test
+  public void dtdSubtract_smallerMinusLarger_yieldsCorrectNegativeMagnitude() throws Exception {
+    assertEquals("-PT1H", new DTD("PT1H").subtract(new DTD("PT2H")).toString());
+    assertEquals("-PT30M", new DTD("PT30M").subtract(new DTD("PT1H")).toString());
+    assertEquals("-PT1S", new DTD("PT0S").subtract(new DTD("PT1S")).toString());
+  }
+
+  @Test
+  public void dtdAdd_negativeOperand_renormalizesProperly() throws Exception {
+    assertEquals("PT1H", new DTD("-PT1H").add(new DTD("PT2H")).toString());
+    assertEquals("-PT1H", new DTD("PT1H").add(new DTD("-PT2H")).toString());
+    assertEquals("PT15M", new DTD("-PT30M").add(new DTD("PT45M")).toString());
+  }
+
+  // =========================================================================
+  // YMD subtract regressions (analogous addInternal bug)
+  // =========================================================================
+
+  /**
+   * Pre-fix this returned {@code -P1Y122M} because {@code newNegative} looked only at
+   * {@code newYears}, and the negate of months by {@code *= -1} on a {@code byte}
+   * collided with YMD's high-bit-encoded sign field.
+   */
+  @Test
+  public void ymdSubtract_smallerMinusLarger_yieldsCorrectNegativeMagnitude() throws Exception {
+    assertEquals("-P6M", new YMD("P6M").subtract(new YMD("P1Y")).toString());
+    assertEquals("-P1Y", new YMD("P1Y").subtract(new YMD("P2Y")).toString());
+  }
+
+  // =========================================================================
+  // DateTime + duration boundary cases (off-by-one borrow on January and day=0)
+  // =========================================================================
+
+  /**
+   * Pre-fix {@code 2026-05-01T01:00:00Z - PT2H} returned {@code 2026-05-00T23:00:00Z}
+   * (invalid 0th-of-May) because the day-borrow loop checked {@code newDays < 0}
+   * instead of {@code newDays < 1}.
+   */
+  @Test
+  public void dateTimeSubtract_dayTimeDuration_acrossMonthBoundary() throws Exception {
+    DateTime a = new DateTime("2026-05-01T01:00:00Z");
+    DTD twoHours = new DTD("PT2H");
+    assertEquals("2026-04-30T23:00:00Z", a.subtract(twoHours).toString());
+  }
+
+  /**
+   * Pre-fix subtracting from January would call {@code maxDayInMonth(year, 0)} (the
+   * lookup happened before the year/month wrap), producing wrong day counts for
+   * year-boundary borrows. Correct: roll to December of the previous year.
+   */
+  @Test
+  public void dateTimeSubtract_dayTimeDuration_acrossYearBoundary() throws Exception {
+    DateTime a = new DateTime("2025-01-01T01:00:00Z");
+    DTD twoHours = new DTD("PT2H");
+    assertEquals("2024-12-31T23:00:00Z", a.subtract(twoHours).toString());
+  }
+
+  /** Symmetric case: forward roll across year boundary (December into January). */
+  @Test
+  public void dateTimeAdd_dayTimeDuration_acrossYearBoundary() throws Exception {
+    DateTime a = new DateTime("2024-12-31T23:00:00Z");
+    DTD twoHours = new DTD("PT2H");
+    assertEquals("2025-01-01T01:00:00Z", a.add(twoHours).toString());
+  }
 }


### PR DESCRIPTION
… off-by-one

Three independent bugs surfaced during the audit triggered by the dateTime subtract fix:

1. DTD.addInternal: when the days components cancelled but sub-day components didn't (e.g. PT1H - PT2H), newNegative was decided only by sign(newDays) — false. The non-flipped negative hours then went into `new DTD(false, days, hours, minutes, micros)` where the constructor stored hours as a signed byte; getHours() masks with 0x7F so getHours() of -1 returned 127. Result: PT1H - PT2H == -PT127H.

2. YMD.addInternal: same shape of bug. P6M - P1Y == -P1Y122M because the negated months byte hit YMD's high-bit-encoded sign field.

3. AbstractTimeInstant.add (the cross-day-boundary borrow loop):
   * `newDays < 0` allowed newDays == 0 to escape, yielding invalid 0th-of-month dates (2026-05-01 - PT2H == 2026-05-00T23:00:00).
   * `maxDayInMonth(newYear, newMonth - 1)` was looked up BEFORE the month wrap, so a borrow at January passed month 0.

Fix template for #1 and #2: convert each operand to total signed micros (or total signed months for YMD), add, take abs, then renormalize. Eliminates the field-by-field branching and the byte-sign-bit trap.

Fix for #3: change `<= 0` to `< 1`, compute the prev/next (year, month) BEFORE the day-count lookup so January borrows from December of the prior year correctly.

Adds six regression tests in DateTimeTest covering DTD subtract small- minus-large, DTD add with mixed signs, YMD subtract small-minus-large, DateTime cross-month subtract, DateTime cross-year subtract, and DateTime cross-year add. All 1036 existing Brackit tests continue to pass.