### PR TITLE
Consolidate duplicated helpers from the correctness pass

### DIFF
--- a/src/main/java/io/brackit/query/QueryException.java
+++ b/src/main/java/io/brackit/query/QueryException.java
@@ -46,10 +46,16 @@ public class QueryException extends RuntimeException {
   private final transient Object errorValue;
 
   /**
-   * fn:error constructor: keeps the description VERBATIM (no String.format — a '%' in user data
-   * crashed it) and retains the error value for $err:value.
+   * fn:error factory: keeps the description VERBATIM (no String.format — a '%' in user data
+   * crashed it) and retains the error value for $err:value. A named factory instead of a
+   * constructor: the varargs (QNm, String, Object...) constructor below format-interprets the
+   * description, so an overload would be one missed argument away from that hazard.
    */
-  public QueryException(QNm code, String description, Object errorValue, boolean fromError) {
+  public static QueryException fromFnError(QNm code, String description, Object errorValue) {
+    return new QueryException(code, description, errorValue, true);
+  }
+
+  private QueryException(QNm code, String description, Object errorValue, boolean verbatim) {
     super(code.toString() + ": " + description);
     this.code = code;
     this.description = description;

--- a/src/main/java/io/brackit/query/atomic/AbstractDuration.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractDuration.java
@@ -117,11 +117,10 @@ public abstract class AbstractDuration extends AbstractAtomic implements Duratio
       out.append(seconds);
       int remainder = micros - seconds * 1000000;
       if (remainder != 0) {
-        // Fractional seconds = the micros remainder zero-padded to 6 digits with trailing zeros
-        // stripped. Appending the bare int dropped the leading zeros (50000 micros = 0.05s rendered
-        // as ".50000") and kept trailing zeros (".500000").
+        // Fractional seconds: see AbstractTimeInstant.fractionalSecondsString (bare-int append
+        // dropped leading zeros and kept trailing ones).
         out.append('.');
-        out.append(String.format("%06d", remainder).replaceAll("0+$", ""));
+        out.append(AbstractTimeInstant.fractionalSecondsString(remainder));
       }
       out.append('S');
       fieldSet = true;

--- a/src/main/java/io/brackit/query/atomic/AbstractNumeric.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractNumeric.java
@@ -42,6 +42,16 @@ import io.brackit.query.jdm.Type;
  * @author Sebastian Baechle
  */
 public abstract class AbstractNumeric extends AbstractAtomic implements Numeric {
+
+  /**
+   * Only doubles/floats can be NaN — dispatch on the DblNumeric/FltNumeric INTERFACES first
+   * (document-sourced wrapper atomics are not the concrete Dbl/Flt classes) so hot
+   * comparator/aggregation paths never pay an Int/Dec doubleValue() conversion.
+   */
+  public static boolean isNaN(final Atomic a) {
+    return (a instanceof DblNumeric || a instanceof FltNumeric) && Double.isNaN(((Numeric) a).doubleValue());
+  }
+
   /**
    *
    */

--- a/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
@@ -120,6 +120,16 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
     AbstractTimeInstant a = this;
     AbstractTimeInstant b = other;
 
+    // EQUAL offsets (overwhelmingly: both UTC) need no normalization — subtracting the same
+    // duration from both sides cannot change their order, and the mixed-normalization hazard
+    // canonicalize() guards against requires DIFFERING offsets. Skips two DateTime+add
+    // allocations per comparison on the sort/comparator hot path.
+    final DTD thisTz = a.getTimezone();
+    final DTD otherTz = b.getTimezone();
+    if (thisTz != null && otherTz != null && sameOffset(thisTz, otherTz)) {
+      return compareFields(a, b);
+    }
+
     // A value with ANY timezone — including UTC (Z / +00:00) — IS timezoned. The old guard treated
     // a 00:00 offset as "no timezone", so a UTC value compared against a non-UTC value wrongly took
     // the implicit-timezone ±14h undecidable path (e.g. "…01:00Z" eq "…03:00+02:00" -> false).
@@ -409,6 +419,40 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
     } else {
       return 31;
     }
+  }
+
+  /**
+   * Lexical year with xs:date/xs:dateTime zero padding to four digits; a negative (BCE) year
+   * keeps its magnitude: "-0001", not just "-".
+   */
+  static String yearString(final int year) {
+    final int absYear = Math.abs(year);
+    return (year < 0 ? "-" : "") + (absYear < 10 ? "000" : absYear < 100 ? "00" : absYear < 1000 ? "0" : "") + absYear;
+  }
+
+  /**
+   * Lexical fractional seconds for a micros remainder in (0, 1_000_000): six digits zero-padded
+   * with trailing zeros stripped — e.g. 250000 -> "25", 123 -> "000123". No Formatter and no
+   * regex; this sits on every sub-second temporal/duration stringValue().
+   */
+  static String fractionalSecondsString(int micros) {
+    int width = 6;
+    while (micros % 10 == 0) {
+      micros /= 10;
+      width--;
+    }
+    final char[] out = new char[width];
+    for (int i = width - 1; i >= 0; i--) {
+      out[i] = (char) ('0' + micros % 10);
+      micros /= 10;
+    }
+    return new String(out);
+  }
+
+  private static boolean sameOffset(final DTD a, final DTD b) {
+    return a.isNegative() == b.isNegative() && a.getDays() == b.getDays() && a.getHours() == b.getHours() && a
+                                                                                                              .getMinutes()
+        == b.getMinutes() && a.getMicros() == b.getMicros();
   }
 
   protected String timezoneString() {

--- a/src/main/java/io/brackit/query/atomic/Date.java
+++ b/src/main/java/io/brackit/query/atomic/Date.java
@@ -187,10 +187,7 @@ public class Date extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
-    final int absYear = Math.abs(year);
-    String yTmp = (year < 0 ? "-" : "") + (absYear < 10 ? "000" : absYear < 100 ? "00" : absYear < 1000 ? "0" : "")
-        + absYear;
+    String yTmp = yearString(year);
     String mTmp = (month < 10 ? "0" : "") + month;
     String dTmp = (day < 10 ? "0" : "") + day;
     String tzTmp = timezoneString();

--- a/src/main/java/io/brackit/query/atomic/DateTime.java
+++ b/src/main/java/io/brackit/query/atomic/DateTime.java
@@ -310,10 +310,7 @@ public class DateTime extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
-    final int absYear = Math.abs(year);
-    String yTmp = (year < 0 ? "-" : "") + (absYear < 10 ? "000" : absYear < 100 ? "00" : absYear < 1000 ? "0" : "")
-        + absYear;
+    String yTmp = yearString(year);
     String mTmp = (month < 10 ? "0" : "") + month;
     String dTmp = (day < 10 ? "0" : "") + day;
     String hTmp = (hour < 10 ? "0" : "") + hour;
@@ -324,11 +321,7 @@ public class DateTime extends AbstractTimeInstant {
     int remainder = micros - seconds * 1000000;
     String sTmp = (seconds < 10 ? "0" : "") + String.valueOf(seconds);
     if (remainder != 0) {
-      // Fractional seconds: the micros remainder zero-padded to 6 digits with trailing zeros
-      // stripped, after a '.' separator — e.g. 250000 -> ".25", 123 -> ".000123". (The old loop
-      // used ':' and mangled the magnitude / could spin on single-digit remainders.)
-      final String frac = String.format("%06d", remainder).replaceAll("0+$", "");
-      sTmp += "." + frac;
+      sTmp += "." + fractionalSecondsString(remainder);
     }
     return String.format("%s-%s-%sT%s:%s:%s%s", yTmp, mTmp, dTmp, hTmp, minTmp, sTmp, tzTmp);
   }

--- a/src/main/java/io/brackit/query/atomic/GYE.java
+++ b/src/main/java/io/brackit/query/atomic/GYE.java
@@ -153,11 +153,7 @@ public class GYE extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
-    final int absYear = Math.abs(year);
-    String yTmp = ((year < 0) ? "-" : "") + ((absYear < 10)
-        ? "000"
-        : (absYear < 100) ? "00" : (absYear < 1000) ? "0" : "") + absYear;
+    String yTmp = yearString(year);
     String tzTmp = timezoneString();
 
     return String.format("%s%s", yTmp, tzTmp);

--- a/src/main/java/io/brackit/query/atomic/GYM.java
+++ b/src/main/java/io/brackit/query/atomic/GYM.java
@@ -176,11 +176,7 @@ public class GYM extends AbstractTimeInstant {
 
   @Override
   public String stringValue() {
-    // A negative (BCE) year must keep its magnitude: "-0001", not just "-".
-    final int absYear = Math.abs(year);
-    String yTmp = ((year < 0) ? "-" : "") + ((absYear < 10)
-        ? "000"
-        : (absYear < 100) ? "00" : (absYear < 1000) ? "0" : "") + absYear;
+    String yTmp = yearString(year);
     String mTmp = ((month < 10) ? "0" : "") + month;
     String tzTmp = timezoneString();
 

--- a/src/main/java/io/brackit/query/atomic/Time.java
+++ b/src/main/java/io/brackit/query/atomic/Time.java
@@ -197,9 +197,7 @@ public class Time extends AbstractTimeInstant {
     int remainder = (micros - (seconds * 1000000));
     String sTmp = ((seconds < 10) ? "0" : "") + seconds;
     if (remainder != 0) {
-      // Fractional seconds: micros padded to 6 digits, trailing zeros stripped, '.' separator.
-      final String frac = String.format("%06d", remainder).replaceAll("0+$", "");
-      sTmp += "." + frac;
+      sTmp += "." + fractionalSecondsString(remainder);
     }
     return String.format("%s:%s:%s%s", hTmp, minTmp, sTmp, tzTmp);
   }

--- a/src/main/java/io/brackit/query/function/fn/Error.java
+++ b/src/main/java/io/brackit/query/function/fn/Error.java
@@ -53,6 +53,6 @@ public class Error extends AbstractFunction {
     // Verbatim description + retained error value: the old (QNm, String, Object...) overload ran
     // the user description through String.format with the error value as a format arg — a '%' in
     // the description threw UnknownFormatConversionException, and the error value was discarded.
-    throw new QueryException(qnm, description.stringValue(), seq, true);
+    throw QueryException.fromFnError(qnm, description.stringValue(), seq);
   }
 }

--- a/src/main/java/io/brackit/query/util/Regex.java
+++ b/src/main/java/io/brackit/query/util/Regex.java
@@ -188,6 +188,19 @@ public class Regex {
     int groupDepth = 0;
 
     for (char c : regex.toCharArray()) {
+      // Single carry-over chokepoint for whitespace-removal (x-flag) mode: every character except
+      // to-be-stripped whitespace (outside character classes) is appended exactly once here. The
+      // structural branches below previously each re-appended their character — a branch that
+      // forgot silently corrupted the rebuilt pattern.
+      if (removeWhitespace) {
+        if (charClassDepth == 0 && WHITESPACE.contains(c)) {
+          // Strip — and don't touch the boolean flags (an escape stays pending across stripped
+          // whitespace, matching the spec's remove-before-parse semantics).
+          continue;
+        }
+        sb.append(c);
+      }
+
       if (escaped) {
         if (backRef == 0 && c == '0') {
           throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION, "Reference to group 0 not allowed");
@@ -195,9 +208,6 @@ public class Regex {
           if (charClassDepth > 0) {
             throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION,
                                      "Back references in character class expressions" + " are disallowed.");
-          }
-          if (removeWhitespace) {
-            sb.append(c);
           }
           backRef = backRef * 10 + Integer.parseInt(Character.toString(c));
           continue;
@@ -216,21 +226,12 @@ public class Regex {
       }
 
       if (c == '\\' && !escaped) {
-        // Not preceded by backslash. In whitespace-removal (x-flag) mode the rebuilt pattern is
-        // assembled char-by-char, so structural characters (\ ( ) [ ] and back-reference digits)
-        // must be re-appended here — dropping them silently changed the regex semantics.
-        if (removeWhitespace) {
-          sb.append(c);
-        }
         escaped = true;
         groupStart = false;
         continue;
       }
 
       if (c == '(' && !escaped) {
-        if (removeWhitespace) {
-          sb.append(c);
-        }
         groupStart = true;
         groupDepth++;
         escaped = false;
@@ -245,29 +246,12 @@ public class Regex {
           throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION, "Invalid sequence of brackets.");
         }
         completeGroups++;
-        if (removeWhitespace) {
-          sb.append(c);
-        }
       } else if (c == '[' && !escaped) {
         charClassDepth++;
-        if (removeWhitespace) {
-          sb.append(c);
-        }
       } else if (c == ']' && !escaped) {
         if (--charClassDepth < 0) {
           throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION, "Invalid sequence of brackets.");
         }
-        if (removeWhitespace) {
-          sb.append(c);
-        }
-      } else if (removeWhitespace) {
-        // Remove whitespace outside of character classes
-        if (charClassDepth == 0 && WHITESPACE.contains(c)) {
-          // Don't touch boolean flags
-          continue;
-        }
-
-        sb.append(c);
       }
 
       groupStart = false;

--- a/src/main/java/io/brackit/query/util/aggregator/MinMaxAggregator.java
+++ b/src/main/java/io/brackit/query/util/aggregator/MinMaxAggregator.java
@@ -32,6 +32,7 @@ import io.brackit.query.QueryException;
 import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Dbl;
 import io.brackit.query.atomic.Int64;
+import io.brackit.query.atomic.AbstractNumeric;
 import io.brackit.query.atomic.Numeric;
 import io.brackit.query.expr.Cast;
 import io.brackit.query.jdm.Item;
@@ -378,10 +379,10 @@ public class MinMaxAggregator implements Aggregator {
     // F&O §14.4: if the converted sequence contains NaN, fn:min/fn:max return NaN. The cmp-based
     // update below uses the total order (NaN above everything), which never SELECTS NaN — so
     // min((1, NaN)) silently returned 1. NaN is sticky once seen.
-    if (isNaN(s)) {
+    if (AbstractNumeric.isNaN(s)) {
       return s;
     }
-    if (isNaN(minmax)) {
+    if (AbstractNumeric.isNaN(minmax)) {
       return minmax;
     }
 
@@ -391,12 +392,5 @@ public class MinMaxAggregator implements Aggregator {
       minmax = s;
     }
     return minmax;
-  }
-
-  private static boolean isNaN(Atomic a) {
-    // Only doubles/floats can be NaN — interface-first dispatch keeps Int/Dec off the
-    // doubleValue() conversion in the per-item aggregation loop.
-    return (a instanceof io.brackit.query.atomic.DblNumeric || a instanceof io.brackit.query.atomic.FltNumeric)
-        && Double.isNaN(((Numeric) a).doubleValue());
   }
 }

--- a/src/main/java/io/brackit/query/util/sort/Ordering.java
+++ b/src/main/java/io/brackit/query/util/sort/Ordering.java
@@ -29,6 +29,7 @@ package io.brackit.query.util.sort;
 
 import java.util.Comparator;
 
+import io.brackit.query.atomic.AbstractNumeric;
 import io.brackit.query.atomic.Atomic;
 import io.brackit.query.ErrorCode;
 import io.brackit.query.QueryContext;
@@ -141,8 +142,8 @@ public class Ordering implements Comparator<Tuple> {
         // () < NaN < values, 'empty greatest' orders values < NaN < (). Java's total order
         // (NaN greater than everything) silently produced the wrong order under 'empty least'
         // (the compiler default).
-        final boolean lNaN = isNaN(lAtomic);
-        final boolean rNaN = isNaN(rAtomic);
+        final boolean lNaN = AbstractNumeric.isNaN(lAtomic);
+        final boolean rNaN = AbstractNumeric.isNaN(rAtomic);
         if (lNaN || rNaN) {
           if (lNaN && rNaN) {
             continue; // NaN equals NaN for ordering purposes — next orderspec
@@ -163,13 +164,6 @@ public class Ordering implements Comparator<Tuple> {
         throw new RuntimeException(e);
       }
     }
-  }
-
-  private static boolean isNaN(Atomic a) {
-    // Only doubles/floats can be NaN — dispatch on those interfaces first so the hot
-    // comparator path never pays Int/Dec doubleValue() conversions.
-    return (a instanceof io.brackit.query.atomic.DblNumeric || a instanceof io.brackit.query.atomic.FltNumeric)
-        && Double.isNaN(((io.brackit.query.atomic.Numeric) a).doubleValue());
   }
 
   public void clear() {


### PR DESCRIPTION
Follow-up cleanup to #97 — no behavior changes, full suite **1104/0**.

- `AbstractTimeInstant.yearString` / `fractionalSecondsString`: the BCE year padding and fraction rendering were pasted in 4 and 3 places respectively; the fraction helper also drops the per-call `String.format` + regex `replaceAll`.
- `AbstractNumeric.isNaN`: single home for the interface-first NaN dispatch (was duplicated in `Ordering` and `MinMaxAggregator`).
- `AbstractTimeInstant.cmp`: equal-offset short-circuit — both-UTC comparisons (the common case) skip two `DateTime` + `canonicalize` allocations per comparison; differing offsets still normalize.
- `Regex.adaptRegEx`: single carry-over chokepoint replaces six scattered per-branch re-appends.
- `QueryException.fromFnError` factory replaces the dead `boolean fromError` disambiguation flag.