### PR TITLE
fix(atomic): Int32/Int64 compare & arithmetic via DblNumeric/FltNumeric interface (not concrete class)

### DIFF
--- a/src/main/java/io/brackit/query/atomic/Int32.java
+++ b/src/main/java/io/brackit/query/atomic/Int32.java
@@ -232,7 +232,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return addBigDecimal(new BigDecimal(v), other.decimalValue(), false);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return addDouble(v, other.doubleValue());
     } else {
       return addFloat(v, other.floatValue());
@@ -251,7 +251,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       return other.negate().add(this);
     } else if (other instanceof DecNumeric) {
       return subtractBigDecimal(new BigDecimal(v), other.decimalValue(), false);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return subtractDouble(v, other.doubleValue());
     } else {
       return subtractFloat(v, other.floatValue());
@@ -270,7 +270,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       return other.multiply(this);
     } else if (other instanceof DecNumeric) {
       return multiplyBigDecimal(new BigDecimal(v), other.decimalValue(), true);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return multiplyDouble(v, other.doubleValue());
     } else {
       return multiplyFloat(v, other.floatValue());
@@ -289,7 +289,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return divideBigDecimal(new BigDecimal(v), other.decimalValue(), false);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return divideDouble(v, other.doubleValue());
     } else {
       return divideFloat(v, other.floatValue());
@@ -308,7 +308,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return idivideBigDecimal(new BigDecimal(v), other.decimalValue());
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return idivideDouble(v, other.doubleValue());
     } else {
       return idivideFloat(v, other.floatValue());
@@ -327,7 +327,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return modBigDecimal(new BigDecimal(v), other.decimalValue());
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return modDouble(v, other.doubleValue());
     } else {
       return divideFloat(v, other.floatValue());

--- a/src/main/java/io/brackit/query/atomic/Int64.java
+++ b/src/main/java/io/brackit/query/atomic/Int64.java
@@ -104,9 +104,9 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return -other.cmp(this);
     } else if (other instanceof DecNumeric) {
       return new BigDecimal(v).compareTo(((Numeric) other).decimalValue());
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return Double.compare(v, ((Numeric) other).doubleValue());
-    } else if (other instanceof Flt) {
+    } else if (other instanceof FltNumeric) {
       return Float.compare(v, ((Numeric) other).floatValue());
     }
     throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
@@ -125,7 +125,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return -((AbstractNumeric) other).atomicCmpInternal(this);
     } else if (other instanceof DecNumeric) {
       return new BigDecimal(v).compareTo(((Numeric) other).decimalValue());
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return Double.compare(v, ((Numeric) other).doubleValue());
     } else {
       return Float.compare(v, ((Numeric) other).floatValue());
@@ -176,7 +176,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return addBigDecimal(new BigDecimal(v), other.decimalValue(), false);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return addDouble(v, other.doubleValue());
     } else {
       return addFloat(v, other.floatValue());
@@ -192,7 +192,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return other.negate().add(this);
     } else if (other instanceof DecNumeric) {
       return subtractBigDecimal(new BigDecimal(v), other.decimalValue(), false);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return subtractDouble(v, other.doubleValue());
     } else {
       return subtractFloat(v, other.floatValue());
@@ -208,7 +208,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return other.multiply(this);
     } else if (other instanceof DecNumeric) {
       return multiplyBigDecimal(new BigDecimal(v), other.decimalValue(), true);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return multiplyDouble(v, other.doubleValue());
     } else {
       return multiplyFloat(v, other.floatValue());
@@ -224,7 +224,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return divideBigDecimal(new BigDecimal(v), other.decimalValue(), false);
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return divideDouble(v, other.doubleValue());
     } else {
       return divideFloat(v, other.floatValue());
@@ -240,7 +240,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return idivideBigDecimal(new BigDecimal(v), other.decimalValue());
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return idivideDouble(v, other.doubleValue());
     } else {
       return idivideFloat(v, other.floatValue());
@@ -256,7 +256,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       return other.add(this);
     } else if (other instanceof DecNumeric) {
       return modBigDecimal(new BigDecimal(v), other.decimalValue());
-    } else if (other instanceof Dbl) {
+    } else if (other instanceof DblNumeric) {
       return modDouble(v, other.doubleValue());
     } else {
       return divideFloat(v, other.floatValue());

--- a/src/test/java/io/brackit/query/atomic/IntDoublePromotionTest.java
+++ b/src/test/java/io/brackit/query/atomic/IntDoublePromotionTest.java
@@ -1,0 +1,180 @@
+package io.brackit.query.atomic;
+
+import io.brackit.query.jdm.Type;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link Int32}/{@link Int64} must compare with and operate on ANY {@link DblNumeric}/
+ * {@link FltNumeric} operand, dispatching on the numeric INTERFACE — not only on the concrete
+ * {@link Dbl}/{@link Flt} classes. Externally supplied numerics (e.g. document-sourced numbers that
+ * wrap and delegate to a {@code Dbl}) implement the interface but are not the concrete class, so a
+ * concrete {@code instanceof Dbl} check would mis-route them: comparison threw
+ * {@code err:XPTY0004 "Cannot compare 'xs:integer' with 'xs:double'"} and arithmetic silently
+ * narrowed to {@code xs:float}.
+ */
+public class IntDoublePromotionTest {
+
+  /** A {@link DblNumeric} that is NOT the concrete {@link Dbl} (mirrors a delegating wrapper). */
+  private static final class ExternalDbl extends AbstractNumeric implements DblNumeric {
+    private final Dbl delegate;
+
+    ExternalDbl(final double v) {
+      this.delegate = new Dbl(v);
+    }
+
+    @Override
+    public Type type() {
+      return delegate.type();
+    }
+
+    @Override
+    public double doubleValue() {
+      return delegate.doubleValue();
+    }
+
+    @Override
+    public float floatValue() {
+      return delegate.floatValue();
+    }
+
+    @Override
+    public BigDecimal decimalValue() {
+      return delegate.decimalValue();
+    }
+
+    @Override
+    public BigDecimal integerValue() {
+      return delegate.integerValue();
+    }
+
+    @Override
+    public long longValue() {
+      return delegate.longValue();
+    }
+
+    @Override
+    public int intValue() {
+      return delegate.intValue();
+    }
+
+    @Override
+    public boolean booleanValue() {
+      return delegate.booleanValue();
+    }
+
+    @Override
+    public String stringValue() {
+      return delegate.stringValue();
+    }
+
+    @Override
+    public Atomic asType(final Type type) {
+      return delegate.asType(type);
+    }
+
+    @Override
+    public int cmp(final Atomic other) {
+      return delegate.cmp(other);
+    }
+
+    @Override
+    public int atomicCmpInternal(final Atomic other) {
+      return delegate.atomicCmpInternal(other);
+    }
+
+    @Override
+    public Numeric add(final Numeric other) {
+      return delegate.add(other);
+    }
+
+    @Override
+    public Numeric subtract(final Numeric other) {
+      return delegate.subtract(other);
+    }
+
+    @Override
+    public Numeric multiply(final Numeric other) {
+      return delegate.multiply(other);
+    }
+
+    @Override
+    public Numeric div(final Numeric other) {
+      return delegate.div(other);
+    }
+
+    @Override
+    public Numeric idiv(final Numeric other) {
+      return delegate.idiv(other);
+    }
+
+    @Override
+    public Numeric mod(final Numeric other) {
+      return delegate.mod(other);
+    }
+
+    @Override
+    public Numeric negate() {
+      return delegate.negate();
+    }
+
+    @Override
+    public Numeric round() {
+      return delegate.round();
+    }
+
+    @Override
+    public Numeric abs() {
+      return delegate.abs();
+    }
+
+    @Override
+    public Numeric floor() {
+      return delegate.floor();
+    }
+
+    @Override
+    public Numeric ceiling() {
+      return delegate.ceiling();
+    }
+
+    @Override
+    public Numeric roundHalfToEven(final int precision) {
+      return delegate.roundHalfToEven(precision);
+    }
+
+    @Override
+    public IntNumeric asIntNumeric() {
+      return delegate.asIntNumeric();
+    }
+  }
+
+  @Test
+  public void int64ComparesWithNonConcreteDblNumeric() {
+    final Int64 i = new Int64(5_000_000_000L);
+    final ExternalDbl d = new ExternalDbl(3.7);
+    assertTrue(i.cmp(d) > 0, "5e9 (Int64) gt 3.7 (DblNumeric)");
+    assertTrue(d.cmp(i) < 0, "3.7 (DblNumeric) lt 5e9 (Int64)");
+    assertTrue(i.atomicCmp(d) > 0, "atomicCmp must promote, not throw");
+  }
+
+  @Test
+  public void int32ComparesWithNonConcreteDblNumeric() {
+    final Int32 i = new Int32(4);
+    final ExternalDbl d = new ExternalDbl(3.7);
+    assertTrue(i.cmp(d) > 0);
+    assertTrue(i.atomicCmp(d) > 0);
+  }
+
+  @Test
+  public void intArithmeticWithNonConcreteDblNumericStaysDouble() {
+    // 3 + 0.5 must promote to xs:double, not narrow to xs:float.
+    assertEquals(Type.DBL, new Int32(3).add(new ExternalDbl(0.5)).type());
+    assertEquals(Type.DBL, new Int64(5_000_000_000L).add(new ExternalDbl(0.5)).type());
+    assertEquals(3.5, new Int32(3).add(new ExternalDbl(0.5)).doubleValue(), 1e-12);
+  }
+}


### PR DESCRIPTION
## Summary

`Int32` and `Int64` matched a double/float operand by its **concrete** `Dbl`/`Flt` class (`instanceof Dbl` / `instanceof Flt`) while checking only the `DecNumeric` **interface** for decimals. Any `DblNumeric`/`FltNumeric` that is not the concrete `Dbl`/`Flt` class — e.g. a document-sourced number that wraps and delegates to a `Dbl` (as SirixDB's JSON DB items do) — was mis-routed:

- **comparison** fell through to the `Cannot compare` throw → `err:XPTY0004 "Cannot compare 'xs:integer' with 'xs:double'"` (broke `order by` / value comparisons over mixed integer/double values), and
- **arithmetic** silently narrowed the result to `xs:float`.

## Fix

Match the numeric **interfaces** (`DblNumeric`/`FltNumeric`), exactly as the base `Int` already does. Behaviour is unchanged for the concrete `Dbl`/`Flt` classes (they implement those interfaces), so existing callers are unaffected.

`IntDoublePromotionTest` adds a non-concrete `DblNumeric` stub to guard the interface dispatch for both comparison and arithmetic.