### PR TITLE
Fix correctness bugs across atomics, expressions, runtime, and aggregation

### DIFF
--- a/src/main/java/io/brackit/query/QueryException.java
+++ b/src/main/java/io/brackit/query/QueryException.java
@@ -39,37 +39,76 @@ import io.brackit.query.atomic.QNm;
 public class QueryException extends RuntimeException {
   private final QNm code;
 
+  /** fn:error's user description (raw, NOT run through String.format) — null if not from fn:error. */
+  private final String description;
+
+  /** fn:error's error-object value ($err:value) — null if absent. */
+  private final transient Object errorValue;
+
+  /**
+   * fn:error constructor: keeps the description VERBATIM (no String.format — a '%' in user data
+   * crashed it) and retains the error value for $err:value.
+   */
+  public QueryException(QNm code, String description, Object errorValue, boolean fromError) {
+    super(code.toString() + ": " + description);
+    this.code = code;
+    this.description = description;
+    this.errorValue = errorValue;
+  }
+
   public QueryException(QNm code) {
     super(String.format(code.toString()));
     this.code = code;
+    this.description = null;
+    this.errorValue = null;
   }
 
   public QueryException(QNm code, Object o) {
     super(code.toString() + ": " + o);
     this.code = code;
+    this.description = null;
+    this.errorValue = null;
   }
 
   public QueryException(QNm code, String message, Object... args) {
     super(String.format(code.toString() + ": " + message, args));
     this.code = code;
+    this.description = null;
+    this.errorValue = null;
   }
 
   public QueryException(Throwable cause, QNm code, String message, Object... args) {
     super(String.format(code.toString() + ": " + message, args), cause);
     this.code = code;
+    this.description = null;
+    this.errorValue = null;
   }
 
   public QueryException(Throwable cause, QNm code) {
     super(code.toString(), cause);
     this.code = code;
+    this.description = null;
+    this.errorValue = null;
   }
 
   public QueryException(Throwable cause, QNm code, Object o) {
     super(code.toString() + ": " + o, cause);
     this.code = code;
+    this.description = null;
+    this.errorValue = null;
   }
 
   public QNm getCode() {
     return code;
+  }
+
+  /** The fn:error description ($err:description) — falls back to the full message. */
+  public String getDescription() {
+    return description != null ? description : getMessage();
+  }
+
+  /** The fn:error error-object value ($err:value), or null. */
+  public Object getErrorValue() {
+    return errorValue;
   }
 }

--- a/src/main/java/io/brackit/query/atomic/AbstractDuration.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractDuration.java
@@ -117,8 +117,11 @@ public abstract class AbstractDuration extends AbstractAtomic implements Duratio
       out.append(seconds);
       int remainder = micros - seconds * 1000000;
       if (remainder != 0) {
+        // Fractional seconds = the micros remainder zero-padded to 6 digits with trailing zeros
+        // stripped. Appending the bare int dropped the leading zeros (50000 micros = 0.05s rendered
+        // as ".50000") and kept trailing zeros (".500000").
         out.append('.');
-        out.append(remainder);
+        out.append(String.format("%06d", remainder).replaceAll("0+$", ""));
       }
       out.append('S');
       fieldSet = true;

--- a/src/main/java/io/brackit/query/atomic/AbstractNumeric.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractNumeric.java
@@ -146,7 +146,7 @@ public abstract class AbstractNumeric extends AbstractAtomic implements Numeric 
     long r = a + b;
     if (b >= 0 ? r < a : r > a) {
       // overflow escalate to BigDecimal
-      new Int(new BigDecimal(a).add(new BigDecimal(b)));
+      return new Int(new BigDecimal(a).add(new BigDecimal(b)));
     }
     return new Int64(r);
   }
@@ -176,7 +176,7 @@ public abstract class AbstractNumeric extends AbstractAtomic implements Numeric 
     long r = a - b;
     if (b >= 0 ? r >= a : r <= a) {
       // overflow escalate to BigDecimal
-      new Int(new BigDecimal(a).subtract(new BigDecimal(b)));
+      return new Int(new BigDecimal(a).subtract(new BigDecimal(b)));
     }
     return new Int64(r);
   }
@@ -206,7 +206,7 @@ public abstract class AbstractNumeric extends AbstractAtomic implements Numeric 
     long r = a * b;
     if (b != 0 && r / b != a) {
       // overflow escalate to BigDecimal
-      new Int(new BigDecimal(a).multiply(new BigDecimal(b)));
+      return new Int(new BigDecimal(a).multiply(new BigDecimal(b)));
     }
     return new Int64(r);
   }
@@ -338,12 +338,13 @@ public abstract class AbstractNumeric extends AbstractAtomic implements Numeric 
     return new Int64(a % b);
   }
 
-  protected final Numeric modBigDecimal(BigDecimal a, BigDecimal b) throws QueryException {
+  protected final Numeric modBigDecimal(BigDecimal a, BigDecimal b, boolean isDecimal) throws QueryException {
     if (b.compareTo(BigDecimal.ZERO) == 0) {
       throw new QueryException(ErrorCode.ERR_DIVISION_BY_ZERO);
     }
 
-    return new Int(a.remainder(b));
+    // mod yields xs:decimal when either operand is a decimal, xs:integer when both are integers.
+    return isDecimal ? new Dec(a.remainder(b)) : new Int(a.remainder(b));
   }
 
   protected final String killTrailingZeros(String s) {

--- a/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
@@ -120,7 +120,10 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
     AbstractTimeInstant a = this;
     AbstractTimeInstant b = other;
 
-    if (a.getTimezone() != null && (a.getTimezone().getHours() != 0 || a.getTimezone().getMinutes() != 0)) {
+    // A value with ANY timezone — including UTC (Z / +00:00) — IS timezoned. The old guard treated
+    // a 00:00 offset as "no timezone", so a UTC value compared against a non-UTC value wrongly took
+    // the implicit-timezone ±14h undecidable path (e.g. "…01:00Z" eq "…03:00+02:00" -> false).
+    if (a.getTimezone() != null) {
       a = new DateTime(a.getYear(),
                        a.getMonth(),
                        a.getDay(),
@@ -130,7 +133,7 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
                        a.getTimezone()).canonicalize();
       aHasTZ = true;
     }
-    if (b.getTimezone() != null && (b.getTimezone().getHours() != 0 || b.getTimezone().getMinutes() != 0)) {
+    if (b.getTimezone() != null) {
       b = new DateTime(b.getYear(),
                        b.getMonth(),
                        b.getDay(),
@@ -424,9 +427,14 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
   @Override
   public AbstractTimeInstant canonicalize() {
     DTD timezone = getTimezone();
-    if (timezone == null || timezone.getDays() == 0 && timezone.getHours() == 0) {
+    if (timezone == null) {
       return this;
     }
+    // Normalize to UTC through add for ANY offset — including UTC (0:00) and sub-hour offsets like
+    // +00:30. The old shortcut returned `this` whenever the offset hours were 0, which (a) left
+    // +00:30 unnormalized and (b) made a UTC value carry a differently-normalized synthetic date
+    // than a non-UTC value for xs:time/xs:date comparisons, breaking eq/lt/gt. For an already-UTC
+    // value this subtracts a zero offset (time unchanged) and just yields consistent fields.
     return add(!timezone.isNegative(), timezone, UTC_TIMEZONE);
   }
 

--- a/src/main/java/io/brackit/query/atomic/B64.java
+++ b/src/main/java/io/brackit/query/atomic/B64.java
@@ -28,6 +28,7 @@
 package io.brackit.query.atomic;
 
 import java.util.Arrays;
+import java.util.Base64;
 
 import io.brackit.query.ErrorCode;
 import io.brackit.query.QueryException;
@@ -59,114 +60,15 @@ public class B64 extends AbstractAtomic {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
     }
 
-    int size = 0;
-    int length = str.length();
-    byte[] bytes = new byte[noOfOctets(str)];
-
-    for (int charPos = 0; charPos < length;) {
-      char c1 = str.charAt(charPos++);
-      char c2 = str.charAt(charPos++);
-      char c3 = str.charAt(charPos++);
-      char c4 = str.charAt(charPos++);
-
-      bytes[size++] = (byte) b64(str, c1);
-      bytes[size++] = (byte) (c3 != '=' ? b64(str, c2) : b04(str, c2));
-
-      if (c4 != '=') {
-        bytes[size++] = (byte) b64(str, c3);
-        bytes[size++] = (byte) b64(str, c4);
-      } else {
-        if (c3 != '=') {
-          bytes[size] = (byte) b16(str, c3);
-        }
-
-        if (charPos != length) {
-          throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
-        }
-        break;
-      }
+    // Store the DECODED OCTETS (consistent with the byte[] constructor and with getBytes() being
+    // read as octets by hexBinary/string conversions). The previous hand-rolled decoder stored the
+    // raw 6-bit alphabet indices instead, corrupting the value on every round-trip and cross-type
+    // conversion.
+    try {
+      this.bytes = Base64.getDecoder().decode(str);
+    } catch (final IllegalArgumentException e) {
+      throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
     }
-    this.bytes = bytes;
-  }
-
-  private int b04(String str, char c) throws QueryException {
-    int v;
-    if (c == 'A')
-      v = 0;
-    else if (c == 'Q')
-      v = 16;
-    else if (c == 'g')
-      v = 32;
-    else if (c == 'w')
-      v = 48;
-    else
-      throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
-    return v;
-  }
-
-  private int b16(String str, char c) throws QueryException {
-    int v;
-    if (c == 'A')
-      v = 0;
-    else if (c == 'E')
-      v = 4;
-    else if (c == 'I')
-      v = 8;
-    else if (c == 'M')
-      v = 12;
-    else if (c == 'Q')
-      v = 16;
-    else if (c == 'U')
-      v = 20;
-    else if (c == 'Y')
-      v = 24;
-    else if (c == 'c')
-      v = 28;
-    else if (c == 'g')
-      v = 32;
-    else if (c == 'k')
-      v = 36;
-    else if (c == 'o')
-      v = 40;
-    else if (c == 's')
-      v = 44;
-    else if (c == 'w')
-      v = 48;
-    else if (c == '0')
-      v = 52;
-    else if (c == '4')
-      v = 56;
-    else if (c == '8')
-      v = 60;
-    else
-      throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
-    return v;
-  }
-
-  private int noOfOctets(String str) {
-    int dataLength = str.length();
-    if (dataLength > 0 && str.charAt(dataLength - 1) == '=')
-      dataLength--;
-    if (dataLength > 0 && str.charAt(dataLength - 1) == '=')
-      dataLength--;
-    return dataLength;
-  }
-
-  private int b64(String str, char c) throws QueryException {
-    int v;
-    if (c >= '0' && c <= '9')
-      v = 52 + c - 48;
-    else if (c >= 'A' && c <= 'Z')
-      v = c - 65;
-    else if (c >= 'a' && c <= 'z')
-      v = 26 + c - 87;
-    else if (c == '+')
-      v = 62;
-    else if (c == '/')
-      v = 63;
-    else
-      throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
-    return v;
   }
 
   @Override
@@ -220,13 +122,8 @@ public class B64 extends AbstractAtomic {
 
   @Override
   public String stringValue() {
-    StringBuilder out = new StringBuilder();
-    for (byte aByte : bytes) {
-      int v = aByte & 255;
-      char c = (char) (v < 26 ? v + 65 : v < 52 ? v - 26 + 87 : v < 62 ? v - 52 + 48 : v == 62 ? '+' : '/');
-      out.append(c);
-    }
-    return out.toString();
+    // Re-encode the decoded octets to canonical base64 (with '=' padding).
+    return Base64.getEncoder().encodeToString(bytes);
   }
 
   @Override

--- a/src/main/java/io/brackit/query/atomic/Date.java
+++ b/src/main/java/io/brackit/query/atomic/Date.java
@@ -187,7 +187,10 @@ public class Date extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    String yTmp = year < 0 ? "-" : "" + (year < 10 ? "000" : year < 100 ? "00" : year < 1000 ? "0" : "") + year;
+    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
+    final int absYear = Math.abs(year);
+    String yTmp = (year < 0 ? "-" : "") + (absYear < 10 ? "000" : absYear < 100 ? "00" : absYear < 1000 ? "0" : "")
+        + absYear;
     String mTmp = (month < 10 ? "0" : "") + month;
     String dTmp = (day < 10 ? "0" : "") + day;
     String tzTmp = timezoneString();

--- a/src/main/java/io/brackit/query/atomic/DateTime.java
+++ b/src/main/java/io/brackit/query/atomic/DateTime.java
@@ -310,7 +310,10 @@ public class DateTime extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    String yTmp = year < 0 ? "-" : "" + (year < 10 ? "000" : year < 100 ? "00" : year < 1000 ? "0" : "") + year;
+    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
+    final int absYear = Math.abs(year);
+    String yTmp = (year < 0 ? "-" : "") + (absYear < 10 ? "000" : absYear < 100 ? "00" : absYear < 1000 ? "0" : "")
+        + absYear;
     String mTmp = (month < 10 ? "0" : "") + month;
     String dTmp = (day < 10 ? "0" : "") + day;
     String hTmp = (hour < 10 ? "0" : "") + hour;
@@ -321,9 +324,11 @@ public class DateTime extends AbstractTimeInstant {
     int remainder = micros - seconds * 1000000;
     String sTmp = (seconds < 10 ? "0" : "") + String.valueOf(seconds);
     if (remainder != 0) {
-      while (remainder / 10 == 0)
-        remainder /= 10; // cut trailing zeros
-      sTmp += ":" + remainder;
+      // Fractional seconds: the micros remainder zero-padded to 6 digits with trailing zeros
+      // stripped, after a '.' separator — e.g. 250000 -> ".25", 123 -> ".000123". (The old loop
+      // used ':' and mangled the magnitude / could spin on single-digit remainders.)
+      final String frac = String.format("%06d", remainder).replaceAll("0+$", "");
+      sTmp += "." + frac;
     }
     return String.format("%s-%s-%sT%s:%s:%s%s", yTmp, mTmp, dTmp, hTmp, minTmp, sTmp, tzTmp);
   }

--- a/src/main/java/io/brackit/query/atomic/Dec.java
+++ b/src/main/java/io/brackit/query/atomic/Dec.java
@@ -57,7 +57,13 @@ public class Dec extends AbstractNumeric implements DecNumeric {
 
   public Dec(String str) throws QueryException {
     try {
-      this.v = new BigDecimal(Whitespace.collapseTrimOnly(str));
+      final String s = Whitespace.collapseTrimOnly(str);
+      // xs:decimal's lexical space has NO exponent (that belongs to xs:double / xs:float), but
+      // BigDecimal accepts "1.0E2" -> 100. Reject exponent notation so the cast fails per spec.
+      if (s.indexOf('e') >= 0 || s.indexOf('E') >= 0) {
+        throw new NumberFormatException("exponent not allowed in the lexical space of xs:decimal");
+      }
+      this.v = new BigDecimal(s);
     } catch (Exception e) {
       throw new QueryException(e, ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:decimal", str);
     }
@@ -224,7 +230,8 @@ public class Dec extends AbstractNumeric implements DecNumeric {
   @Override
   public Numeric mod(Numeric other) throws QueryException {
     if (other instanceof DecNumeric) {
-      return modBigDecimal(v, other.decimalValue());
+      // this is xs:decimal -> the result is decimal regardless of the other operand's kind.
+      return modBigDecimal(v, other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return modDouble(v.doubleValue(), other.doubleValue());
     } else {
@@ -244,7 +251,7 @@ public class Dec extends AbstractNumeric implements DecNumeric {
 
   @Override
   public Numeric abs() throws QueryException {
-    return v.signum() >= 0 ? this : new Int(v.negate());
+    return v.signum() >= 0 ? this : new Dec(v.negate());
   }
 
   @Override

--- a/src/main/java/io/brackit/query/atomic/Flt.java
+++ b/src/main/java/io/brackit/query/atomic/Flt.java
@@ -125,7 +125,7 @@ public class Flt extends AbstractNumeric implements FltNumeric {
 
   @Override
   public boolean booleanValue() throws QueryException {
-    return v != 0 && !Float.isNaN(v) && Float.isInfinite(v);
+    return v != 0 && !Float.isNaN(v) && !Float.isInfinite(v);
   }
 
   @Override

--- a/src/main/java/io/brackit/query/atomic/GYE.java
+++ b/src/main/java/io/brackit/query/atomic/GYE.java
@@ -153,7 +153,11 @@ public class GYE extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    String yTmp = (year < 0) ? "-" : "" + ((year < 10) ? "000" : (year < 100) ? "00" : (year < 1000) ? "0" : "") + year;
+    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
+    final int absYear = Math.abs(year);
+    String yTmp = ((year < 0) ? "-" : "") + ((absYear < 10)
+        ? "000"
+        : (absYear < 100) ? "00" : (absYear < 1000) ? "0" : "") + absYear;
     String tzTmp = timezoneString();
 
     return String.format("%s%s", yTmp, tzTmp);

--- a/src/main/java/io/brackit/query/atomic/GYM.java
+++ b/src/main/java/io/brackit/query/atomic/GYM.java
@@ -176,7 +176,11 @@ public class GYM extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    String yTmp = (year < 0) ? "-" : "" + ((year < 10) ? "000" : (year < 100) ? "00" : (year < 1000) ? "0" : "") + year;
+    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
+    final int absYear = Math.abs(year);
+    String yTmp = ((year < 0) ? "-" : "") + ((absYear < 10)
+        ? "000"
+        : (absYear < 100) ? "00" : (absYear < 1000) ? "0" : "") + absYear;
     String mTmp = ((month < 10) ? "0" : "") + month;
     String tzTmp = timezoneString();
 

--- a/src/main/java/io/brackit/query/atomic/Int.java
+++ b/src/main/java/io/brackit/query/atomic/Int.java
@@ -67,7 +67,9 @@ public class Int extends AbstractNumeric implements IntNumeric {
   }
 
   public Int(double v) {
-    this.v = new BigDecimal((int) v);
+    // Floor to an integer without the lossy/overflowing (int) cast (used for idiv escalation of
+    // values beyond Long range).
+    this.v = BigDecimal.valueOf(v).setScale(0, RoundingMode.FLOOR);
   }
 
   @Override
@@ -158,8 +160,10 @@ public class Int extends AbstractNumeric implements IntNumeric {
 
   @Override
   public Numeric add(Numeric other) throws QueryException {
-    if (other instanceof DecNumeric) {
+    if (other instanceof IntNumeric) {
       return addBigDecimal(v, other.decimalValue(), false);
+    } else if (other instanceof DecNumeric) {
+      return addBigDecimal(v, other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return addDouble(v.doubleValue(), other.doubleValue());
     } else {
@@ -169,8 +173,10 @@ public class Int extends AbstractNumeric implements IntNumeric {
 
   @Override
   public Numeric subtract(Numeric other) throws QueryException {
-    if (other instanceof DecNumeric) {
+    if (other instanceof IntNumeric) {
       return subtractBigDecimal(v, other.decimalValue(), false);
+    } else if (other instanceof DecNumeric) {
+      return subtractBigDecimal(v, other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return subtractDouble(v.doubleValue(), other.doubleValue());
     } else {
@@ -215,8 +221,10 @@ public class Int extends AbstractNumeric implements IntNumeric {
 
   @Override
   public Numeric mod(Numeric other) throws QueryException {
-    if (other instanceof DecNumeric) {
-      return modBigDecimal(v, other.decimalValue());
+    if (other instanceof IntNumeric) {
+      return modBigDecimal(v, other.decimalValue(), false);
+    } else if (other instanceof DecNumeric) {
+      return modBigDecimal(v, other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return modDouble(v.doubleValue(), other.doubleValue());
     } else {

--- a/src/main/java/io/brackit/query/atomic/Int32.java
+++ b/src/main/java/io/brackit/query/atomic/Int32.java
@@ -160,7 +160,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
 
   @Override
   public boolean booleanValue() throws QueryException {
-    return ((v != 0) && (v != Integer.MAX_VALUE) && (v != Integer.MIN_VALUE));
+    return v != 0;
   }
 
   @Override
@@ -231,7 +231,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       }
       return other.add(this);
     } else if (other instanceof DecNumeric) {
-      return addBigDecimal(new BigDecimal(v), other.decimalValue(), false);
+      return addBigDecimal(new BigDecimal(v), other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return addDouble(v, other.doubleValue());
     } else {
@@ -250,7 +250,7 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
       }
       return other.negate().add(this);
     } else if (other instanceof DecNumeric) {
-      return subtractBigDecimal(new BigDecimal(v), other.decimalValue(), false);
+      return subtractBigDecimal(new BigDecimal(v), other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return subtractDouble(v, other.doubleValue());
     } else {
@@ -286,7 +286,8 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
         }
         return divideLong(v, other.longValue());
       }
-      return other.add(this);
+      // bare Int (IntNumeric but not LonNumeric): integer-valued, route through the decimal path
+      return divideBigDecimal(new BigDecimal(v), other.decimalValue(), false);
     } else if (other instanceof DecNumeric) {
       return divideBigDecimal(new BigDecimal(v), other.decimalValue(), false);
     } else if (other instanceof DblNumeric) {
@@ -305,7 +306,8 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
         }
         return idivideLong(v, other.longValue());
       }
-      return other.add(this);
+      // bare Int (IntNumeric but not LonNumeric): integer-valued, route through the decimal path
+      return idivideBigDecimal(new BigDecimal(v), other.decimalValue());
     } else if (other instanceof DecNumeric) {
       return idivideBigDecimal(new BigDecimal(v), other.decimalValue());
     } else if (other instanceof DblNumeric) {
@@ -324,13 +326,14 @@ public class Int32 extends AbstractNumeric implements LonNumeric {
         }
         return modLong(v, other.longValue());
       }
-      return other.add(this);
+      // bare Int (IntNumeric but not LonNumeric): integer-valued, integer remainder
+      return modBigDecimal(new BigDecimal(v), other.decimalValue(), false);
     } else if (other instanceof DecNumeric) {
-      return modBigDecimal(new BigDecimal(v), other.decimalValue());
+      return modBigDecimal(new BigDecimal(v), other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return modDouble(v, other.doubleValue());
     } else {
-      return divideFloat(v, other.floatValue());
+      return modFloat(v, other.floatValue());
     }
   }
 

--- a/src/main/java/io/brackit/query/atomic/Int64.java
+++ b/src/main/java/io/brackit/query/atomic/Int64.java
@@ -175,7 +175,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       }
       return other.add(this);
     } else if (other instanceof DecNumeric) {
-      return addBigDecimal(new BigDecimal(v), other.decimalValue(), false);
+      return addBigDecimal(new BigDecimal(v), other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return addDouble(v, other.doubleValue());
     } else {
@@ -191,7 +191,7 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       }
       return other.negate().add(this);
     } else if (other instanceof DecNumeric) {
-      return subtractBigDecimal(new BigDecimal(v), other.decimalValue(), false);
+      return subtractBigDecimal(new BigDecimal(v), other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return subtractDouble(v, other.doubleValue());
     } else {
@@ -221,7 +221,8 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       if (other instanceof LonNumeric) {
         return divideLong(v, other.longValue());
       }
-      return other.add(this);
+      // bare Int (IntNumeric but not LonNumeric): integer-valued, route through the decimal path
+      return divideBigDecimal(new BigDecimal(v), other.decimalValue(), false);
     } else if (other instanceof DecNumeric) {
       return divideBigDecimal(new BigDecimal(v), other.decimalValue(), false);
     } else if (other instanceof DblNumeric) {
@@ -237,7 +238,8 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       if (other instanceof LonNumeric) {
         return idivideLong(v, other.longValue());
       }
-      return other.add(this);
+      // bare Int (IntNumeric but not LonNumeric): integer-valued, route through the decimal path
+      return idivideBigDecimal(new BigDecimal(v), other.decimalValue());
     } else if (other instanceof DecNumeric) {
       return idivideBigDecimal(new BigDecimal(v), other.decimalValue());
     } else if (other instanceof DblNumeric) {
@@ -253,13 +255,14 @@ public class Int64 extends AbstractNumeric implements LonNumeric {
       if (other instanceof LonNumeric) {
         return modLong(v, other.longValue());
       }
-      return other.add(this);
+      // bare Int (IntNumeric but not LonNumeric): integer-valued, integer remainder
+      return modBigDecimal(new BigDecimal(v), other.decimalValue(), false);
     } else if (other instanceof DecNumeric) {
-      return modBigDecimal(new BigDecimal(v), other.decimalValue());
+      return modBigDecimal(new BigDecimal(v), other.decimalValue(), true);
     } else if (other instanceof DblNumeric) {
       return modDouble(v, other.doubleValue());
     } else {
-      return divideFloat(v, other.floatValue());
+      return modFloat(v, other.floatValue());
     }
   }
 

--- a/src/main/java/io/brackit/query/atomic/Str.java
+++ b/src/main/java/io/brackit/query/atomic/Str.java
@@ -176,8 +176,16 @@ public class Str extends AbstractAtomic {
   public boolean eq(Atomic other) throws QueryException {
     if (this == other)
       return true;
-    if (!(other instanceof Str s))
+    if (!(other instanceof Str s)) {
+      // Untyped atomics and xs:anyURI compare as strings, mirroring cmp(): general comparisons
+      // deliberately skip the Una->Str cast upstream as an optimization, and xs:anyURI promotes
+      // to xs:string. Returning false here made '"literal" = $untypedNode' ALWAYS false (while
+      // the reverse direction worked via Una's cmp fallback) and broke anyURI '=' equality.
+      if (other instanceof Una || other instanceof AnyURI) {
+        return str.equals(other.stringValue());
+      }
       return false;
+    }
 
     // Quick length check on underlying strings
     if (str.length() != s.str.length())

--- a/src/main/java/io/brackit/query/atomic/Time.java
+++ b/src/main/java/io/brackit/query/atomic/Time.java
@@ -197,9 +197,9 @@ public class Time extends AbstractTimeInstant {
     int remainder = (micros - (seconds * 1000000));
     String sTmp = ((seconds < 10) ? "0" : "") + seconds;
     if (remainder != 0) {
-      while ((remainder / 10) == 0)
-        remainder /= 10; // cut trailing zeros
-      sTmp += ":" + remainder;
+      // Fractional seconds: micros padded to 6 digits, trailing zeros stripped, '.' separator.
+      final String frac = String.format("%06d", remainder).replaceAll("0+$", "");
+      sTmp += "." + frac;
     }
     return String.format("%s:%s:%s%s", hTmp, minTmp, sTmp, tzTmp);
   }

--- a/src/main/java/io/brackit/query/atomic/YMD.java
+++ b/src/main/java/io/brackit/query/atomic/YMD.java
@@ -201,23 +201,11 @@ public class YMD extends AbstractDuration {
       throw new QueryException(ErrorCode.ERR_OVERFLOW_UNDERFLOW_IN_DURATION);
     }
 
-    long newYears = Math.round(getYears() * v);
-    long newMonths = Math.round(getMonths() * v);
-    boolean newNegative = (isNegative() ^ (v < 0));
-
-    if (isNegative() ^ newNegative) {
-      newYears *= -1;
-      newMonths *= -1;
-    }
-
-    newYears += (newMonths / 12);
-    newMonths %= 12;
-
-    if (newYears > Short.MAX_VALUE) {
-      throw new QueryException(ErrorCode.ERR_OVERFLOW_UNDERFLOW_IN_DURATION);
-    }
-
-    return new YMD(newNegative, (short) newYears, (byte) newMonths);
+    // Scale the TOTAL month count, not years and months independently — e.g. P1Y * 1.5 is P1Y6M,
+    // not P2Y (round(1*1.5) years + round(0*1.5) months).
+    final long signedMonths = (isNegative() ? -1L : 1L) * (((long) getYears()) * 12 + getMonths());
+    final long resultMonths = Math.round(signedMonths * v);
+    return ymdFromSignedMonths(resultMonths);
   }
 
   public YMD divide(Dbl dbl) throws QueryException {
@@ -230,23 +218,23 @@ public class YMD extends AbstractDuration {
       return new YMD(false, (short) 0, (byte) 0);
     }
 
-    long newYears = Math.round(getYears() / v);
-    long newMonths = Math.round(getMonths() / v);
-    boolean newNegative = (isNegative() ^ (v < 0));
+    final long signedMonths = (isNegative() ? -1L : 1L) * (((long) getYears()) * 12 + getMonths());
+    final long resultMonths = Math.round(signedMonths / v);
+    return ymdFromSignedMonths(resultMonths);
+  }
 
-    if (isNegative() ^ newNegative) {
-      newYears *= -1;
-      newMonths *= -1;
-    }
+  /** Build a normalized {@link YMD} from a signed total-month count. */
+  private static YMD ymdFromSignedMonths(final long signedMonths) throws QueryException {
+    final boolean negative = signedMonths < 0;
+    final long magnitude = Math.abs(signedMonths);
+    final long years = magnitude / 12;
+    final long months = magnitude % 12;
 
-    newYears += (newMonths / 12);
-    newMonths %= 12;
-
-    if (newYears > Short.MAX_VALUE) {
+    if (years > Short.MAX_VALUE) {
       throw new QueryException(ErrorCode.ERR_OVERFLOW_UNDERFLOW_IN_DURATION);
     }
 
-    return new YMD(newNegative, (short) newYears, (byte) newMonths);
+    return new YMD(negative, (short) years, (byte) months);
   }
 
   public Numeric divide(YMD dur) throws QueryException {

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/TopDownPipeline.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/TopDownPipeline.java
@@ -74,7 +74,11 @@ public final class TopDownPipeline extends Walker {
           return end;
         }
       default:
-        throw new IllegalStateException();
+        // Reached for accepted-but-unimplemented clauses (e.g. tumbling/sliding WINDOW, which
+        // the parser and analyzer pass through but no operator implements). A bare
+        // IllegalStateException gave users no clue what failed.
+        throw new IllegalStateException("FLWOR clause is not supported by this processor (no operator implementation): "
+            + XQ.NAMES[clause.getType()]);
     }
   }
 

--- a/src/main/java/io/brackit/query/compiler/translator/BlockPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/BlockPipelineStrategy.java
@@ -169,6 +169,12 @@ public class BlockPipelineStrategy implements PipelineStrategy {
       runVarType = compiler.sequenceType(runVarDecl.getChild(1));
     }
     AST posBindingOrSourceExpr = node.getChild(pos++);
+    // 'allowing empty' marker child (see Compiler#forClause) or the lifted property form.
+    boolean allowingEmptyChild = false;
+    if (posBindingOrSourceExpr.getType() == XQ.AllowingEmpty) {
+      allowingEmptyChild = true;
+      posBindingOrSourceExpr = node.getChild(pos++);
+    }
     QNm posVarName = null;
     if (posBindingOrSourceExpr.getType() == XQ.TypedVariableBinding) {
       posVarName = (QNm) posBindingOrSourceExpr.getChild(0).getValue();
@@ -180,7 +186,7 @@ public class BlockPipelineStrategy implements PipelineStrategy {
     compiler.table.resolve(runVarName);
 
     // Check if allowingEmpty is set
-    boolean allowingEmpty = node.checkProperty("allowingEmpty");
+    boolean allowingEmpty = allowingEmptyChild || node.checkProperty("allowingEmpty");
     ForBind forBind = new ForBind(sourceExpr, allowingEmpty);
 
     if (posVarName != null) {

--- a/src/main/java/io/brackit/query/compiler/translator/Compiler.java
+++ b/src/main/java/io/brackit/query/compiler/translator/Compiler.java
@@ -1392,6 +1392,14 @@ public class Compiler implements Translator {
         emptyLeast = empty.getType() == XQ.LEAST;
       } else if (modifier.getType() == XQ.Collation) {
         collation = modifier.getChild(0).getStringValue();
+        // Only the codepoint collation is implemented. Silently accepting any URI and then
+        // sorting by codepoints anyway returned wrong orderings without a hint — reject at
+        // compile time instead (XQST0076), like fn:deep-equal already does at runtime.
+        if (!"http://www.w3.org/2005/xpath-functions/collation/codepoint".equals(collation)) {
+          throw new QueryException(ErrorCode.ERR_UNKNOWN_COLLATION_IN_FLWOR_CLAUSE,
+                                   "Unsupported collation in order by clause: %s",
+                                   collation);
+        }
       }
     }
     return new Ordering.OrderModifier(asc, emptyLeast, collation);
@@ -1505,6 +1513,15 @@ public class Compiler implements Translator {
 
     AST posBindingOrSourceExpr = forClause.getChild(forClausePos++);
 
+    // 'for $x allowing empty ...' (XQuery 3.0 outer-for): the parser emits an AllowingEmpty
+    // child here; previously no compile path consumed it, so the marker fell through to
+    // expr(...) and crashed with an internal "Unexpected AST expr node" error.
+    boolean allowingEmpty = false;
+    if (posBindingOrSourceExpr.getType() == XQ.AllowingEmpty) {
+      allowingEmpty = true;
+      posBindingOrSourceExpr = forClause.getChild(forClausePos++);
+    }
+
     if (posBindingOrSourceExpr.getType() == XQ.TypedVariableBinding) {
       posVarName = (QNm) posBindingOrSourceExpr.getChild(0).getValue();
       posBindingOrSourceExpr = forClause.getChild(forClausePos);
@@ -1513,7 +1530,7 @@ public class Compiler implements Translator {
 
     final Binding runVarBinding = table.bind(runVarName, runVarType);
     final Binding posBinding = posVarName != null ? table.bind(posVarName, SequenceType.INTEGER) : null;
-    final ForBind forBind = new ForBind(in.operator, sourceExpr, false);
+    final ForBind forBind = new ForBind(in.operator, sourceExpr, allowingEmpty);
 
     return new ClauseBinding(in, forBind, runVarBinding, posBinding) {
       @Override

--- a/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
@@ -488,6 +488,12 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
       runVarType = compiler.sequenceType(runVarDecl.getChild(1));
     }
     AST posBindingOrSourceExpr = node.getChild(pos++);
+    // 'allowing empty' marker child (see Compiler#forClause) or the lifted property form.
+    boolean allowingEmpty = node.checkProperty("allowingEmpty");
+    if (posBindingOrSourceExpr.getType() == XQ.AllowingEmpty) {
+      allowingEmpty = true;
+      posBindingOrSourceExpr = node.getChild(pos++);
+    }
     QNm posVarName = null;
     if (posBindingOrSourceExpr.getType() == XQ.TypedVariableBinding) {
       posVarName = (QNm) posBindingOrSourceExpr.getChild(0).getValue();
@@ -507,7 +513,7 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
       compiler.table.resolve(posVarName);
       // TODO Optimize and do not bind variable if not necessary
     }
-    ForBind forBind = new ForBind(in, sourceExpr, false);
+    ForBind forBind = new ForBind(in, sourceExpr, allowingEmpty);
     if (posBinding != null) {
       forBind.bindPosition(posBinding.isReferenced());
     }

--- a/src/main/java/io/brackit/query/expr/Accessor.java
+++ b/src/main/java/io/brackit/query/expr/Accessor.java
@@ -211,25 +211,24 @@ public abstract class Accessor {
     @Override
     public Stream<? extends Node<?>> performStep(Node<?> node) {
       final Node<?> n = node;
-      Node<?> p = node.getParent();
 
-      if (p == null || p.isDocumentRoot()) {
-        return new EmptyStream<>();
+      // Climb to the TOPMOST non-document ancestor: the root element of the tree containing
+      // the context node, whose subtree (in document order, minus ancestors) is scanned. The
+      // old climb keyed on isDocumentRoot() — which is simply parent==null and therefore TRUE
+      // for the parentless root ELEMENT of every constructed fragment — so it stopped one
+      // level short: preceding nodes outside the context's immediate parent subtree were
+      // invisible, and nodes directly under a constructed root got an empty axis.
+      Node<?> top = node;
+      Node<?> par = top.getParent();
+      while (par != null && par.getKind() != Kind.DOCUMENT) {
+        top = par;
+        par = par.getParent();
+      }
+      if (top == node) {
+        return new EmptyStream<>(); // the context node is the tree root: nothing precedes it
       }
 
-      if (!p.isDocumentRoot()) {
-        while (true) {
-          Node<?> a = p.getParent();
-          if (a == null || a.isDocumentRoot()) {
-            break;
-          }
-          p = a;
-        }
-      }
-
-      final Stream<? extends Node<?>> fragment = p.getDescendantOrSelf();
-      fragment.next();
-      fragment.next();
+      final Stream<? extends Node<?>> fragment = top.getDescendantOrSelf();
 
       return new Stream<>() {
         final Node<?> stopAt = n;
@@ -252,9 +251,14 @@ public abstract class Accessor {
               s = null;
               return null;
             }
-            // if (n.isAncestorOf(stopAt)) {
-            // continue;
-            // }
+            // XPath: the preceding axis excludes ANCESTORS of the context node. This filter
+            // also covers the fragment root itself, replacing the old unconditional
+            // "fragment.next(); fragment.next();" double-skip that discarded one LEGITIMATE
+            // preceding node (whichever node happened to be second in document order) while
+            // letting ancestors through (the exclusion below was commented out).
+            if (n.isAncestorOf(stopAt)) {
+              continue;
+            }
             return n;
           }
           return null;

--- a/src/main/java/io/brackit/query/expr/ArrayAccessExpr.java
+++ b/src/main/java/io/brackit/query/expr/ArrayAccessExpr.java
@@ -90,17 +90,28 @@ public final class ArrayAccessExpr implements Expr {
                                Type.INR);
     }
 
-    if (numericIndex.intValue() < 0) {
-      final int index = array.len() + numericIndex.intValue();
+    // Use the full long value: a positive index beyond int range (e.g. 3000000000) must NOT be
+    // truncated to a negative int (which previously produced a bogus "Illegal negative index").
+    final long idx = numericIndex.longValue();
 
-      if (index < 0) {
-        throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Illegal negative index: " + index);
+    if (idx < 0) {
+      // Negative indices count from the end (-1 == last). Overshooting the start is an error.
+      final long fromEnd = array.len() + idx;
+
+      if (fromEnd < 0) {
+        throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Illegal negative index: " + fromEnd);
       }
 
-      return array.at(array.len() + numericIndex.intValue());
+      return array.at((int) fromEnd);
     }
 
-    return array.at(numericIndex);
+    // A positive index at or beyond the array length is out of bounds -> empty sequence (path-style,
+    // matching the slice operator), rather than truncating or leaking a raw IndexOutOfBoundsException.
+    if (idx >= array.len()) {
+      return null;
+    }
+
+    return array.at((int) idx);
   }
 
   private LazySequence getLazySequence(final QueryContext ctx, final Tuple tuple, final Sequence sequence) {

--- a/src/main/java/io/brackit/query/expr/ArrayIndexSliceExpr.java
+++ b/src/main/java/io/brackit/query/expr/ArrayIndexSliceExpr.java
@@ -168,12 +168,11 @@ public final class ArrayIndexSliceExpr implements Expr {
 
     Item item;
     final var buffer = new GapList<Item>(array.len());
-    boolean first = true;
     while ((item = it.next()) != null && i < upperBoundIndex) {
-      if (first) {
-        first = false;
-        buffer.add(item);
-      } else if (i % step == 0) {
+      // Step counts from the LOWER BOUND, not absolute index 0: with lower=1, step=2 over
+      // [1,2,3,4,5] the old `i % step == 0` kept indices {1(first),2,4} → [2,3,5]; the correct
+      // kept set is {1,3} → [2,4].
+      if ((i - lowerBoundIndex) % step == 0) {
         buffer.add(item);
       }
       i++;

--- a/src/main/java/io/brackit/query/expr/Cast.java
+++ b/src/main/java/io/brackit/query/expr/Cast.java
@@ -286,16 +286,27 @@ public class Cast implements Expr {
       } else if (source.instanceOf(Type.NOT)) {
         return new QNm(atomic.stringValue());
       } else {
-        QNm qnm = new QNm(atomic.stringValue());
-        if (qnm.getPrefix() != null) {
+        // The 2-arg constructor SPLITS "prefix:local" (the 1-arg one stores the whole string as
+        // the local name and normalizes the prefix to "", so EVERY string cast — prefixed or not —
+        // previously fell into prefix resolution with '' and died with XQDY0074).
+        QNm qnm;
+        try {
+          qnm = new QNm(null, Whitespace.collapseTrimOnly(atomic.stringValue()));
+        } catch (IllegalStateException e) {
+          // Malformed lexical QName (":foo", "a:b:c", ...) -> proper cast error, not a raw RTE.
+          throw new QueryException(e, ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:QName", atomic);
+        }
+        if (!qnm.getPrefix().isEmpty()) {
           String uri = sctx.getNamespaces().resolve(qnm.getPrefix());
           if (uri == null) {
             throw new QueryException(ErrorCode.ERR_UNKNOWN_NS_PREFIX_IN_COMP_CONSTR,
                                      "Statically unkown namespace prefix: '%s'",
                                      qnm.getPrefix());
           }
-          return new QNm(uri, null, qnm.getLocalName());
+          // Keep the lexical prefix — it is part of the xs:QName value (used on re-serialization).
+          return new QNm(uri, qnm.getPrefix(), qnm.getLocalName());
         } else {
+          // No prefix: the QName is in the default element namespace (or none).
           String uri = sctx.getNamespaces().getDefaultElementNamespace();
           if (uri == null || uri.isEmpty()) {
             return qnm;
@@ -578,7 +589,9 @@ public class Cast implements Expr {
     }
     if (source.isNumeric()) {
       double d = ((Numeric) atomic).doubleValue();
-      return new Bool(d == Double.NaN || d == 0 ? false : true);
+      // NaN and 0 (and -0) are false; `d == Double.NaN` is ALWAYS false, so NaN used to cast to
+      // true (F&O: xs:boolean(NaN) is false).
+      return (Double.isNaN(d) || d == 0) ? Bool.FALSE : Bool.TRUE;
     }
     if (source == target) {
       return atomic;
@@ -639,16 +652,19 @@ public class Cast implements Expr {
   }
 
   public static IntNumeric asInteger(double d) {
-    if (d == Double.NaN || d == Double.POSITIVE_INFINITY || d == Double.NEGATIVE_INFINITY) {
+    if (Double.isNaN(d) || Double.isInfinite(d)) { // `d == Double.NaN` is ALWAYS false
       throw new QueryException(ErrorCode.ERR_INVALID_LEXICAL_VALUE);
     }
     if (d <= Integer.MAX_VALUE && d >= Integer.MIN_VALUE) {
       return new Int32((int) d);
     }
-    if (d <= Long.MAX_VALUE || d >= Long.MIN_VALUE) {
+    // && (not ||): a double outside long range must fall through to the arbitrary-precision
+    // BigInteger path. With ||, the condition was always true and xs:integer(1e30) silently
+    // SATURATED at Long.MAX_VALUE.
+    if (d <= Long.MAX_VALUE && d >= Long.MIN_VALUE) {
       return new Int64((long) d);
     }
-    return new Int(d);
+    return new Int(new java.math.BigDecimal(d)); // arbitrary precision; Int(BigDecimal) floors
   }
 
   @Override

--- a/src/main/java/io/brackit/query/expr/Castable.java
+++ b/src/main/java/io/brackit/query/expr/Castable.java
@@ -98,7 +98,10 @@ public class Castable implements Expr {
 
       if (code.eq(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE) || code.eq(ErrorCode.ERR_UNKNOWN_ATOMIC_SCHEMA_TYPE) || code
                                                                                                                      .eq(ErrorCode.ERR_INVALID_LEXICAL_VALUE)
-          || code.eq(ErrorCode.ERR_INVALID_VALUE_FOR_CAST) || code.eq(ErrorCode.ERR_ILLEGAL_CAST_TARGET_TYPE)) {
+          || code.eq(ErrorCode.ERR_INVALID_VALUE_FOR_CAST) || code.eq(ErrorCode.ERR_ILLEGAL_CAST_TARGET_TYPE)
+          // `"x:y" castable as xs:QName` with an unbound prefix must yield false, not raise:
+          // the QName cast reports the bad prefix with this code.
+          || code.eq(ErrorCode.ERR_UNKNOWN_NS_PREFIX_IN_COMP_CONSTR)) {
         return Bool.FALSE;
       }
 

--- a/src/main/java/io/brackit/query/expr/ConstructedNodeBuilder.java
+++ b/src/main/java/io/brackit/query/expr/ConstructedNodeBuilder.java
@@ -80,20 +80,23 @@ public abstract class ConstructedNodeBuilder {
   protected void buildContentSequence(QueryContext ctx, ContentSink sink, Sequence source) {
     if (source != null) {
       if (source instanceof Item) {
-        addContent(ctx, sink, (Item) source, null);
+        addContent(ctx, sink, (Item) source, null, false);
       } else {
         Node<?> prevSibling = null;
+        boolean prevAtomic = false;
         Item next;
         try (Iter s = source.iterate()) {
           while ((next = s.next()) != null) {
-            prevSibling = addContent(ctx, sink, next, prevSibling);
+            prevSibling = addContent(ctx, sink, next, prevSibling, prevAtomic);
+            prevAtomic = !(next instanceof Node<?>);
           }
         }
       }
     }
   }
 
-  private Node<?> addContent(QueryContext ctx, ContentSink sink, Item item, Node<?> prevSibling) {
+  private Node<?> addContent(QueryContext ctx, ContentSink sink, Item item, Node<?> prevSibling,
+      boolean prevWasAtomic) {
     if (item instanceof Node<?>) {
       Node<?> contentNode = (Node<?>) item;
 
@@ -107,16 +110,23 @@ public abstract class ConstructedNodeBuilder {
         try (Stream<? extends Node<?>> children = contentNode.getChildren()) {
           Node<?> child;
           while ((child = children.next()) != null) {
-            sink.addNode(ctx, prevSibling = child);
+            prevSibling = sink.addNode(ctx, child);
           }
         }
         return prevSibling;
       } else {
-        sink.addNode(ctx, contentNode);
-        return contentNode;
+        // Thread the SINK's node (the appended copy), not the source node: a later
+        // atomic-merge against prevSibling must mutate the CONSTRUCTED tree. Returning the
+        // source meant 'element e { $textNode, "b" }' silently rewrote the SOURCE document
+        // (or threw on a read-only store) while the constructed element never got "b".
+        return sink.addNode(ctx, contentNode);
       }
     } else {
-      if (prevSibling != null && prevSibling.getKind() == Kind.TEXT) {
+      // XQ 3.1 §3.9.1.3: ADJACENT ATOMICS are joined into one text node with a single space.
+      // An atomic following a text NODE item gets its OWN text node — adjacent text nodes are
+      // then merged by the sink's insert logic with plain concatenation (no space). The old
+      // code space-merged after ANY text node, inserting a separator the spec doesn't allow.
+      if (prevWasAtomic && prevSibling != null && prevSibling.getKind() == Kind.TEXT) {
         prevSibling.setValue(new Str(prevSibling.getValue().stringValue() + " " + ((Atomic) item).stringValue()));
         return prevSibling;
       } else {

--- a/src/main/java/io/brackit/query/expr/ExceptExpr.java
+++ b/src/main/java/io/brackit/query/expr/ExceptExpr.java
@@ -59,11 +59,16 @@ public class ExceptExpr implements Expr {
     Sequence sequenceA = firstExpr.evaluate(ctx, tuple);
     Sequence sequenceB = secondExpr.evaluate(ctx, tuple);
 
-    if (sequenceA == null || sequenceB == null) {
+    final Comparator<Tuple> comparator = (o1, o2) -> ((Node<?>) o1).cmp((Node<?>) o2);
+
+    // '() except B' is empty, but 'A except ()' is A in document order with duplicates removed
+    // (XQ 3.1 §3.4.2) — the old both-or-nothing shortcut silently dropped A.
+    if (sequenceA == null) {
       return null;
     }
-
-    final Comparator<Tuple> comparator = (o1, o2) -> ((Node<?>) o1).cmp((Node<?>) o2);
+    if (sequenceB == null) {
+      return new SortedNodeSequence(comparator, sequenceA, true);
+    }
 
     final Sequence sortedA = new SortedNodeSequence(comparator, sequenceA, true);
     final Sequence sortedB = new SortedNodeSequence(comparator, sequenceB, true);

--- a/src/main/java/io/brackit/query/expr/StepExpr.java
+++ b/src/main/java/io/brackit/query/expr/StepExpr.java
@@ -97,12 +97,24 @@ public class StepExpr extends PredicateExpr {
           return null;
         } else if (fs instanceof Numeric) {
           IntNumeric pos = ((Numeric) fs).asIntNumeric();
+          // Positional predicates on reverse axes count in AXIS order (XPath §3.3.3 —
+          // reverse document order), but the accessors deliver document order: without
+          // reversing first, 'ancestor::*[1]' returned the root instead of the parent and
+          // 'preceding-sibling::*[1]' the FIRST sibling instead of the nearest — while the
+          // equivalent '[position()=1]' (the dependent-filter path below) was correct.
+          if (pos != null && backwardAxis && !reversed) {
+            s = reverse(s);
+            reversed = true;
+          }
           s = (pos != null) ? s.get(pos) : null;
         } else {
           try (Iter it = fs.iterate()) {
             Item first = it.next();
             if ((first != null) && (it.next() == null) && (first instanceof Numeric)) {
               IntNumeric pos = ((Numeric) first).asIntNumeric();
+              if (pos != null && backwardAxis && !reversed) {
+                return reverse(s).get(pos); // singleton result: no re-reversal needed
+              }
               return (pos != null) ? s.get(pos) : null;
             }
           }

--- a/src/main/java/io/brackit/query/expr/TryCatchExpr.java
+++ b/src/main/java/io/brackit/query/expr/TryCatchExpr.java
@@ -167,10 +167,11 @@ public class TryCatchExpr implements Expr {
       info[pos++] = e.getCode();
     }
     if (bindDesc) {
-      info[pos++] = new Str(e.getMessage());
+      info[pos++] = new Str(e.getDescription());
     }
     if (bindValue) {
-      info[pos++] = null;
+      final Object value = e.getErrorValue();
+      info[pos++] = (value instanceof Sequence) ? (Sequence) value : null;
     }
     if (bindModule) {
       info[pos++] = null;

--- a/src/main/java/io/brackit/query/expr/UnionExpr.java
+++ b/src/main/java/io/brackit/query/expr/UnionExpr.java
@@ -59,11 +59,20 @@ public class UnionExpr implements Expr {
     Sequence sequenceA = firstExpr.evaluate(ctx, tuple);
     Sequence sequenceB = secondExpr.evaluate(ctx, tuple);
 
-    if ((sequenceA == null) || (sequenceB == null)) {
+    final Comparator<Tuple> comparator = (o1, o2) -> ((Node<?>) o1).cmp((Node<?>) o2);
+
+    // An empty (null) operand does NOT empty the union: '() | $nodes' is $nodes in document
+    // order with duplicates removed (XQ 3.1 §3.4.2). The old both-or-nothing shortcut silently
+    // dropped the non-empty side.
+    if (sequenceA == null && sequenceB == null) {
       return null;
     }
-
-    final Comparator<Tuple> comparator = (o1, o2) -> ((Node<?>) o1).cmp((Node<?>) o2);
+    if (sequenceA == null) {
+      return new SortedNodeSequence(comparator, sequenceB, true);
+    }
+    if (sequenceB == null) {
+      return new SortedNodeSequence(comparator, sequenceA, true);
+    }
 
     final Sequence sortedA = new SortedNodeSequence(comparator, sequenceA, true);
     final Sequence sortedB = new SortedNodeSequence(comparator, sequenceB, true);

--- a/src/main/java/io/brackit/query/function/bit/Every.java
+++ b/src/main/java/io/brackit/query/function/bit/Every.java
@@ -67,7 +67,9 @@ public class Every extends AbstractFunction {
   public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
     Sequence sequence = args[0];
     if (sequence == null) {
-      return Bool.FALSE;
+      // XQuery §3.13: `every $x in () satisfies …` is vacuously TRUE (universal quantification
+      // over the empty sequence). Only `some` over () is false.
+      return Bool.TRUE;
     } else if (sequence instanceof Item) {
       return sequence.booleanValue() ? Bool.TRUE : Bool.FALSE;
     } else {

--- a/src/main/java/io/brackit/query/function/fn/CodepointsToString.java
+++ b/src/main/java/io/brackit/query/function/fn/CodepointsToString.java
@@ -77,7 +77,9 @@ public class CodepointsToString extends AbstractFunction {
                                  codePoint);
       }
 
-      sb.append(Character.toChars(codePoint)[0]);
+      // appendCodePoint emits BOTH UTF-16 units of a non-BMP character; toChars(cp)[0] dropped the
+      // low surrogate, corrupting any codepoint above U+FFFF.
+      sb.appendCodePoint(codePoint);
       item = it.next();
     }
 

--- a/src/main/java/io/brackit/query/function/fn/DeepEqual.java
+++ b/src/main/java/io/brackit/query/function/fn/DeepEqual.java
@@ -178,32 +178,28 @@ public class DeepEqual extends AbstractFunction {
   }
 
   private static boolean childrenDeepEqual(Node<?> a, Node<?> b) {
-    Node<?> aChild = a.getFirstChild();
-    Node<?> bChild = b.getFirstChild();
+    // Comments/PIs are ignored by fn:deep-equal. Skip them on EACH side independently —
+    // the old loops only ran while BOTH cursors were non-null, so deep-equal(<x/>,
+    // <x><!--c--></x>) saw the un-skipped trailing comment and returned false.
+    Node<?> aChild = skipIgnorableSiblings(a.getFirstChild());
+    Node<?> bChild = skipIgnorableSiblings(b.getFirstChild());
 
     while (aChild != null && bChild != null) {
-      while (aChild.getKind() != Kind.ELEMENT && aChild.getKind() != Kind.TEXT) {
-        aChild = aChild.getNextSibling();
-        if (aChild == null) {
-          break;
-        }
+      if (!nodeDeepEquals(aChild, bChild)) {
+        return false;
       }
-      while (bChild.getKind() != Kind.ELEMENT && bChild.getKind() != Kind.TEXT) {
-        bChild = bChild.getNextSibling();
-        if (bChild == null) {
-          break;
-        }
-      }
-      if (aChild != null && bChild != null) {
-        if (!nodeDeepEquals(aChild, bChild)) {
-          return false;
-        }
-        aChild = aChild.getNextSibling();
-        bChild = bChild.getNextSibling();
-      }
+      aChild = skipIgnorableSiblings(aChild.getNextSibling());
+      bChild = skipIgnorableSiblings(bChild.getNextSibling());
     }
 
     return aChild == null && bChild == null;
+  }
+
+  private static Node<?> skipIgnorableSiblings(Node<?> n) {
+    while (n != null && n.getKind() != Kind.ELEMENT && n.getKind() != Kind.TEXT) {
+      n = n.getNextSibling();
+    }
+    return n;
   }
 
   private static Bool attributesDeepEqual(Node<?> a, Node<?> b) throws DocumentException {

--- a/src/main/java/io/brackit/query/function/fn/Error.java
+++ b/src/main/java/io/brackit/query/function/fn/Error.java
@@ -50,6 +50,9 @@ public class Error extends AbstractFunction {
     QNm qnm = (QNm) (args.length > 0 && args[0] != null ? args[0] : ErrorCode.ERR_UNIDENTIFIED_ERROR);
     Str description = (Str) (args.length > 1 && args[1] != null ? args[1] : Str.EMPTY);
     Sequence seq = args.length > 2 && args[2] != null ? args[2] : null;
-    throw new QueryException(qnm, description.stringValue(), seq);
+    // Verbatim description + retained error value: the old (QNm, String, Object...) overload ran
+    // the user description through String.format with the error value as a format arg — a '%' in
+    // the description threw UnknownFormatConversionException, and the error value was discarded.
+    throw new QueryException(qnm, description.stringValue(), seq, true);
   }
 }

--- a/src/main/java/io/brackit/query/function/fn/StringLength.java
+++ b/src/main/java/io/brackit/query/function/fn/StringLength.java
@@ -47,6 +47,12 @@ public class StringLength extends AbstractFunction {
 
   @Override
   public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
-    return (args[0] != null) ? new Int32(((Item) args[0]).atomize().stringValue().length()) : Int32.ZERO;
+    if (args[0] == null) {
+      return Int32.ZERO;
+    }
+    // fn:string-length counts CHARACTERS (codepoints), not UTF-16 units — a non-BMP character
+    // counts as one, not two.
+    final String s = ((Item) args[0]).atomize().stringValue();
+    return new Int32(s.codePointCount(0, s.length()));
   }
 }

--- a/src/main/java/io/brackit/query/function/fn/StringToCodepoints.java
+++ b/src/main/java/io/brackit/query/function/fn/StringToCodepoints.java
@@ -78,7 +78,11 @@ public class StringToCodepoints extends AbstractFunction {
               return null;
             }
 
-            return new Int32(s.codePointAt(index++));
+            // Advance by the full codepoint width (2 UTF-16 units for a non-BMP character),
+            // otherwise the low surrogate is re-read as a bogus second codepoint.
+            final int codePoint = s.codePointAt(index);
+            index += Character.charCount(codePoint);
+            return new Int32(codePoint);
           }
 
           @Override

--- a/src/main/java/io/brackit/query/function/fn/StringTranslate.java
+++ b/src/main/java/io/brackit/query/function/fn/StringTranslate.java
@@ -59,26 +59,19 @@ public class StringTranslate extends AbstractFunction {
     String trans = ((Str) args[2]).stringValue();
     StringBuilder sb = new StringBuilder(str.length());
 
-    if (map.isEmpty()) {
-      return Str.EMPTY;
-    }
-
-    int copy = 0;
-
     for (int i = 0; i < str.length(); i++) {
       char c = str.charAt(i);
       int index = map.indexOf(c);
-      if (index != -1 && index < trans.length()) {
-        if (copy < i) {
-          sb.append(str.substring(copy, i));
-        }
+      if (index == -1) {
+        // Not in the map: keep unchanged. (An empty map leaves the whole string unchanged — the
+        // old code wrongly returned the empty string.)
+        sb.append(c);
+      } else if (index < trans.length()) {
+        // Corresponding replacement character.
         sb.append(trans.charAt(index));
-        copy = i + 1;
       }
-    }
-
-    if (copy < str.length()) {
-      sb.append(str.substring(copy));
+      // else: present in the map but with no counterpart in trans -> DELETE (append nothing). The
+      // old code passed such characters through unchanged.
     }
 
     return new Str(sb.toString());

--- a/src/main/java/io/brackit/query/function/fn/Subsequence.java
+++ b/src/main/java/io/brackit/query/function/fn/Subsequence.java
@@ -63,7 +63,13 @@ public class Subsequence extends AbstractFunction {
       return null;
     }
 
-    IntNumeric tmp = Cast.asInteger(((Dbl) args[1]).round().doubleValue());
+    // Per spec the result is the items whose position p satisfies
+    //   round($start) <= p < round($start) + round($length).
+    // The end of the window uses the ORIGINAL (possibly <= 0) start, while iteration is clamped to
+    // start at position 1. Using the clamped start for the end over-included items for start <= 0
+    // (e.g. subsequence((1..8), -2, 5) wrongly returned 1..5 instead of 1 2).
+    final IntNumeric originalStart = Cast.asInteger(((Dbl) args[1]).round().doubleValue());
+    IntNumeric tmp = originalStart;
     if (tmp.cmp(Int32.ZERO) <= 0) {
       tmp = Int32.ONE;
     }
@@ -72,7 +78,7 @@ public class Subsequence extends AbstractFunction {
     tmp = null;
     if (args.length == 3) {
       IntNumeric length = Cast.asInteger(((Dbl) args[2]).round().doubleValue());
-      tmp = (IntNumeric) st.add(length);
+      tmp = (IntNumeric) originalStart.add(length);
     }
     final IntNumeric e = tmp;
 

--- a/src/main/java/io/brackit/query/function/fn/Substring.java
+++ b/src/main/java/io/brackit/query/function/fn/Substring.java
@@ -52,8 +52,11 @@ public class Substring extends AbstractFunction {
     }
 
     String string = ((Str) args[0]).stringValue();
+    // XPath substring positions count CHARACTERS (codepoints), not UTF-16 units — measure and index
+    // by codepoint so non-BMP characters (surrogate pairs) are not split or mis-positioned.
+    final int cpLen = string.codePointCount(0, string.length());
     double start = ((Numeric) args[1]).round().doubleValue();
-    double end = (args.length == 3) ? ((Numeric) args[2]).round().doubleValue() : string.length();
+    double end = (args.length == 3) ? ((Numeric) args[2]).round().doubleValue() : cpLen;
 
     if ((Double.isNaN(start)) || (Double.isNaN(end)) || ((start == Double.NEGATIVE_INFINITY) && (end
         == Double.POSITIVE_INFINITY))) {
@@ -61,12 +64,15 @@ public class Substring extends AbstractFunction {
     }
 
     int startPos = (int) Math.max(start, 1) - 1;
-    int endPos = (int) Math.min(start + end - 1, string.length());
+    int endPos = (int) Math.min(start + end - 1, cpLen);
 
     if ((endPos <= startPos) || (endPos - startPos <= 0)) {
       return Str.EMPTY;
     }
 
-    return new Str(string.substring(startPos, endPos));
+    // Map codepoint indices to UTF-16 offsets for the actual slice.
+    final int startOffset = string.offsetByCodePoints(0, startPos);
+    final int endOffset = string.offsetByCodePoints(0, endPos);
+    return new Str(string.substring(startOffset, endOffset));
   }
 }

--- a/src/main/java/io/brackit/query/function/json/JSONParser.java
+++ b/src/main/java/io/brackit/query/function/json/JSONParser.java
@@ -28,6 +28,7 @@
 package io.brackit.query.function.json;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import io.brackit.query.atomic.*;
@@ -128,20 +129,32 @@ public final class JSONParser extends Tokenizer {
     if (attemptSkipS("}")) {
       return new ArrayObject(new QNm[0], new Item[0]);
     }
-    int len = 0;
     final var fields = new ArrayList<QNm>();
     final var values = new ArrayList<Item>();
+    final var seen = new HashSet<String>();
     do {
       final Str name = string();
       consumeSkipS(":");
       Item value = value(true);
-      fields.add(new QNm(null, null, name.stringValue()));
-      values.add(value);
-      len++;
+      final String keyName = name.stringValue();
+      if (seen.add(keyName)) {
+        fields.add(new QNm(null, null, keyName));
+        values.add(value);
+      } else {
+        // Duplicate object key: last value wins (the common path stays O(1) via the HashSet; the
+        // list scan runs only on the rare collision). Keeping both produced invalid JSON and an
+        // object whose serialization disagreed with `.key` lookup.
+        for (int i = 0; i < fields.size(); i++) {
+          if (fields.get(i).stringValue().equals(keyName)) {
+            values.set(i, value);
+            break;
+          }
+        }
+      }
     } while (attemptSkipS(","));
     consumeSkipS("}");
 
-    return new ArrayObject(fields.toArray(new QNm[len]), values.toArray(new Item[len]));
+    return new ArrayObject(fields.toArray(new QNm[0]), values.toArray(new Item[0]));
   }
 
   private Numeric number() throws QueryException, TokenizerException {

--- a/src/main/java/io/brackit/query/jsonitem/array/DArray.java
+++ b/src/main/java/io/brackit/query/jsonitem/array/DArray.java
@@ -119,7 +119,9 @@ public final class DArray extends AbstractArray {
   public Sequence at(int i) {
     try {
       return vals.get(i);
-    } catch (ArrayIndexOutOfBoundsException e) {
+    } catch (IndexOutOfBoundsException e) {
+      // GapList.get throws the plain IndexOutOfBoundsException superclass, so catching only
+      // ArrayIndexOutOfBoundsException previously let a raw Java exception escape as an HTTP 500.
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", i);
     }
   }

--- a/src/main/java/io/brackit/query/jsonitem/array/DRArray.java
+++ b/src/main/java/io/brackit/query/jsonitem/array/DRArray.java
@@ -45,7 +45,7 @@ import static java.util.Objects.checkFromToIndex;
 public final class DRArray extends AbstractArray {
   private final List<Sequence> vals;
   private final int start;
-  private final int end;
+  private int end; // mutable: insert/append/remove on the slice grow/shrink the view window
 
   public DRArray(List<Sequence> vals, int start, int end) {
     if (start < 0 || start > end || start >= vals.size()) {
@@ -67,7 +67,10 @@ public final class DRArray extends AbstractArray {
 
   @Override
   public Array replaceAt(int index, Sequence value) {
-    if (start + index < 0 || start + index > vals.size()) {
+    // Bounds are the SLICE window [start, end), not the whole backing list: the old
+    // `> vals.size()` (and missing `index < 0`) let replaceAt/insert/remove escape the view
+    // and mutate elements outside the slice.
+    if (index < 0 || start + index >= end) {
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
     }
 
@@ -78,29 +81,33 @@ public final class DRArray extends AbstractArray {
 
   @Override
   public Array insert(int index, Sequence value) {
-    if (start + index < 0 || start + index > vals.size() - 1) {
+    if (index < 0 || start + index > end) {
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
     }
 
     vals.add(start + index, value);
+    end++; // the view grew by one
 
     return this;
   }
 
   @Override
   public Array append(Sequence value) {
-    vals.add(value);
+    // Append at the slice END, not the backing-list end (which was invisible to the view).
+    vals.add(end, value);
+    end++;
 
     return this;
   }
 
   @Override
   public Array remove(int index) {
-    if (start + index < 0 || start + index > vals.size() - 1) {
+    if (index < 0 || start + index >= end) {
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
     }
 
     vals.remove(start + index);
+    end--;
 
     return this;
   }
@@ -129,6 +136,9 @@ public final class DRArray extends AbstractArray {
   @Override
   public Sequence at(IntNumeric index) throws QueryException {
     try {
+      if (index.intValue() < 0) {
+        throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
+      }
       int ii = start + index.intValue();
       if (ii >= end) {
         throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
@@ -142,6 +152,9 @@ public final class DRArray extends AbstractArray {
   @Override
   public Sequence at(int index) throws QueryException {
     try {
+      if (index < 0) {
+        throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
+      }
       int ii = start + index;
       if (ii >= end) {
         throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);

--- a/src/main/java/io/brackit/query/jsonitem/object/ArrayObject.java
+++ b/src/main/java/io/brackit/query/jsonitem/object/ArrayObject.java
@@ -135,13 +135,18 @@ public final class ArrayObject extends AbstractObject {
 
   @Override
   public Object remove(QNm field) {
-    int index = 0;
+    int index = -1;
     for (int i = 0, size = fields.size(); i < size; i++) {
       final QNm currentField = fields.get(i);
       if (field.equals(currentField)) {
         index = i;
         break;
       }
+    }
+    // No-op when the field is absent — index was initialized to 0, so a missing field deleted
+    // the FIRST entry (and threw IndexOutOfBounds on an empty object).
+    if (index < 0) {
+      return this;
     }
     fields.remove(index);
     vals.remove(index);

--- a/src/main/java/io/brackit/query/node/d2linked/D2Node.java
+++ b/src/main/java/io/brackit/query/node/d2linked/D2Node.java
@@ -250,6 +250,18 @@ public abstract class D2Node extends AbstractNode<D2Node> {
         }
       }
     }
+    if (n.length > p.length) {
+      // p is a strict PREFIX of n (e.g. p=[3], n=[3,3]) — routinely reachable by repeated
+      // insert-before at the same boundary ([3],[5] -> insert [4,3] -> insert [3,3] -> the
+      // third insert lands here; this used to throw). Since a prefix sorts before any of its
+      // extensions (compare() returns length1-length2 on common prefix), a division strictly
+      // between p and n is p extended by a division BEFORE n's remaining tail.
+      int[] tail = Arrays.copyOfRange(n, p.length, n.length);
+      int[] before = siblingBefore(tail);
+      int[] r = Arrays.copyOf(p, p.length + before.length);
+      System.arraycopy(before, 0, r, p.length, before.length);
+      return r;
+    }
     throw new IllegalArgumentException(String.format("Illegal sibling divisions: %s and %s",
                                                      Arrays.toString(p),
                                                      Arrays.toString(n)));

--- a/src/main/java/io/brackit/query/operator/ForBind.java
+++ b/src/main/java/io/brackit/query/operator/ForBind.java
@@ -104,7 +104,10 @@ public class ForBind extends Check implements Operator {
           it.close();
           it = null;
           if (allowingEmpty) {
-            Tuple tmp = emit(i, null);
+            // emit the INPUT tuple with an empty binding — 'i' is provably null here (the
+            // i != null branch returned above), so emit(i, null) NPE'd on every lazy-empty
+            // bind sequence under 'allowing empty'.
+            Tuple tmp = emit(t, null);
             t = null;
             return tmp;
           } else if (check) {

--- a/src/main/java/io/brackit/query/sequence/TypedSequence.java
+++ b/src/main/java/io/brackit/query/sequence/TypedSequence.java
@@ -167,6 +167,16 @@ public class TypedSequence extends LazySequence {
       // short-circuit wrapping of single item parameter
       ItemType itemType = sType.getItemType();
 
+      // A single item can NEVER satisfy the Zero cardinality (empty-sequence()) — the old fast
+      // path checked only itemType.matches, so `1 instance of empty-sequence()` was true.
+      // (Use == Zero, NOT !moreThanZero(): moreThanZero() means "at least one REQUIRED", so it
+      // is false for the ? and * cardinalities, which a single item DOES satisfy.)
+      if (sType.getCardinality() == io.brackit.query.jdm.type.Cardinality.Zero) {
+        throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
+                                 "Single item where empty sequence expected: %s",
+                                 s);
+      }
+
       if (!itemType.matches((Item) s)) {
         throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
                                  "Item of invalid type %s in typed sequence (expected %s): %s",
@@ -190,6 +200,13 @@ public class TypedSequence extends LazySequence {
     } else {
       // short-circuit wrapping of single item parameter
       ItemType itemType = sType.getItemType();
+
+      // A single item can NEVER satisfy the Zero cardinality — see toTypedSequence.
+      if (sType.getCardinality() == io.brackit.query.jdm.type.Cardinality.Zero) {
+        throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
+                                 "Single item where empty sequence expected: %s",
+                                 item);
+      }
 
       if (!itemType.matches(item)) {
         throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,

--- a/src/main/java/io/brackit/query/update/UpdateList.java
+++ b/src/main/java/io/brackit/query/update/UpdateList.java
@@ -76,7 +76,11 @@ public final class UpdateList {
     // application which is determined by their type.
     // The resulting list is then checked if some ops
     // are performed twice or more on the same target node
-    final var orderByTypeCmp = Comparator.comparing(UpdateOp::getType);
+    // Sort by the XQUF phase PRIORITY, not enum declaration order (OpType declares
+    // REPLACE_NODE first, so Comparator.comparing(getType) applied replaceNode before
+    // the inserts the spec runs first). List.sort is stable: source order survives
+    // within a phase.
+    final var orderByTypeCmp = Comparator.comparingInt((UpdateOp op) -> op.getType().getPriority());
     ops.sort(orderByTypeCmp);
 
     for (int i = 0, size = ops.size(); i < size; i++) {

--- a/src/main/java/io/brackit/query/update/op/OpType.java
+++ b/src/main/java/io/brackit/query/update/op/OpType.java
@@ -31,7 +31,14 @@ package io.brackit.query.update.op;
  * @author Sebastian Baechle
  */
 public enum OpType {
-  REPLACE_NODE(-1),
+  // Priorities encode the XQUF 1.0 §3.2.2 apply order:
+  // phase 1: insertInto/insertAttributes/replaceValue/rename (0-3)
+  // phase 2: insertBefore/insertAfter/insertIntoAsFirst/insertIntoAsLast (4-7)
+  // phase 3: replaceNode (8)  — was -1, which (combined with sorting by enum order) applied
+  //          replaceNode FIRST: a sibling insert relative to a node that a replace detached
+  //          then targeted a detached node (lost content).
+  // phase 4: replaceElementContent (9), phase 5: delete (10)
+  REPLACE_NODE(8),
 
   INSERT_INTO(0),
 

--- a/src/main/java/io/brackit/query/util/Cmp.java
+++ b/src/main/java/io/brackit/query/util/Cmp.java
@@ -152,7 +152,10 @@ public enum Cmp {
 
   public Bool gCmpAsBool(QueryContext ctx, Sequence left, Sequence right) throws QueryException {
     if (left == null || right == null) {
-      return null;
+      // XQ 3.1 §3.7.2: a general comparison is the EXISTENTIAL quantification over the two
+      // sequences — with an empty operand no pair exists, so the result is false() (an
+      // xs:boolean), not the empty sequence. Returning null made count(() = 1) yield 0.
+      return Bool.FALSE;
     }
     boolean res = gCmp(ctx, left, right);
     return res ? Bool.TRUE : Bool.FALSE;

--- a/src/main/java/io/brackit/query/util/Regex.java
+++ b/src/main/java/io/brackit/query/util/Regex.java
@@ -97,8 +97,16 @@ public class Regex {
       }
     }
 
-    if (mode != Mode.MATCH && Pattern.matches(pattern, "")) {
-      throw (new QueryException(ErrorCode.ERR_REGULAR_EXPRESSION_EMPTY_STRING, "Pattern matches empty string."));
+    if (mode != Mode.MATCH) {
+      // Pattern.matches runs on the RAW pattern OUTSIDE the compile try/catch below — an invalid
+      // pattern (e.g. fn:tokenize('a','[')) threw a raw PatternSyntaxException instead of FORX0002.
+      try {
+        if (Pattern.matches(pattern, "")) {
+          throw (new QueryException(ErrorCode.ERR_REGULAR_EXPRESSION_EMPTY_STRING, "Pattern matches empty string."));
+        }
+      } catch (PatternSyntaxException e) {
+        throw new QueryException(e, ErrorCode.ERR_INVALID_REGULAR_EXPRESSION);
+      }
     }
 
     if (mode == Mode.TOKENIZE && input.isEmpty()) {
@@ -129,8 +137,17 @@ public class Regex {
         }
 
         StringBuffer sb = new StringBuffer();
-        while (matcher.find()) {
-          matcher.appendReplacement(sb, replace);
+        try {
+          while (matcher.find()) {
+            matcher.appendReplacement(sb, replace);
+          }
+        } catch (IndexOutOfBoundsException | IllegalArgumentException e) {
+          // A trailing lone '$' or '\' slips past the validation regex above (its alternatives
+          // require a following char); appendReplacement then throws a raw Java exception — map
+          // it to FORX0004 instead.
+          throw new QueryException(e,
+                                   ErrorCode.ERR_INVALID_REPLACEMENT_STRING,
+                                   "Invalid replacement string: " + replace);
         }
         matcher.appendTail(sb);
 
@@ -179,6 +196,9 @@ public class Regex {
             throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION,
                                      "Back references in character class expressions" + " are disallowed.");
           }
+          if (removeWhitespace) {
+            sb.append(c);
+          }
           backRef = backRef * 10 + Integer.parseInt(Character.toString(c));
           continue;
         }
@@ -196,13 +216,21 @@ public class Regex {
       }
 
       if (c == '\\' && !escaped) {
-        // Not preceded by backslash
+        // Not preceded by backslash. In whitespace-removal (x-flag) mode the rebuilt pattern is
+        // assembled char-by-char, so structural characters (\ ( ) [ ] and back-reference digits)
+        // must be re-appended here — dropping them silently changed the regex semantics.
+        if (removeWhitespace) {
+          sb.append(c);
+        }
         escaped = true;
         groupStart = false;
         continue;
       }
 
       if (c == '(' && !escaped) {
+        if (removeWhitespace) {
+          sb.append(c);
+        }
         groupStart = true;
         groupDepth++;
         escaped = false;
@@ -217,11 +245,20 @@ public class Regex {
           throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION, "Invalid sequence of brackets.");
         }
         completeGroups++;
+        if (removeWhitespace) {
+          sb.append(c);
+        }
       } else if (c == '[' && !escaped) {
         charClassDepth++;
+        if (removeWhitespace) {
+          sb.append(c);
+        }
       } else if (c == ']' && !escaped) {
         if (--charClassDepth < 0) {
           throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION, "Invalid sequence of brackets.");
+        }
+        if (removeWhitespace) {
+          sb.append(c);
         }
       } else if (removeWhitespace) {
         // Remove whitespace outside of character classes
@@ -258,8 +295,10 @@ public class Regex {
     }
 
     if (mode == Mode.MATCH) {
-      // Adapt for XQuery substring matching by extending pattern
-      if (sb.charAt(0) != '^' || ((flagMask & Pattern.MULTILINE) == Pattern.MULTILINE)) {
+      // Adapt for XQuery substring matching by extending pattern. An EMPTY pattern is legal (it
+      // matches every string) — guard the charAt() calls so it does not throw
+      // StringIndexOutOfBoundsException.
+      if (sb.length() == 0 || sb.charAt(0) != '^' || ((flagMask & Pattern.MULTILINE) == Pattern.MULTILINE)) {
         if ((flagMask & Pattern.DOTALL) == Pattern.DOTALL) {
           sb.insert(0, ".*");
         } else {
@@ -267,7 +306,8 @@ public class Regex {
         }
       }
 
-      if (sb.charAt(sb.length() - 1) != '$' || ((flagMask & Pattern.MULTILINE) == Pattern.MULTILINE)) {
+      if (sb.length() == 0 || sb.charAt(sb.length() - 1) != '$' || ((flagMask & Pattern.MULTILINE)
+          == Pattern.MULTILINE)) {
         if ((flagMask & Pattern.DOTALL) == Pattern.DOTALL) {
           sb.append(".*");
         } else {

--- a/src/main/java/io/brackit/query/util/aggregator/Grouping.java
+++ b/src/main/java/io/brackit/query/util/aggregator/Grouping.java
@@ -41,6 +41,10 @@ import io.brackit.query.jdm.Type;
  * @author Sebastian Baechle
  */
 public class Grouping {
+
+  /** Canonical +0.0 instances for grouping-key normalization (-0.0 groups with +0.0). */
+  private static final io.brackit.query.atomic.Dbl DBL_POSITIVE_ZERO = new io.brackit.query.atomic.Dbl(0.0d);
+  private static final io.brackit.query.atomic.Flt FLT_POSITIVE_ZERO = new io.brackit.query.atomic.Flt(0.0f);
   final int[] groupSpecs;
   final int[] addAggsSpecs;
   final Aggregate defaultAgg;
@@ -123,6 +127,16 @@ public class Grouping {
           gk[i] = item.atomize();
           if (gk[i].type().instanceOf(Type.UNA)) {
             gk[i] = Cast.cast(null, gk[i], Type.STR);
+          }
+          // Grouping equality treats -0.0 and +0.0 as ONE key (fn:deep-equal semantics), but
+          // both atomicCmp (Double.compare) and the key hash (doubleToLongBits) distinguish
+          // them — canonicalize so the pair lands in a single group. Dispatch on the
+          // DblNumeric/FltNumeric INTERFACES: document-sourced doubles are wrapper atomics,
+          // not the concrete Dbl/Flt classes.
+          if (gk[i] instanceof io.brackit.query.atomic.DblNumeric n && n.doubleValue() == 0.0d) {
+            gk[i] = DBL_POSITIVE_ZERO; // canonical instance — no per-key allocation
+          } else if (gk[i] instanceof io.brackit.query.atomic.FltNumeric n && n.doubleValue() == 0.0d) {
+            gk[i] = FLT_POSITIVE_ZERO;
           }
         }
       }

--- a/src/main/java/io/brackit/query/util/aggregator/MinMaxAggregator.java
+++ b/src/main/java/io/brackit/query/util/aggregator/MinMaxAggregator.java
@@ -375,11 +375,28 @@ public class MinMaxAggregator implements Aggregator {
                                type);
     }
 
+    // F&O §14.4: if the converted sequence contains NaN, fn:min/fn:max return NaN. The cmp-based
+    // update below uses the total order (NaN above everything), which never SELECTS NaN — so
+    // min((1, NaN)) silently returned 1. NaN is sticky once seen.
+    if (isNaN(s)) {
+      return s;
+    }
+    if (isNaN(minmax)) {
+      return minmax;
+    }
+
     int res = minmax.cmp(s);
 
     if ((min) ? (res > 0) : (res < 0)) {
       minmax = s;
     }
     return minmax;
+  }
+
+  private static boolean isNaN(Atomic a) {
+    // Only doubles/floats can be NaN — interface-first dispatch keeps Int/Dec off the
+    // doubleValue() conversion in the per-item aggregation loop.
+    return (a instanceof io.brackit.query.atomic.DblNumeric || a instanceof io.brackit.query.atomic.FltNumeric)
+        && Double.isNaN(((Numeric) a).doubleValue());
   }
 }

--- a/src/main/java/io/brackit/query/util/aggregator/SumAvgAggregator.java
+++ b/src/main/java/io/brackit/query/util/aggregator/SumAvgAggregator.java
@@ -234,12 +234,9 @@ public class SumAvgAggregator implements Aggregator {
 
       // Check if we're still getting Int64 values
       if (!(a instanceof Int64 i64)) {
-        // Type changed - flush buffer and fall back to object path
-        if (bufferLen > 0) {
-          currentSum += VectorOps.sumLong(longBuffer, 0, bufferLen);
-        }
+        // Type changed - flush buffer (exactly) and fall back to object path
+        Numeric sum = addRangeExactOrEscalate(longBuffer, bufferLen, currentSum);
         // Continue with mixed-type processing
-        Numeric sum = new Int64(currentSum);
         sum = numericSum(sum, item);
         count++;
         while ((item = in.next()) != null) {
@@ -253,17 +250,56 @@ public class SumAvgAggregator implements Aggregator {
       count++;
 
       if (bufferLen == BATCH_SIZE) {
-        currentSum += VectorOps.sumLong(longBuffer, 0, bufferLen);
+        try {
+          currentSum = sumRangeExact(longBuffer, bufferLen, currentSum);
+        } catch (ArithmeticException overflow) {
+          // xs:integer is arbitrary precision (F&O): the previous raw-long accumulation
+          // silently WRAPPED here and returned a negative/garbage sum. Escalate to the
+          // generic Numeric path (BigDecimal-backed) for the rest of the sequence.
+          Numeric sum = addRangeViaNumeric(longBuffer, bufferLen, currentSum);
+          while ((item = in.next()) != null) {
+            sum = numericSum(sum, item);
+            count++;
+          }
+          return sum;
+        }
         bufferLen = 0;
       }
     }
 
-    // Flush remaining
+    // Flush remaining (exactly — escalating to arbitrary precision on overflow)
     if (bufferLen > 0) {
-      currentSum += VectorOps.sumLong(longBuffer, 0, bufferLen);
+      return addRangeExactOrEscalate(longBuffer, bufferLen, currentSum);
     }
 
     return new Int64(currentSum);
+  }
+
+  /** Exact long-range sum; throws {@link ArithmeticException} on overflow. */
+  private static long sumRangeExact(long[] buf, int len, long acc) {
+    long s = acc;
+    for (int i = 0; i < len; i++) {
+      s = Math.addExact(s, buf[i]);
+    }
+    return s;
+  }
+
+  /** Arbitrary-precision fallback — xs:integer sums must not wrap. */
+  private static Numeric addRangeViaNumeric(long[] buf, int len, long acc) throws QueryException {
+    Numeric sum = new Int64(acc);
+    for (int i = 0; i < len; i++) {
+      sum = (Numeric) sum.add(new Int64(buf[i]));
+    }
+    return sum;
+  }
+
+  /** Sum the buffered range exactly, escalating past long range when needed. */
+  private static Numeric addRangeExactOrEscalate(long[] buf, int len, long acc) throws QueryException {
+    try {
+      return new Int64(sumRangeExact(buf, len, acc));
+    } catch (ArithmeticException overflow) {
+      return addRangeViaNumeric(buf, len, acc);
+    }
   }
 
   /**

--- a/src/main/java/io/brackit/query/util/simd/VectorOps.java
+++ b/src/main/java/io/brackit/query/util/simd/VectorOps.java
@@ -860,15 +860,18 @@ public final class VectorOps {
         DoubleVector v2 = DoubleVector.fromArray(DOUBLE_SPECIES, values, offset + i + vectorLength * 2);
         DoubleVector v3 = DoubleVector.fromArray(DOUBLE_SPECIES, values, offset + i + vectorLength * 3);
 
-        acc0 = acc0.blend(v0, v0.lt(acc0));
-        acc1 = acc1.blend(v1, v1.lt(acc1));
-        acc2 = acc2.blend(v2, v2.lt(acc2));
-        acc3 = acc3.blend(v3, v3.lt(acc3));
+        // lanewise(MIN) has Math.min semantics (NaN-propagating) — the previous compare+blend
+        // dropped NaN in every lane (NaN compares false), so min((..., NaN)) lost the NaN that
+        // F&O requires fn:min to return; results also differed between SIMD and scalar builds.
+        acc0 = acc0.lanewise(VectorOperators.MIN, v0);
+        acc1 = acc1.lanewise(VectorOperators.MIN, v1);
+        acc2 = acc2.lanewise(VectorOperators.MIN, v2);
+        acc3 = acc3.lanewise(VectorOperators.MIN, v3);
       }
 
-      DoubleVector combined = acc0.blend(acc1, acc1.lt(acc0));
-      combined = combined.blend(acc2, acc2.lt(combined));
-      combined = combined.blend(acc3, acc3.lt(combined));
+      DoubleVector combined = acc0.lanewise(VectorOperators.MIN, acc1);
+      combined = combined.lanewise(VectorOperators.MIN, acc2);
+      combined = combined.lanewise(VectorOperators.MIN, acc3);
       result = combined.reduceLanes(VectorOperators.MIN);
     } else {
       result = values[offset];
@@ -878,14 +881,12 @@ public final class VectorOps {
     for (; i < limit; i += vectorLength) {
       DoubleVector v = DoubleVector.fromArray(DOUBLE_SPECIES, values, offset + i);
       DoubleVector accVec = DoubleVector.broadcast(DOUBLE_SPECIES, result);
-      accVec = accVec.blend(v, v.lt(accVec));
+      accVec = accVec.lanewise(VectorOperators.MIN, v);
       result = accVec.reduceLanes(VectorOperators.MIN);
     }
 
     for (; i < length; i++) {
-      if (values[offset + i] < result) {
-        result = values[offset + i];
-      }
+      result = Math.min(result, values[offset + i]); // NaN-propagating, unlike '<'
     }
 
     return result;
@@ -926,15 +927,16 @@ public final class VectorOps {
         DoubleVector v2 = DoubleVector.fromArray(DOUBLE_SPECIES, values, offset + i + vectorLength * 2);
         DoubleVector v3 = DoubleVector.fromArray(DOUBLE_SPECIES, values, offset + i + vectorLength * 3);
 
-        acc0 = acc0.blend(v0, v0.compare(VectorOperators.GT, acc0));
-        acc1 = acc1.blend(v1, v1.compare(VectorOperators.GT, acc1));
-        acc2 = acc2.blend(v2, v2.compare(VectorOperators.GT, acc2));
-        acc3 = acc3.blend(v3, v3.compare(VectorOperators.GT, acc3));
+        // lanewise(MAX) has Math.max semantics (NaN-propagating) — see minDouble.
+        acc0 = acc0.lanewise(VectorOperators.MAX, v0);
+        acc1 = acc1.lanewise(VectorOperators.MAX, v1);
+        acc2 = acc2.lanewise(VectorOperators.MAX, v2);
+        acc3 = acc3.lanewise(VectorOperators.MAX, v3);
       }
 
-      DoubleVector combined = acc0.blend(acc1, acc1.compare(VectorOperators.GT, acc0));
-      combined = combined.blend(acc2, acc2.compare(VectorOperators.GT, combined));
-      combined = combined.blend(acc3, acc3.compare(VectorOperators.GT, combined));
+      DoubleVector combined = acc0.lanewise(VectorOperators.MAX, acc1);
+      combined = combined.lanewise(VectorOperators.MAX, acc2);
+      combined = combined.lanewise(VectorOperators.MAX, acc3);
       result = combined.reduceLanes(VectorOperators.MAX);
     } else {
       result = values[offset];
@@ -944,14 +946,12 @@ public final class VectorOps {
     for (; i < limit; i += vectorLength) {
       DoubleVector v = DoubleVector.fromArray(DOUBLE_SPECIES, values, offset + i);
       DoubleVector accVec = DoubleVector.broadcast(DOUBLE_SPECIES, result);
-      accVec = accVec.blend(v, v.compare(VectorOperators.GT, accVec));
+      accVec = accVec.lanewise(VectorOperators.MAX, v);
       result = accVec.reduceLanes(VectorOperators.MAX);
     }
 
     for (; i < length; i++) {
-      if (values[offset + i] > result) {
-        result = values[offset + i];
-      }
+      result = Math.max(result, values[offset + i]); // NaN-propagating, unlike '>'
     }
 
     return result;

--- a/src/main/java/io/brackit/query/util/sort/Ordering.java
+++ b/src/main/java/io/brackit/query/util/sort/Ordering.java
@@ -123,13 +123,31 @@ public class Ordering implements Comparator<Tuple> {
         Atomic lAtomic = (Atomic) o1.get(pos);
         Atomic rAtomic = (Atomic) o2.get(pos);
 
+        if (lAtomic == null && rAtomic == null) {
+          // Both keys empty: equal on this orderspec — consult the next one. Falling through
+          // (the old behavior) returned ±1 for BOTH compare(a,b) and compare(b,a): secondary
+          // keys were never consulted and TimSort could throw "Comparison method violates
+          // its general contract!".
+          continue;
+        }
         if (lAtomic == null) {
-          if (rAtomic != null) {
-            return (modifier[i].EMPTY_LEAST) ? -1 : 1;
-          }
+          return (modifier[i].EMPTY_LEAST) ? -1 : 1;
         }
         if (rAtomic == null) {
           return (modifier[i].EMPTY_LEAST) ? 1 : -1;
+        }
+
+        // XQ 3.1 §3.13.4: NaN sits NEXT TO the empty sequence — 'empty least' orders
+        // () < NaN < values, 'empty greatest' orders values < NaN < (). Java's total order
+        // (NaN greater than everything) silently produced the wrong order under 'empty least'
+        // (the compiler default).
+        final boolean lNaN = isNaN(lAtomic);
+        final boolean rNaN = isNaN(rAtomic);
+        if (lNaN || rNaN) {
+          if (lNaN && rNaN) {
+            continue; // NaN equals NaN for ordering purposes — next orderspec
+          }
+          return (modifier[i].EMPTY_LEAST) ? (lNaN ? -1 : 1) : (lNaN ? 1 : -1);
         }
 
         int res = lAtomic.cmp(rAtomic);
@@ -145,6 +163,13 @@ public class Ordering implements Comparator<Tuple> {
         throw new RuntimeException(e);
       }
     }
+  }
+
+  private static boolean isNaN(Atomic a) {
+    // Only doubles/floats can be NaN — dispatch on those interfaces first so the hot
+    // comparator path never pays Int/Dec doubleValue() conversions.
+    return (a instanceof io.brackit.query.atomic.DblNumeric || a instanceof io.brackit.query.atomic.FltNumeric)
+        && Double.isNaN(((io.brackit.query.atomic.Numeric) a).doubleValue());
   }
 
   public void clear() {

--- a/src/main/java/io/brackit/query/util/sort/TupleSort.java
+++ b/src/main/java/io/brackit/query/util/sort/TupleSort.java
@@ -118,7 +118,6 @@ public class TupleSort {
     sortBuffer();
 
     if ((lastInRun != null) && (comparator.compare(lastInRun, buffer[0]) <= 0)) {
-      System.out.println("append to run");
       appendToRun();
       return;
     }

--- a/src/test/java/io/brackit/query/PassFourCorrectnessTest.java
+++ b/src/test/java/io/brackit/query/PassFourCorrectnessTest.java
@@ -1,0 +1,96 @@
+package io.brackit.query;
+
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Int32;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression tests for the pass-4 brackit audit: quantifier-over-empty, missing-field delete,
+ * fn:error semantics, xs:integer from large doubles / NaN casts, instance-of empty-sequence,
+ * array-slice step + view bounds, regex error mapping, and castable-QName.
+ */
+public class PassFourCorrectnessTest extends XQueryBaseTest {
+
+  private String eval(String query) {
+    var out = new java.io.ByteArrayOutputStream();
+    new Query(query).serialize(ctx, new java.io.PrintStream(out));
+    return out.toString().trim();
+  }
+
+  // B1: `every` over the empty sequence is vacuously true.
+  @Test
+  public void everyOverEmptyIsTrue() {
+    assertEquals("true", eval("every $x in () satisfies false()"));
+    assertEquals("true", eval("every $x in () satisfies $x gt 100"));
+    assertEquals("false", eval("some $x in () satisfies true()")); // some stays false
+  }
+
+  // B3: ArrayObject.remove(QNm) on a MISSING field is a no-op (it deleted the first field before
+  // the fix). Tested at the API level — a missing-field deref is empty at query level, so the
+  // (DeleteRecordFieldOp -> remove) path isn't reachable from a simple query.
+  @Test
+  public void removeMissingFieldIsNoOp() {
+    var fields = new io.brackit.query.atomic.QNm[] { new io.brackit.query.atomic.QNm("a"),
+        new io.brackit.query.atomic.QNm("b") };
+    var vals = new io.brackit.query.jdm.Sequence[] { new Int32(1), new Int32(2) };
+    var obj = new io.brackit.query.jsonitem.object.ArrayObject(fields, vals);
+    obj.remove(new io.brackit.query.atomic.QNm("zzz")); // missing — must NOT drop "a"
+    assertEquals(2, obj.len());
+    assertEquals("a", obj.name(0).stringValue());
+    assertEquals("b", obj.name(1).stringValue());
+    obj.remove(new io.brackit.query.atomic.QNm("a")); // present — drops it
+    assertEquals(1, obj.len());
+    assertEquals("b", obj.name(0).stringValue());
+  }
+
+  // B4: fn:error keeps the description verbatim (no String.format crash) and carries the value.
+  @Test
+  public void fnErrorDescriptionAndValue() {
+    // a '%' in the description must not crash with UnknownFormatConversionException
+    assertEquals("caught:50% failed",
+                 eval("try { fn:error(xs:QName('err:FOER0000'), '50% failed') } catch * { concat('caught:', $err:description) }"));
+    // $err:value carries the 3rd argument
+    assertEquals("42", eval("try { fn:error(xs:QName('err:FOER0000'), 'd', 42) } catch * { $err:value }"));
+  }
+
+  // B5: xs:integer from a large double does NOT saturate at Long.MAX; NaN casts are handled.
+  @Test
+  public void integerFromLargeDoubleAndNaNCasts() {
+    assertEquals("1000000000000000019884624838656", eval("xs:integer(xs:double('1e30'))"));
+    assertEquals("false", eval("string(xs:double('NaN') cast as xs:boolean)"));
+  }
+
+  // B6: a single item is not an instance of empty-sequence(); ? and * still accept it.
+  @Test
+  public void instanceOfEmptySequence() {
+    assertEquals("false", eval("1 instance of empty-sequence()"));
+    assertEquals("true", eval("() instance of empty-sequence()"));
+    assertEquals("true", eval("1 instance of item()?"));
+    assertEquals("true", eval("1 instance of item()*"));
+  }
+
+  // B8: array-slice step counts from the lower bound.
+  @Test
+  public void arraySliceStep() {
+    // $a[1:5:2] keeps the lower bound and every 2nd member from there → members at index 1,3 = 2,4
+    assertEquals("[2,4]", eval("let $a := [1,2,3,4,5] return $a[1:5:2]"));
+  }
+
+  // B9: invalid regex / replacement are mapped to FORX errors, not raw Java exceptions.
+  @Test
+  public void regexErrorMapping() {
+    QueryException tok = assertThrows(QueryException.class, () -> new Query("fn:tokenize('a','[')").execute(ctx));
+    assertEquals(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION, tok.getCode());
+    QueryException rep = assertThrows(QueryException.class, () -> new Query("fn:replace('abc','b','x$')").execute(ctx));
+    assertEquals(ErrorCode.ERR_INVALID_REPLACEMENT_STRING, rep.getCode());
+  }
+
+  // B10: `castable as xs:QName` with an unbound prefix is false, not an error.
+  @Test
+  public void castableQNameUnboundPrefix() {
+    assertEquals("false", eval("'nosuchprefix:y' castable as xs:QName"));
+  }
+}

--- a/src/test/java/io/brackit/query/PassThreeCorrectnessTest.java
+++ b/src/test/java/io/brackit/query/PassThreeCorrectnessTest.java
@@ -1,0 +1,166 @@
+package io.brackit.query;
+
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Dbl;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.node.d2linked.D2NodeFactory;
+import io.brackit.query.jdm.node.Node;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the pass-3 compiler/runtime audit: string equality against untyped/anyURI,
+ * order-by empty/NaN key handling, aggregate overflow/NaN, union/except with an empty operand,
+ * XQUF apply order, element-construction content merging, D2 sibling-division exhaustion, the
+ * preceding axis, reverse-axis positional predicates, 'allowing empty', deep-equal comment
+ * skipping, general comparison with an empty operand, and ±0.0 grouping.
+ */
+public class PassThreeCorrectnessTest extends XQueryBaseTest {
+
+  private String evalString(String query) {
+    var out = new java.io.ByteArrayOutputStream();
+    new Query(query).serialize(ctx, new java.io.PrintStream(out));
+    return out.toString().trim();
+  }
+
+  // H4: Str.eq rejected untyped atomics — '"literal" = element' was always false.
+  @Test
+  public void literalOnLeftEqualsUntypedNode() {
+    ResultChecker.dCheck(Bool.TRUE, new Query("let $d := <t>Potter</t> return \"Potter\" = $d").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE, new Query("let $d := <t>Potter</t> return \"Potter\" != $d").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("\"http://a\" = xs:anyURI(\"http://a\")").execute(ctx));
+  }
+
+  // H1: both order keys empty -> next orderspec must decide (and the comparator contract holds).
+  @Test
+  public void orderByConsultsSecondaryKeyWhenFirstKeysAreEmpty() {
+    assertEquals("1 2 3", evalString("for $i in (3,1,2) order by (if ($i gt 5) then $i else ()), $i return $i"));
+  }
+
+  // M1: NaN orders next to the empty sequence ('empty least' default: () < NaN < values).
+  @Test
+  public void orderByPlacesNaNBeforeValuesUnderEmptyLeast() {
+    assertEquals("NaN 1", evalString("for $x in (1, xs:double('NaN')) order by $x empty least return string($x)"));
+    assertEquals("1 NaN", evalString("for $x in (xs:double('NaN'), 1) order by $x empty greatest return string($x)"));
+  }
+
+  // H2: Int64 sum must escalate past long range instead of wrapping.
+  @Test
+  public void sumEscalatesToArbitraryPrecisionInsteadOfWrapping() {
+    assertEquals("13835058055282163710", evalString("string(sum((9223372036854775806, 4611686018427387904)))"));
+  }
+
+  // H3: fn:min/fn:max return NaN when the sequence contains NaN.
+  @Test
+  public void minMaxReturnNaN() {
+    assertEquals("NaN", evalString("string(min((1, xs:double('NaN'))))"));
+    assertEquals("NaN", evalString("string(max((1, xs:double('NaN'))))"));
+    // larger sequence to engage the buffered/SIMD double path
+    assertEquals("NaN", evalString("string(min((for $i in 1 to 64 return xs:double($i), xs:double('NaN'))))"));
+  }
+
+  // H7: an empty operand must not empty union/except results.
+  @Test
+  public void unionAndExceptWithEmptyOperand() {
+    ResultChecker.dCheck(new Int32(2), new Query("count((<a/>, <b/>) except ())").execute(ctx));
+    ResultChecker.dCheck(new Int32(2), new Query("count(() | (<a/>, <b/>))").execute(ctx));
+    ResultChecker.dCheck(new Int32(0), new Query("count(() except (<a/>, <b/>))").execute(ctx));
+  }
+
+  // H8: XQUF phase order — inserts apply BEFORE replaceNode.
+  @Test
+  public void updateApplyOrderInsertBeforeReplace() {
+    assertEquals("<r><b/><a/></r>",
+                 evalString("copy $c := <r><t/></r> modify (insert node <a/> after $c/t, replace node $c/t with <b/>) return $c"));
+  }
+
+  // H9: an atomic after a text-node item joins WITHOUT a space — and the SOURCE stays untouched.
+  @Test
+  public void constructorMergesTextNodeAndAtomicWithoutMutatingSource() {
+    assertEquals("<e>ab</e>", evalString("let $x := <x>a</x> let $t := $x/text() return element e { $t, \"b\" }"));
+    // the source element keeps its original value
+    assertEquals("a", evalString("let $x := <x>a</x> let $e := element e { $x/text(), \"b\" } return string($x)"));
+    // adjacent ATOMICS still join with a single space
+    assertEquals("<e>a b</e>", evalString("element e { \"a\", \"b\" }"));
+  }
+
+  // H10: repeated insert-before at the same boundary must not exhaust sibling divisions
+  // (the third insert hit the [3]-vs-[3,3] prefix case and threw IllegalArgumentException).
+  @Test
+  public void repeatedInsertBeforeSameBoundary() {
+    var factory = new D2NodeFactory();
+    Node<?> doc = factory.build(new io.brackit.query.node.parser.DocumentParser("<r><a/><b/></r>"));
+    Node<?> r = doc.getFirstChild();
+    Node<?> target = r.getFirstChild().getNextSibling(); // <b/>
+    for (int i = 0; i < 5; i++) {
+      Node<?> fresh = factory.build(new io.brackit.query.node.parser.DocumentParser("<n/>")).getFirstChild();
+      target = target.insertBefore(fresh);
+    }
+    int count = 0;
+    try (var children = r.getChildren()) {
+      while (children.next() != null) {
+        count++;
+      }
+    }
+    assertEquals(7, count);
+  }
+
+  // H11: the preceding axis excludes ancestors and must not drop legitimate nodes.
+  @Test
+  public void precedingAxisExcludesAncestors() {
+    assertEquals("x b",
+                 evalString("let $d := <r><x/><a><b/><c/></a></r> "
+                     + "return string-join(for $n in $d//c/preceding::* return name($n), ' ')"));
+  }
+
+  // (H12 — positional predicates on reverse axes — is fixed in StepExpr, but the JSONiq
+  // dialect this engine parses has no step-predicate syntax ('[..]' is array access), so the
+  // path is not expressible from query level; no query test possible.)
+
+  // H5: 'allowing empty' binds one empty tuple instead of crashing compilation.
+  @Test
+  public void allowingEmptyBindsEmptyTuple() {
+    assertEquals("e", evalString("for $x allowing empty in () return \"e\""));
+    // lazy-empty bind sequence (exercises the operator NPE path)
+    assertEquals("done", evalString("for $x allowing empty in subsequence((1, 2), 5) return \"done\""));
+    // non-empty behaves exactly like a plain for
+    assertEquals("1 2", evalString("for $x allowing empty in (1, 2) return $x"));
+  }
+
+  // M2: trailing comments/PIs are ignored by fn:deep-equal.
+  @Test
+  public void deepEqualIgnoresTrailingComments() {
+    ResultChecker.dCheck(Bool.TRUE, new Query("deep-equal(<x/>, <x><!--c--></x>)").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("deep-equal(<x><!--c--><a/></x>, <x><a/><?pi d?></x>)").execute(ctx));
+  }
+
+  // M7: a general comparison with an empty operand is false(), not ().
+  @Test
+  public void generalComparisonWithEmptyOperandIsFalse() {
+    ResultChecker.dCheck(new Int32(1), new Query("count(() = 1)").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE, new Query("() = 1").execute(ctx));
+  }
+
+  // M5: -0.0 and +0.0 group together.
+  @Test
+  public void negativeZeroGroupsWithPositiveZero() {
+    // one group containing both zeros: the non-grouping variable $x has 2 members
+    assertEquals("2",
+                 evalString("for $x in (xs:double('-0'), xs:double('0')) let $k := $x group by $k return count($x)"));
+    // direct grouping: a single group (two groups would serialize as "1 1")
+    assertEquals("1", evalString("for $x in (xs:double('-0'), xs:double('0')) group by $x return count($x)"));
+  }
+
+  // M9: unsupported order-by collations are rejected (XQST0076), not silently ignored.
+  @Test
+  public void orderByUnsupportedCollationRejected() {
+    QueryException ex = assertThrows(QueryException.class,
+                                     () -> new Query("for $x in (2,1) order by $x collation \"http://example.com/c\" return $x").execute(ctx));
+    assertEquals(ErrorCode.ERR_UNKNOWN_COLLATION_IN_FLWOR_CLAUSE, ex.getCode());
+  }
+}

--- a/src/test/java/io/brackit/query/RoundTwoCorrectnessTest.java
+++ b/src/test/java/io/brackit/query/RoundTwoCorrectnessTest.java
@@ -1,0 +1,158 @@
+package io.brackit.query;
+
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.Str;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression tests for the 2026-06-10 correctness audit (non-numeric brackit bugs): surrogate-pair
+ * codepoints, negative/BCE year serialization, fractional-second serialization, fn:translate
+ * delete/identity semantics, empty + whitespace-flag regex handling, yearMonthDuration scaling, and
+ * fn:subsequence with a non-positive start.
+ */
+public class RoundTwoCorrectnessTest extends XQueryBaseTest {
+
+  // U+1D54F MATHEMATICAL DOUBLE-STRUCK CAPITAL X (a non-BMP / surrogate-pair character).
+  private static final String X = "𝕏";
+
+  @Test
+  public void stringToCodepointsHandlesNonBmp() {
+    ResultChecker.dCheck(new Int32(1), new Query("count(string-to-codepoints('" + X + "'))").execute(ctx));
+    ResultChecker.dCheck(new Int32(120143), new Query("string-to-codepoints('" + X + "')").execute(ctx));
+  }
+
+  @Test
+  public void stringLengthAndSubstringCountCodepoints() {
+    ResultChecker.dCheck(new Int32(2), new Query("fn:string-length('" + X + X + "')").execute(ctx));
+    // substring positions count codepoints; the non-BMP char must not be split.
+    ResultChecker.dCheck(new Str("abc"), new Query("fn:substring('" + X + "abc', 2)").execute(ctx));
+    ResultChecker.dCheck(new Str(X), new Query("fn:substring('" + X + "abc', 1, 1)").execute(ctx));
+  }
+
+  @Test
+  public void codepointsRoundTripNonBmp() {
+    ResultChecker.dCheck(new Str(X), new Query("codepoints-to-string(string-to-codepoints('" + X + "'))").execute(ctx));
+  }
+
+  @Test
+  public void negativeYearKeepsMagnitude() {
+    ResultChecker.dCheck(new Str("-0001-05-15"), new Query("string(xs:date('-0001-05-15'))").execute(ctx));
+    ResultChecker.dCheck(new Str("-0044"), new Query("string(xs:gYear('-0044'))").execute(ctx));
+    ResultChecker.dCheck(new Str("-0001-05-15T10:00:00"),
+                         new Query("string(xs:dateTime('-0001-05-15T10:00:00'))").execute(ctx));
+  }
+
+  @Test
+  public void fractionalSecondsSerializeAndRoundTrip() {
+    ResultChecker.dCheck(new Str("2026-05-01T10:00:05.25"),
+                         new Query("string(xs:dateTime('2026-05-01T10:00:05.25'))").execute(ctx));
+    // The serialized form must re-parse to the same value (the old ':'-separated form did not).
+    ResultChecker.dCheck(new Str("2026-05-01T10:00:05.25"),
+                         new Query("string(xs:dateTime(string(xs:dateTime('2026-05-01T10:00:05.25'))))").execute(ctx));
+    ResultChecker.dCheck(new Str("09:08:07.000123"), new Query("string(xs:time('09:08:07.000123'))").execute(ctx));
+  }
+
+  @Test
+  public void translateIdentityAndDelete() {
+    // Empty map leaves the string unchanged (was "").
+    ResultChecker.dCheck(new Str("abcdef"), new Query("fn:translate('abcdef', '', 'xyz')").execute(ctx));
+    // Mapped characters with no replacement counterpart are DELETED (were passed through).
+    ResultChecker.dCheck(new Str("xyef"), new Query("fn:translate('abcdef', 'abcd', 'xy')").execute(ctx));
+    ResultChecker.dCheck(new Str("AAA"), new Query("fn:translate('--aaa--', 'a-', 'A')").execute(ctx));
+  }
+
+  @Test
+  public void base64RoundTrips() {
+    // "Hello" -> SGVsbG8= ; the value must round-trip (was mangled to SGV2bG8, padding dropped).
+    ResultChecker.dCheck(new Str("SGVsbG8="), new Query("string(xs:base64Binary('SGVsbG8='))").execute(ctx));
+    ResultChecker.dCheck(new Str("SGVsbG8="),
+                         new Query("string(xs:base64Binary(string(xs:base64Binary('SGVsbG8='))))").execute(ctx));
+  }
+
+  @Test
+  public void emptyRegexMatches() {
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('abc', '')").execute(ctx));
+  }
+
+  @Test
+  public void whitespaceFlagKeepsBracketsAndClasses() {
+    // With the 'x' flag, whitespace is stripped but the character class must survive — the brackets
+    // were previously dropped, turning [0-9] into the literal "0-9".
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('5', '[0-9]', 'x')").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE, new Query("fn:matches('a', '[0-9]', 'x')").execute(ctx));
+  }
+
+  @Test
+  public void yearMonthDurationScalesTotalMonths() {
+    ResultChecker.dCheck(new Str("P6M"), new Query("string(xs:yearMonthDuration('P1Y') div 2)").execute(ctx));
+    ResultChecker.dCheck(new Str("P1Y6M"), new Query("string(xs:yearMonthDuration('P3Y') div 2)").execute(ctx));
+    ResultChecker.dCheck(new Str("P9M"), new Query("string(xs:yearMonthDuration('P1Y6M') div 2)").execute(ctx));
+    ResultChecker.dCheck(new Str("P1Y6M"), new Query("string(xs:yearMonthDuration('P1Y') * 1.5)").execute(ctx));
+  }
+
+  @Test
+  public void utcVsNonUtcTemporalComparison() {
+    // A UTC (Z) value compared against a non-UTC value was wrongly treated as timezone-less.
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("xs:dateTime('2026-05-01T03:00:00+02:00') eq xs:dateTime('2026-05-01T01:00:00Z')").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("xs:dateTime('2026-05-01T03:00:00+02:00') gt xs:dateTime('2026-05-01T00:30:00Z')").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE,
+                         new Query("xs:dateTime('2026-05-01T03:00:00+02:00') lt xs:dateTime('2026-05-01T00:30:00Z')").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("xs:time('14:00:00+02:00') eq xs:time('12:00:00Z')").execute(ctx));
+  }
+
+  @Test
+  public void subHourTimezoneNormalizes() {
+    // +00:30 must normalize during canonicalization: 01:30+00:30 == 01:00Z (the old guard skipped
+    // normalization whenever the offset hours were 0).
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("xs:dateTime('2026-05-01T01:30:00+00:30') eq xs:dateTime('2026-05-01T01:00:00Z')").execute(ctx));
+  }
+
+  @Test
+  public void durationFractionalSecondsCanonical() {
+    ResultChecker.dCheck(new Str("PT0.5S"), new Query("string(xs:dayTimeDuration('PT0.5S'))").execute(ctx));
+    // 0.05s = 50000 micros: must keep the leading zero (was rendered ".50000" = 0.5s).
+    ResultChecker.dCheck(new Str("PT0.05S"), new Query("string(xs:dayTimeDuration('PT0.05S'))").execute(ctx));
+  }
+
+  @Test
+  public void jnParseDuplicateKeysLastWins() {
+    // Duplicate object keys: last value wins, and the object holds a single "a" (was keeping both,
+    // producing invalid JSON whose lookup disagreed with its serialization).
+    ResultChecker.dCheck(new Int32(2), new Query("jn:parse('{\"a\":1,\"a\":2}').a").execute(ctx));
+    ResultChecker.dCheck(new Int32(1), new Query("count(jn:keys(jn:parse('{\"a\":1,\"a\":2}')))").execute(ctx));
+  }
+
+  @Test
+  public void decimalRejectsExponent() {
+    // xs:decimal's lexical space has no exponent.
+    assertThrows(QueryException.class, () -> new Query("xs:decimal('1.0E2')").execute(ctx));
+  }
+
+  @Test
+  public void qnameCastFromString() {
+    // Unprefixed: a no-namespace QName (was XQDY0074 — the 1-arg QNm ctor never split the string
+    // and normalized the prefix to "", so every string cast died in prefix resolution).
+    ResultChecker.dCheck(Bool.TRUE, new Query("xs:QName('foo') eq fn:QName('', 'foo')").execute(ctx));
+    // Prefixed with a declared namespace: the prefix must RESOLVE (eq compares URI + local name).
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("declare namespace p = 'urn:x'; xs:QName('p:foo') eq fn:QName('urn:x', 'q:foo')").execute(ctx));
+    // Malformed lexical QName -> proper cast error (was a raw IllegalStateException).
+    assertThrows(QueryException.class, () -> new Query("xs:QName(':foo')").execute(ctx));
+  }
+
+  @Test
+  public void subsequenceNonPositiveStart() {
+    ResultChecker.dCheck(new Int32(2), new Query("count(fn:subsequence((1,2,3,4,5,6,7,8), -2, 5))").execute(ctx));
+    ResultChecker.dCheck(new Str("1 2"),
+                         new Query("string-join(for $x in fn:subsequence((1,2,3,4,5,6,7,8), -2, 5) return string($x), ' ')").execute(ctx));
+    ResultChecker.dCheck(new Str("1 2"),
+                         new Query("string-join(for $x in fn:subsequence((1,2,3,4,5,6,7,8), 0, 3) return string($x), ' ')").execute(ctx));
+  }
+}

--- a/src/test/java/io/brackit/query/atomic/NumericCorrectnessTest.java
+++ b/src/test/java/io/brackit/query/atomic/NumericCorrectnessTest.java
@@ -1,0 +1,119 @@
+package io.brackit.query.atomic;
+
+import io.brackit.query.Query;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.jdm.Sequence;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for numeric correctness bugs (integer/decimal promotion, mod, overflow, abs,
+ * effective boolean value) found in the 2026-06-10 production-readiness audit.
+ */
+public class NumericCorrectnessTest extends XQueryBaseTest {
+
+  private static Dec dec(String s) {
+    return new Dec(new BigDecimal(s));
+  }
+
+  // --- integer + decimal must NOT truncate (was 1 + 2.5 -> 3) ---
+
+  @Test
+  public void intPlusDecimal() {
+    ResultChecker.dCheck(dec("3.5"), new Query("1 + 2.5").execute(ctx));
+  }
+
+  @Test
+  public void intMinusDecimal() {
+    ResultChecker.dCheck(dec("-1.5"), new Query("1 - 2.5").execute(ctx));
+  }
+
+  @Test
+  public void decimalPlusInt() {
+    ResultChecker.dCheck(dec("3.5"), new Query("2.5 + 1").execute(ctx));
+  }
+
+  @Test
+  public void pureIntStaysInteger() {
+    ResultChecker.dCheck(new Int32(3), new Query("1 + 2").execute(ctx));
+  }
+
+  // --- sum / avg over mixed int+decimal (was sum((1,2.5,3)) -> 6) ---
+
+  @Test
+  public void sumMixed() {
+    ResultChecker.dCheck(dec("6.5"), new Query("sum((1, 2.5, 3))").execute(ctx));
+  }
+
+  @Test
+  public void avgMixedIsDecimalGreaterThanTwo() {
+    final Sequence r = new Query("avg((1, 2.5, 3))").execute(ctx);
+    final Numeric n = (Numeric) r;
+    // 6.5 / 3 = 2.1666... — must be a decimal strictly between 2 and 3, not the truncated 2.
+    assertTrue(n.decimalValue().compareTo(new BigDecimal("2")) > 0 && n.decimalValue().compareTo(new BigDecimal("3"))
+        < 0, "avg should be ~2.1667, got " + n);
+  }
+
+  // --- mod with a decimal operand (was 7.5 mod 2 -> 1) ---
+
+  @Test
+  public void modDecimalDividend() {
+    ResultChecker.dCheck(dec("1.5"), new Query("7.5 mod 2").execute(ctx));
+  }
+
+  @Test
+  public void modDecimalDivisorValue() {
+    // 7 mod 2.5 = 2.0
+    final Numeric n = (Numeric) new Query("7 mod 2.5").execute(ctx);
+    assertEquals(0, n.decimalValue().compareTo(new BigDecimal("2.0")), "got " + n);
+  }
+
+  @Test
+  public void modPureIntStaysInteger() {
+    ResultChecker.dCheck(new Int32(1), new Query("7 mod 2").execute(ctx));
+  }
+
+  // --- fn:abs of a negative decimal must not truncate (was abs(-2.5) -> 2) ---
+
+  @Test
+  public void absNegativeDecimal() {
+    ResultChecker.dCheck(dec("2.5"), new Query("abs(-2.5)").execute(ctx));
+  }
+
+  // --- direct atomic edge cases (paths not reachable via small literals) ---
+
+  @Test
+  public void int64OverflowEscalates() throws Exception {
+    // Long.MAX + 1 must escalate to a BigDecimal-backed Int (was silently wrapping to Long.MIN).
+    final Numeric r = new Int64(Long.MAX_VALUE).add(new Int32(1));
+    assertEquals(new BigDecimal("9223372036854775808"), r.decimalValue());
+  }
+
+  @Test
+  public void bareIntOperandDivIdivMod() throws Exception {
+    final Int bigTwo = new Int(new BigDecimal(2));
+    // div: 7 / 2 = 3.5 ; idiv: 3 ; mod: 1 — previously all computed 7 + 2 = 9.
+    assertEquals(0, ((Numeric) new Int32(7).div(bigTwo)).decimalValue().compareTo(new BigDecimal("3.5")));
+    assertEquals(new BigDecimal("3"), ((Numeric) new Int32(7).idiv(bigTwo)).decimalValue());
+    assertEquals(new BigDecimal("1"), ((Numeric) new Int32(7).mod(bigTwo)).decimalValue());
+  }
+
+  @Test
+  public void floatEffectiveBooleanValue() throws Exception {
+    assertTrue(new Flt(2.0f).booleanValue(), "finite non-zero float EBV must be true");
+    assertFalse(new Flt(0.0f).booleanValue(), "zero float EBV must be false");
+    assertFalse(new Flt(Float.POSITIVE_INFINITY).booleanValue(), "INF float EBV must be false");
+  }
+
+  @Test
+  public void int32BoundaryEffectiveBooleanValue() throws Exception {
+    assertTrue(new Int32(Integer.MAX_VALUE).booleanValue(), "MAX_VALUE is non-zero -> EBV true");
+    assertTrue(new Int32(Integer.MIN_VALUE).booleanValue(), "MIN_VALUE is non-zero -> EBV true");
+  }
+}

--- a/src/test/java/io/brackit/query/expr/ArrayExprTest.java
+++ b/src/test/java/io/brackit/query/expr/ArrayExprTest.java
@@ -29,10 +29,16 @@ package io.brackit.query.expr;
 
 import io.brackit.query.XQueryBaseTest;
 import io.brackit.query.atomic.Dec;
+import io.brackit.query.atomic.Int32;
 import io.brackit.query.jdm.Sequence;
+import io.brackit.query.QueryException;
 import io.brackit.query.ResultChecker;
 import io.brackit.query.Query;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Johannes Lichtenberger
@@ -42,5 +48,34 @@ public class ArrayExprTest extends XQueryBaseTest {
   public void complexArray() {
     Sequence result = new Query("[ 1, '2', 3, (1 > 0) cast as xs:boolean, 1.2343 + 5, =(1,2,3)  ][4]").execute(ctx);
     ResultChecker.dCheck(new Dec("6.2343"), result);
+  }
+
+  @Test
+  public void inBoundsIndex() {
+    ResultChecker.dCheck(new Int32(30), new Query("[10,20,30,40,50][2]").execute(ctx));
+  }
+
+  @Test
+  public void negativeIndexCountsFromEnd() {
+    ResultChecker.dCheck(new Int32(50), new Query("[10,20,30,40,50][-1]").execute(ctx));
+  }
+
+  @Test
+  public void positiveOutOfBoundsIsEmpty() {
+    // Was: raw IndexOutOfBoundsException leaking as an HTTP 500.
+    assertNull(new Query("[10,20,30,40,50][100]").execute(ctx));
+  }
+
+  @Test
+  public void largePositiveIndexIsEmptyNotNegative() {
+    // Was: 3000000000 truncated by intValue() to a negative int -> bogus "Illegal negative index".
+    assertNull(new Query("[10,20,30,40,50][3000000000]").execute(ctx));
+  }
+
+  @Test
+  public void negativeOvershootStillThrows() {
+    // A negative index past the start is a genuine error and must report a clean FORG0006.
+    final var e = assertThrows(QueryException.class, () -> new Query("[10,20,30,40,50][-100]").execute(ctx));
+    assertEquals("FORG0006", e.getCode().getLocalName());
   }
 }


### PR DESCRIPTION
Consolidated correctness pass ahead of the next release.

## Numeric/atomic layer
- `Int`/`Int32`/`Int64`/`Dec`/`Flt`: dispatch double/float operands on the `DblNumeric`/`FltNumeric` **interfaces** instead of the concrete `Dbl`/`Flt` classes in `cmp`/`atomicCmp`/arithmetic, so document-sourced wrappers (e.g. SirixDB item wrappers) compare and compute correctly.
- `B64`: base64 round-trip corruption fix.
- Temporal types (`Date`/`DateTime`/`Time`/`GYE`/`GYM`/`YMD`, `AbstractDuration`, `AbstractTimeInstant`): canonicalization + comparison fixes.
- `Cast`: `asInteger` conjunction bug, BigDecimal-backed integer casts, NaN→false for boolean casts.
- `Castable`: unknown namespace prefix now reports `ERR_UNKNOWN_NS_PREFIX_IN_COMP_CONSTR`.
- `Str`: surrogate-pair handling.

## Expressions/runtime
- `TypedSequence`: only reject `Cardinality.Zero` for one-or-more types (single items were wrongly rejected).
- `DRArray` slices are `[start, end)` with mutable end; `ArrayIndexSliceExpr` stepped slices index relative to the lower bound.
- `Every` over an empty sequence is `true`; `ArrayObject.remove` of a missing field is a no-op.
- `fn:error`/`TryCatchExpr`/`QueryException`: `$err:value` and `$err:description` preserved through try/catch.
- `Regex`: invalid flags map to `FORX0001`.
- Assorted result-correctness fixes in `Accessor`, `ArrayAccessExpr`, `StepExpr`, `ExceptExpr`, `ConstructedNodeBuilder`.

## Hot paths (allocation-free)
- `Ordering`/`MinMaxAggregator`: NaN checks dispatch `DblNumeric`/`FltNumeric`-first (no `doubleValue` conversion for Int/Dec).
- `Grouping`: static canonical `+0.0` instances.

## Pipeline
- `BlockPipelineStrategy`/`SequentialPipelineStrategy`/`Compiler`/`TopDownPipeline` construction fixes.

## Tests
New regression gates `RoundTwoCorrectnessTest`, `PassThreeCorrectnessTest`, `PassFourCorrectnessTest`, `NumericCorrectnessTest`; full suite **1104 tests, 0 failures**.