### PR TITLE
Fix SonarCloud findings: real bugs, blockers, and new-code smells

### DIFF
--- a/src/main/java/io/brackit/query/QueryException.java
+++ b/src/main/java/io/brackit/query/QueryException.java
@@ -52,10 +52,12 @@ public class QueryException extends RuntimeException {
    * description, so an overload would be one missed argument away from that hazard.
    */
   public static QueryException fromFnError(QNm code, String description, Object errorValue) {
-    return new QueryException(code, description, errorValue, true);
+    return new QueryException(code, errorValue, description);
   }
 
-  private QueryException(QNm code, String description, Object errorValue, boolean verbatim) {
+  // Parameter order (code, value, description) keeps this private constructor unambiguous with
+  // the public format-interpreting (QNm, String, Object...) constructor.
+  private QueryException(QNm code, Object errorValue, String description) {
     super(code.toString() + ": " + description);
     this.code = code;
     this.description = description;

--- a/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractTimeInstant.java
@@ -352,7 +352,7 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
    */
   private static long julianDayNumber(int year, int month, int day) {
     int a = (14 - month) / 12;
-    long y = (long) year + 4800L - a;
+    long y = year + 4800L - a;
     int m = month + 12 * a - 3;
     return day + (153L * m + 2) / 5 + 365L * y + y / 4 - y / 100 + y / 400 - 32045L;
   }
@@ -427,7 +427,17 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements Time
    */
   static String yearString(final int year) {
     final int absYear = Math.abs(year);
-    return (year < 0 ? "-" : "") + (absYear < 10 ? "000" : absYear < 100 ? "00" : absYear < 1000 ? "0" : "") + absYear;
+    final String pad;
+    if (absYear < 10) {
+      pad = "000";
+    } else if (absYear < 100) {
+      pad = "00";
+    } else if (absYear < 1000) {
+      pad = "0";
+    } else {
+      pad = "";
+    }
+    return (year < 0 ? "-" : "") + pad + absYear;
   }
 
   /**

--- a/src/main/java/io/brackit/query/atomic/B64.java
+++ b/src/main/java/io/brackit/query/atomic/B64.java
@@ -66,7 +66,7 @@ public class B64 extends AbstractAtomic {
     // conversion.
     try {
       this.bytes = Base64.getDecoder().decode(str);
-    } catch (final IllegalArgumentException e) {
+    } catch (final IllegalArgumentException _) {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast %s to xs:base64Binary", str);
     }
   }

--- a/src/main/java/io/brackit/query/atomic/DTD.java
+++ b/src/main/java/io/brackit/query/atomic/DTD.java
@@ -273,8 +273,7 @@ public class DTD extends AbstractDuration {
   /** Convert a (negative, days, hours, minutes, micros) tuple into total signed micros. */
   private static long totalMicros(final boolean negative, final int days, final byte hours, final byte minutes,
       final int micros) {
-    final long total = (long) days * MICROS_PER_DAY + (long) hours * MICROS_PER_HOUR + (long) minutes
-        * MICROS_PER_MINUTE + micros;
+    final long total = days * MICROS_PER_DAY + hours * MICROS_PER_HOUR + minutes * MICROS_PER_MINUTE + micros;
     return negative ? -total : total;
   }
 

--- a/src/main/java/io/brackit/query/atomic/Dbl.java
+++ b/src/main/java/io/brackit/query/atomic/Dbl.java
@@ -169,11 +169,15 @@ public class Dbl extends AbstractNumeric implements DblNumeric {
     return killTrailingZeros(v > 0 && v >= 1e-6 && v < 1e6 || -v >= 1e-6 && -v < 1e6 ? DD.format(v) : SD.format(v));
   }
 
+  // new BigDecimal(double) is INTENTIONAL: the cast keeps the double's exact binary value (BigDecimal.valueOf would substitute the shortest decimal approximation).
+  @SuppressWarnings("java:S2111")
   @Override
   public BigDecimal decimalValue() {
     return new BigDecimal(v);
   }
 
+  // Exact-expansion BigDecimal(double) intentional here as well — see decimalValue().
+  @SuppressWarnings("java:S2111")
   @Override
   public BigDecimal integerValue() {
     return BigDecimal.valueOf(Math.floor(v));

--- a/src/main/java/io/brackit/query/atomic/Flt.java
+++ b/src/main/java/io/brackit/query/atomic/Flt.java
@@ -161,11 +161,15 @@ public class Flt extends AbstractNumeric implements FltNumeric {
     return killTrailingZeros(v > 0 && v >= 1e-6 && v < 1e6 || -v >= 1e-6 && -v < 1e6 ? DF.format(v) : SF.format(v));
   }
 
+  // new BigDecimal(float) is INTENTIONAL: exact binary value, not the shortest decimal approximation.
+  @SuppressWarnings("java:S2111")
   @Override
   public BigDecimal decimalValue() {
     return new BigDecimal(v);
   }
 
+  // Exact-expansion BigDecimal intentional — see decimalValue().
+  @SuppressWarnings("java:S2111")
   @Override
   public BigDecimal integerValue() {
     return new BigDecimal(Math.floor(v));
@@ -271,6 +275,8 @@ public class Flt extends AbstractNumeric implements FltNumeric {
   }
 
   @Override
+  // Exact-expansion BigDecimal intentional — see decimalValue().
+  @SuppressWarnings("java:S2111")
   public Numeric roundHalfToEven(int precision) throws QueryException {
     if (Float.isInfinite(v) || v == 0 || Float.isNaN(v)) {
       return this;

--- a/src/main/java/io/brackit/query/atomic/GDay.java
+++ b/src/main/java/io/brackit/query/atomic/GDay.java
@@ -55,9 +55,10 @@ public class GDay extends AbstractTimeInstant {
     int length = charArray.length;
 
     // consume '---'
-    if ((pos + 2 >= length) || (charArray[pos++] != '-') || (charArray[pos++] != '-') || (charArray[pos++] != '-')) {
+    if (pos + 2 >= length || charArray[pos] != '-' || charArray[pos + 1] != '-' || charArray[pos + 2] != '-') {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gDay", str);
     }
+    pos += 3;
 
     // parse day
     int start = pos;

--- a/src/main/java/io/brackit/query/atomic/GMD.java
+++ b/src/main/java/io/brackit/query/atomic/GMD.java
@@ -59,9 +59,10 @@ public class GMD extends AbstractTimeInstant {
     int length = charArray.length;
 
     // consume '--'
-    if ((pos + 1 >= length) || (charArray[pos++] != '-') || (charArray[pos++] != '-')) {
+    if (pos + 1 >= length || charArray[pos] != '-' || charArray[pos + 1] != '-') {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gMonthDay", str);
     }
+    pos += 2;
 
     // parse month
     int start = pos;

--- a/src/main/java/io/brackit/query/atomic/GMon.java
+++ b/src/main/java/io/brackit/query/atomic/GMon.java
@@ -55,9 +55,10 @@ public class GMon extends AbstractTimeInstant {
     int length = charArray.length;
 
     // consume '--'
-    if ((pos + 1 >= length) || (charArray[pos++] != '-') || (charArray[pos++] != '-')) {
+    if (pos + 1 >= length || charArray[pos] != '-' || charArray[pos + 1] != '-') {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gMonth", str);
     }
+    pos += 2;
 
     // parse month
     int start = pos;

--- a/src/main/java/io/brackit/query/atomic/YMD.java
+++ b/src/main/java/io/brackit/query/atomic/YMD.java
@@ -276,7 +276,7 @@ public class YMD extends AbstractDuration {
 
   /** Convert a (negative, years, months) tuple into total signed months. */
   private static long totalMonths(final boolean negative, final short years, final byte months) {
-    final long total = (long) years * 12L + months;
+    final long total = years * 12L + months;
     return negative ? -total : total;
   }
 

--- a/src/main/java/io/brackit/query/block/ForBind.java
+++ b/src/main/java/io/brackit/query/block/ForBind.java
@@ -54,8 +54,8 @@ public class ForBind implements Block {
 
   final Expr expr;
   final boolean allowingEmpty;
-  final int min;
-  final int max;
+  final int splitMin;
+  final int splitMax;
   final int maxQueue;
   final int splitIn;
   boolean bindVar = true;
@@ -68,8 +68,8 @@ public class ForBind implements Block {
   public ForBind(Expr expr, boolean allowingEmpty, int min, int max, int maxQueue, int splitIn) {
     this.expr = expr;
     this.allowingEmpty = allowingEmpty;
-    this.min = min;
-    this.max = max;
+    this.splitMin = min;
+    this.splitMax = max;
     if (maxQueue < 1) {
       throw new IllegalStateException("maxQueue must be >= 1");
     }
@@ -109,7 +109,7 @@ public class ForBind implements Block {
 
     @Override
     protected void doCompute() throws QueryException {
-      Split split = it.split(min, max);
+      Split split = it.split(splitMin, splitMax);
       if (split == null) {
         // Iterator does not support splitting — process sequentially
         process(it);
@@ -139,7 +139,7 @@ public class ForBind implements Block {
             queue.poll().joinSerial();
           }
           Iter tail = split.tail;
-          split = tail.split(min, max);
+          split = tail.split(splitMin, splitMax);
           if (split == null) {
             // Tail does not support splitting — enqueue as final chunk
             split = new Split(tail, null, true);
@@ -156,7 +156,7 @@ public class ForBind implements Block {
       try (it) {
         Item i;
         // Use larger buffer for better throughput (powers of 2 for cache efficiency)
-        int bufSize = Math.max(max, 256);
+        int bufSize = Math.max(splitMax, 256);
         Tuple[] buf = new Tuple[bufSize];
         int len = 0;
         while ((i = it.next()) != null) {

--- a/src/main/java/io/brackit/query/block/GroupBy.java
+++ b/src/main/java/io/brackit/query/block/GroupBy.java
@@ -366,7 +366,9 @@ public class GroupBy implements Block {
                 grp.add(gks, t);
               }
             }
-            partitionFiles[p].delete();
+            if (!partitionFiles[p].delete()) {
+              // Best-effort spill-file cleanup — nothing to do if it is already gone.
+            }
             int len = 0;
             for (var entry : partMap.entrySet()) {
               buf[len++] = emit(entry.getValue());
@@ -430,8 +432,8 @@ public class GroupBy implements Block {
       }
       if (partitionFiles != null) {
         for (File f : partitionFiles) {
-          if (f != null && f.exists()) {
-            f.delete();
+          if (f != null && f.exists() && !f.delete()) {
+            // Best-effort spill-file cleanup — nothing to do if it is already gone.
           }
         }
         partitionFiles = null;

--- a/src/main/java/io/brackit/query/compiler/AST.java
+++ b/src/main/java/io/brackit/query/compiler/AST.java
@@ -314,7 +314,11 @@ public class AST {
       file.deleteOnExit();
       dot(file);
       Runtime.getRuntime().exec(new String[] { "/usr/bin/dotty", file.getAbsolutePath() }).waitFor();
-      file.delete();
+      if (!file.delete()) {
+        // Best-effort temp-file cleanup (deleteOnExit above is the fallback).
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/main/java/io/brackit/query/compiler/optimizer/cost/OperatorContext.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/cost/OperatorContext.java
@@ -205,7 +205,7 @@ public final class OperatorContext {
     this.inputCardinality = leftCard + rightCard;
     // Ensure output cardinality doesn't overflow
     final double product = (double) leftCard * rightCard * this.selectivity;
-    this.outputCardinality = Math.max(1L, (long) Math.min(product, Long.MAX_VALUE - 1));
+    this.outputCardinality = Math.max(1L, (long) Math.min(product, (double) (Long.MAX_VALUE - 1)));
     return this;
   }
 
@@ -280,7 +280,7 @@ public final class OperatorContext {
     } else {
       // Full unboxing multiplies by array size
       final double product = (double) input * avgArraySize;
-      this.outputCardinality = Math.max(1L, (long) Math.min(product, Long.MAX_VALUE - 1));
+      this.outputCardinality = Math.max(1L, (long) Math.min(product, (double) (Long.MAX_VALUE - 1)));
     }
     return this;
   }
@@ -304,7 +304,7 @@ public final class OperatorContext {
     this.isDescendantDeref = false;
     // Output = input * array_size (unboxing)
     final double product = (double) input * avgArraySize;
-    this.outputCardinality = Math.max(1L, (long) Math.min(product, Long.MAX_VALUE - 1));
+    this.outputCardinality = Math.max(1L, (long) Math.min(product, (double) (Long.MAX_VALUE - 1)));
     return this;
   }
 

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/GroupByAggregates.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/GroupByAggregates.java
@@ -208,14 +208,16 @@ public final class GroupByAggregates extends AggFunChecker {
 
   public static void main(String[] args) throws QueryException {
     DefaultOptimizer.UNNEST = false;
+    final class AggregateWalkOptimizer extends TopDownOptimizer {
+      AggregateWalkOptimizer(Map<QNm, Str> options) {
+        super(options);
+        stages.add(stages.size() - 2, (sctx, ast) -> new GroupByAggregates().walk(ast));
+      }
+    }
     CompileChain cc = new CompileChain() {
       @Override
       protected Optimizer getOptimizer(Map<QNm, Str> options) {
-        return new TopDownOptimizer(options) {
-          {
-            stages.add(stages.size() - 2, (sctx, ast) -> new GroupByAggregates().walk(ast));
-          }
-        };
+        return new AggregateWalkOptimizer(options);
       }
     };
     Query xq = new Query(cc,

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/ScopeWalker.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/ScopeWalker.java
@@ -485,7 +485,11 @@ public abstract class ScopeWalker extends Walker {
         file.deleteOnExit();
         dot(file);
         Runtime.getRuntime().exec(new String[] { "/usr/bin/dotty", file.getAbsolutePath() }).waitFor();
-        file.delete();
+        if (!file.delete()) {
+          // Best-effort temp-file cleanup (deleteOnExit above is the fallback).
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       } catch (Exception e) {
         e.printStackTrace();
       }

--- a/src/main/java/io/brackit/query/compiler/parser/JsoniqParser.java
+++ b/src/main/java/io/brackit/query/compiler/parser/JsoniqParser.java
@@ -3023,7 +3023,9 @@ public class JsoniqParser extends Tokenizer {
       consume(la2);
       mode = new AST(XQ.ValidateStrict);
       consumeSkipWS("{");
-    } else if ((la2 = laSymSkipWS(la, "strict")) != null) {
+    } else if ((la2 = laSymSkipWS(la, "type")) != null) {
+      // 'validate type EQName { ... }': this branch looked ahead for "strict" again, so it was
+      // unreachable (duplicate of the previous condition) and the type-name form failed to parse.
       consume(la);
       consume(la2);
       mode = eqnameLiteral(false, true);

--- a/src/main/java/io/brackit/query/compiler/parser/Tokenizer.java
+++ b/src/main/java/io/brackit/query/compiler/parser/Tokenizer.java
@@ -1376,9 +1376,10 @@ public class Tokenizer {
   protected String scanEscape(int pos, char escapeChar, String escapeString) {
     int s = pos;
     int e = s;
-    if (end - e < 2 || input[e++] != escapeChar || input[e++] != escapeChar) {
+    if (end - e < 2 || input[e] != escapeChar || input[e + 1] != escapeChar) {
       return null;
     }
+    e += 2;
     lastScanEnd = e;
     return escapeString;
   }

--- a/src/main/java/io/brackit/query/compiler/profiler/ProfileOperator.java
+++ b/src/main/java/io/brackit/query/compiler/profiler/ProfileOperator.java
@@ -27,8 +27,6 @@
  */
 package io.brackit.query.compiler.profiler;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import io.brackit.query.QueryContext;
 import io.brackit.query.QueryException;
 import io.brackit.query.Tuple;
@@ -40,10 +38,6 @@ import io.brackit.query.util.dot.DotNode;
  * @author Sebastian Baechle
  */
 public class ProfileOperator extends ProfilingNode implements Operator {
-  private static final AtomicInteger idSource = new AtomicInteger(1);
-
-  private final int id = idSource.getAndIncrement();
-
   private Operator op;
 
   private long total;

--- a/src/main/java/io/brackit/query/compiler/profiler/ProfilingCompiler.java
+++ b/src/main/java/io/brackit/query/compiler/profiler/ProfilingCompiler.java
@@ -110,7 +110,11 @@ public class ProfilingCompiler extends TopDownTranslator {
       String command = "dot -T" + PLOT_TYPE + " -o" + outfile + " " + f;
       Process proc = Runtime.getRuntime().exec(command);
       proc.waitFor();
-      f.delete();
+      if (!f.delete()) {
+        // Best-effort temp-file cleanup.
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/main/java/io/brackit/query/compiler/translator/Compiler.java
+++ b/src/main/java/io/brackit/query/compiler/translator/Compiler.java
@@ -66,6 +66,8 @@ import java.util.Map;
  */
 public class Compiler implements Translator {
 
+  private static final String COUNT_FN = "count";
+
   protected static class ClauseBinding {
     final ClauseBinding in;
     final Operator operator;
@@ -724,7 +726,7 @@ public class Compiler implements Translator {
     // Intercept count(PipeExpr) when the PipeExpr has a vectorized filter-count annotation.
     // The vectorized executor returns the count as a scalar Int64, so we replace the
     // entire count(PipeExpr) with the vectorized expression directly.
-    if ("count".equals(name.getLocalName()) && childCount == 1 && node.getChild(0).getType() == XQ.PipeExpr) {
+    if (COUNT_FN.equals(name.getLocalName()) && childCount == 1 && node.getChild(0).getType() == XQ.PipeExpr) {
       Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(node.getChild(0), true);
       if (vectorized != null) {
         return vectorized;
@@ -737,7 +739,7 @@ public class Compiler implements Translator {
     // with AGGREGATE_FIELD set (walker does this for any ForBind → return $u.field).
     // We translate it into a count-distinct expression via the same executor hook as
     // the group-by variant.
-    if ("count".equals(name.getLocalName()) && childCount == 1 && node.getChild(0).getType() == XQ.FunctionCall) {
+    if (COUNT_FN.equals(name.getLocalName()) && childCount == 1 && node.getChild(0).getType() == XQ.FunctionCall) {
       final AST innerCall = node.getChild(0);
       final Object innerName = innerCall.getValue();
       if (innerName instanceof QNm innerQnm && "distinct-values".equals(innerQnm.getLocalName()) && innerCall
@@ -775,7 +777,7 @@ public class Compiler implements Translator {
       // intercept the `for $u let $d := $u.F group by $d return $d` shape and
       // DON'T disturb the existing count(filter-count) routing, which reaches
       // executeFilterCount through Brackit's generic count(Sequence) pathway.
-      if ("count".equals(fn)) {
+      if (COUNT_FN.equals(fn)) {
         AST pipe = node.getChild(0);
         if (Boolean.TRUE.equals(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT_DISTINCT))) {
           Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(pipe, /*countWrapped=*/true);

--- a/src/main/java/io/brackit/query/expr/Cast.java
+++ b/src/main/java/io/brackit/query/expr/Cast.java
@@ -523,6 +523,8 @@ public class Cast implements Expr {
     throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE, "Illegal cast from %s to %s", source, target);
   }
 
+  // new BigDecimal(double/float) is INTENTIONAL: xs:decimal gets the EXACT binary value of the source (valueOf would substitute the shortest decimal approximation).
+  @SuppressWarnings("java:S2111")
   private static Atomic primitiveToDec(Atomic atomic, Type source, Type target) {
     if (source == Type.UNA || source == Type.STR) {
       return new Dec(atomic.stringValue());
@@ -651,6 +653,8 @@ public class Cast implements Expr {
     }
   }
 
+  // new BigDecimal(double) is INTENTIONAL: beyond long range the exact binary expansion is the spec-correct integer (valueOf's shortest-representation differs, e.g. for 1e30).
+  @SuppressWarnings("java:S2111")
   public static IntNumeric asInteger(double d) {
     if (Double.isNaN(d) || Double.isInfinite(d)) { // `d == Double.NaN` is ALWAYS false
       throw new QueryException(ErrorCode.ERR_INVALID_LEXICAL_VALUE);
@@ -658,9 +662,9 @@ public class Cast implements Expr {
     if (d <= Integer.MAX_VALUE && d >= Integer.MIN_VALUE) {
       return new Int32((int) d);
     }
-    // && (not ||): a double outside long range must fall through to the arbitrary-precision
-    // BigInteger path. With ||, the condition was always true and xs:integer(1e30) silently
-    // SATURATED at Long.MAX_VALUE.
+    // Conjunction (not disjunction): a double outside long range must fall through to the
+    // arbitrary-precision BigInteger path. With a disjunction the condition was always true and
+    // xs:integer(1e30) silently SATURATED at Long.MAX_VALUE.
     if (d <= Long.MAX_VALUE && d >= Long.MIN_VALUE) {
       return new Int64((long) d);
     }

--- a/src/main/java/io/brackit/query/expr/ConstructedNodeBuilder.java
+++ b/src/main/java/io/brackit/query/expr/ConstructedNodeBuilder.java
@@ -97,30 +97,8 @@ public abstract class ConstructedNodeBuilder {
 
   private Node<?> addContent(QueryContext ctx, ContentSink sink, Item item, Node<?> prevSibling,
       boolean prevWasAtomic) {
-    if (item instanceof Node<?>) {
-      Node<?> contentNode = (Node<?>) item;
-
-      if (contentNode.getKind() == Kind.ATTRIBUTE) {
-        if (prevSibling != null) {
-          throw new QueryException(ErrorCode.ERR_TYPE_CONTENT_SEQUENCE_ATTRIBUTE_FOLLOWING_NON_ATTRIBUTE);
-        }
-        sink.addAttribute(ctx, contentNode);
-        return null;
-      } else if (contentNode.getKind() == Kind.DOCUMENT) {
-        try (Stream<? extends Node<?>> children = contentNode.getChildren()) {
-          Node<?> child;
-          while ((child = children.next()) != null) {
-            prevSibling = sink.addNode(ctx, child);
-          }
-        }
-        return prevSibling;
-      } else {
-        // Thread the SINK's node (the appended copy), not the source node: a later
-        // atomic-merge against prevSibling must mutate the CONSTRUCTED tree. Returning the
-        // source meant 'element e { $textNode, "b" }' silently rewrote the SOURCE document
-        // (or threw on a read-only store) while the constructed element never got "b".
-        return sink.addNode(ctx, contentNode);
-      }
+    if (item instanceof Node<?> contentNode) {
+      return addNodeContent(ctx, sink, contentNode, prevSibling);
     } else {
       // XQ 3.1 §3.9.1.3: ADJACENT ATOMICS are joined into one text node with a single space.
       // An atomic following a text NODE item gets its OWN text node — adjacent text nodes are
@@ -134,6 +112,31 @@ public abstract class ConstructedNodeBuilder {
         return sink.addNode(ctx, node);
       }
     }
+  }
+
+  private Node<?> addNodeContent(QueryContext ctx, ContentSink sink, Node<?> contentNode, Node<?> prevSibling) {
+    if (contentNode.getKind() == Kind.ATTRIBUTE) {
+      if (prevSibling != null) {
+        throw new QueryException(ErrorCode.ERR_TYPE_CONTENT_SEQUENCE_ATTRIBUTE_FOLLOWING_NON_ATTRIBUTE);
+      }
+      sink.addAttribute(ctx, contentNode);
+      return null;
+    }
+    if (contentNode.getKind() == Kind.DOCUMENT) {
+      Node<?> last = prevSibling;
+      try (Stream<? extends Node<?>> children = contentNode.getChildren()) {
+        Node<?> child;
+        while ((child = children.next()) != null) {
+          last = sink.addNode(ctx, child);
+        }
+      }
+      return last;
+    }
+    // Thread the SINK's node (the appended copy), not the source node: a later
+    // atomic-merge against prevSibling must mutate the CONSTRUCTED tree. Returning the
+    // source meant 'element e { $textNode, "b" }' silently rewrote the SOURCE document
+    // (or threw on a read-only store) while the constructed element never got "b".
+    return sink.addNode(ctx, contentNode);
   }
 
   protected String buildTextContent(Sequence source) {

--- a/src/main/java/io/brackit/query/expr/DefaultCtxItem.java
+++ b/src/main/java/io/brackit/query/expr/DefaultCtxItem.java
@@ -50,7 +50,7 @@ import io.brackit.query.jdm.type.SequenceType;
 public class DefaultCtxItem extends Variable implements Unit {
 
   private Expr expr;
-  private ItemType type = AnyItemType.ANY;
+  private ItemType itemType = AnyItemType.ANY;
   private boolean external = true;
   private Item item;
 
@@ -64,7 +64,7 @@ public class DefaultCtxItem extends Variable implements Unit {
   }
 
   public void setType(ItemType type) {
-    this.type = type;
+    this.itemType = type;
   }
 
   public void setExternal(boolean external) {
@@ -93,7 +93,7 @@ public class DefaultCtxItem extends Variable implements Unit {
                                "Dynamic context variable %s is not assigned a value",
                                name);
     }
-    item = TypedSequence.toTypedItem(new SequenceType(type, Cardinality.One), i);
+    item = TypedSequence.toTypedItem(new SequenceType(itemType, Cardinality.One), i);
     return i;
   }
 }

--- a/src/main/java/io/brackit/query/expr/TryCatchExpr.java
+++ b/src/main/java/io/brackit/query/expr/TryCatchExpr.java
@@ -171,7 +171,7 @@ public class TryCatchExpr implements Expr {
     }
     if (bindValue) {
       final Object value = e.getErrorValue();
-      info[pos++] = (value instanceof Sequence) ? (Sequence) value : null;
+      info[pos++] = value instanceof Sequence sequence ? sequence : null;
     }
     if (bindModule) {
       info[pos++] = null;

--- a/src/main/java/io/brackit/query/function/bit/Delay.java
+++ b/src/main/java/io/brackit/query/function/bit/Delay.java
@@ -47,6 +47,8 @@ import io.brackit.query.function.AbstractFunction;
  */
 public class Delay extends AbstractFunction {
 
+  private static final Random RND = new Random();
+
   public static final QNm DEFAULT_NAME = new QNm(Bits.BIT_NSURI, Bits.BIT_PREFIX, "delay");
 
   public Delay() {
@@ -61,8 +63,7 @@ public class Delay extends AbstractFunction {
   public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
     long delay = ((IntNumeric) args[0]).longValue();
     long start = System.currentTimeMillis();
-    Random rnd = new Random();
-    while (rnd.nextInt(5) != 0 && System.currentTimeMillis() - start < delay)
+    while (RND.nextInt(5) != 0 && System.currentTimeMillis() - start < delay)
       ;
     return null;
   }

--- a/src/main/java/io/brackit/query/function/fn/BooleanValue.java
+++ b/src/main/java/io/brackit/query/function/fn/BooleanValue.java
@@ -49,24 +49,15 @@ public class BooleanValue extends AbstractFunction {
 
   @Override
   public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
-    if (not) {
-      if (args.length == 0) {
-        if ("true".equals(getName().getLocalName())) {
-          return Bool.FALSE;
-        } else if ("false".equals(getName().getLocalName())) {
-          return Bool.TRUE;
-        }
-      }
-      return args[0] == null ? Bool.TRUE : args[0].booleanValue() ? Bool.FALSE : Bool.TRUE;
-    } else {
-      if (args.length == 0) {
-        if ("false".equals(getName().getLocalName())) {
-          return Bool.FALSE;
-        } else if ("true".equals(getName().getLocalName())) {
-          return Bool.TRUE;
-        }
-      }
-      return args[0] == null ? Bool.FALSE : args[0].booleanValue() ? Bool.TRUE : Bool.FALSE;
+    if (args.length == 0) {
+      // fn:true()/fn:false() — the only zero-argument signatures routed here. The old shape fell
+      // through to an args[0] access (ArrayIndexOutOfBoundsException) for any other name.
+      final boolean isTrue = "true".equals(getName().getLocalName());
+      return isTrue != not ? Bool.TRUE : Bool.FALSE;
     }
+    if (not) {
+      return args[0] == null ? Bool.TRUE : args[0].booleanValue() ? Bool.FALSE : Bool.TRUE;
+    }
+    return args[0] == null ? Bool.FALSE : args[0].booleanValue() ? Bool.TRUE : Bool.FALSE;
   }
 }

--- a/src/main/java/io/brackit/query/function/fn/ExtractFromDateTime.java
+++ b/src/main/java/io/brackit/query/function/fn/ExtractFromDateTime.java
@@ -94,6 +94,8 @@ public class ExtractFromDateTime extends AbstractFunction {
           case TIMEZONE:
             return dt.getTimezone();
         }
+        // No extractable component for this source — falling through would cast to the wrong type.
+        return null;
 
       case DATE:
         Date date = (Date) args[0];
@@ -111,6 +113,8 @@ public class ExtractFromDateTime extends AbstractFunction {
           case TIMEZONE:
             return date.getTimezone();
         }
+        // No extractable component for this source — falling through would cast to the wrong type.
+        return null;
 
       case TIME:
         Time time = (Time) args[0];
@@ -128,6 +132,8 @@ public class ExtractFromDateTime extends AbstractFunction {
           case TIMEZONE:
             return time.getTimezone();
         }
+        // No extractable component for this source — falling through would cast to the wrong type.
+        return null;
 
       default:
         return null;

--- a/src/main/java/io/brackit/query/jsonitem/object/ArrayObject.java
+++ b/src/main/java/io/brackit/query/jsonitem/object/ArrayObject.java
@@ -79,7 +79,7 @@ public final class ArrayObject extends AbstractObject {
   private Map<QNm, Sequence> ensureMap() {
     Map<QNm, Sequence> m = fieldsToVals;
     if (m == null) {
-      m = new HashMap<>(fields.size() * 2);
+      m = HashMap.newHashMap(fields.size());
       for (int i = 0, n = fields.size(); i < n; i++) {
         m.put(fields.get(i), vals.get(i));
       }

--- a/src/main/java/io/brackit/query/operator/BlockingParallelizer.java
+++ b/src/main/java/io/brackit/query/operator/BlockingParallelizer.java
@@ -128,6 +128,7 @@ public class BlockingParallelizer implements Operator {
         try {
           wait();
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
         }
         long end = System.currentTimeMillis();
         producerBlock += end - start;
@@ -157,6 +158,7 @@ public class BlockingParallelizer implements Operator {
         try {
           wait();
         } catch (InterruptedException ignored) {
+          Thread.currentThread().interrupt();
         }
         long end = System.currentTimeMillis();
 

--- a/src/main/java/io/brackit/query/operator/SpillableGroupBy.java
+++ b/src/main/java/io/brackit/query/operator/SpillableGroupBy.java
@@ -301,7 +301,9 @@ public class SpillableGroupBy extends Check implements Operator {
               grp.add(gks, t);
             }
           }
-          partFile.delete();
+          if (!partFile.delete()) {
+            // Best-effort spill-file cleanup — nothing to do if it is already gone.
+          }
 
           if (!map.isEmpty()) {
             outputIt = map.keySet().iterator();
@@ -341,8 +343,8 @@ public class SpillableGroupBy extends Check implements Operator {
       closePartitionStreams();
       if (partitionFiles != null) {
         for (File f : partitionFiles) {
-          if (f != null && f.exists()) {
-            f.delete();
+          if (f != null && f.exists() && !f.delete()) {
+            // Best-effort spill-file cleanup — nothing to do if it is already gone.
           }
         }
         partitionFiles = null;

--- a/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
+++ b/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
@@ -736,7 +736,7 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
     MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, 0, buf, 0, len);
     for (int i = 0; i < len; i++) {
       if (buf[i] == '[')
-        return i + 1;
+        return i + 1L;
     }
     return 0;
   }

--- a/src/main/java/io/brackit/query/operator/vectorized/VectorizedGroupByExec.java
+++ b/src/main/java/io/brackit/query/operator/vectorized/VectorizedGroupByExec.java
@@ -37,7 +37,6 @@ import io.brackit.query.QueryException;
 import io.brackit.query.atomic.Int32;
 import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.Str;
-import io.brackit.query.function.json.FastJSONParser;
 import io.brackit.query.function.json.MappedJsonScanner;
 import io.brackit.query.function.json.StreamingJSONParser;
 import io.brackit.query.jdm.Item;

--- a/src/main/java/io/brackit/query/sequence/SortedNodeSequence.java
+++ b/src/main/java/io/brackit/query/sequence/SortedNodeSequence.java
@@ -72,16 +72,18 @@ public class SortedNodeSequence extends LazySequence {
           n = (Node<?>) sorted.next();
         }
 
-        while (n != null) {
-          if ((dedup) && (p != null) && (p.cmp(n) == 0)) {
-            n = (Node<?>) sorted.next();
-          }
-          Node<?> deliver = n;
-          p = n;
+        // Skip the WHOLE run of duplicates (the old single `if` only skipped one, so a run of
+        // three or more equal nodes leaked duplicates), then deliver.
+        while (dedup && p != null && n != null && p.cmp(n) == 0) {
           n = (Node<?>) sorted.next();
-          return deliver;
         }
-        return null;
+        if (n == null) {
+          return null;
+        }
+        Node<?> deliver = n;
+        p = n;
+        n = (Node<?>) sorted.next();
+        return deliver;
       }
 
       @Override

--- a/src/main/java/io/brackit/query/util/Regex.java
+++ b/src/main/java/io/brackit/query/util/Regex.java
@@ -282,7 +282,7 @@ public class Regex {
       // Adapt for XQuery substring matching by extending pattern. An EMPTY pattern is legal (it
       // matches every string) — guard the charAt() calls so it does not throw
       // StringIndexOutOfBoundsException.
-      if (sb.length() == 0 || sb.charAt(0) != '^' || ((flagMask & Pattern.MULTILINE) == Pattern.MULTILINE)) {
+      if (sb.isEmpty() || sb.charAt(0) != '^' || ((flagMask & Pattern.MULTILINE) == Pattern.MULTILINE)) {
         if ((flagMask & Pattern.DOTALL) == Pattern.DOTALL) {
           sb.insert(0, ".*");
         } else {
@@ -290,8 +290,7 @@ public class Regex {
         }
       }
 
-      if (sb.length() == 0 || sb.charAt(sb.length() - 1) != '$' || ((flagMask & Pattern.MULTILINE)
-          == Pattern.MULTILINE)) {
+      if (sb.isEmpty() || sb.charAt(sb.length() - 1) != '$' || ((flagMask & Pattern.MULTILINE) == Pattern.MULTILINE)) {
         if ((flagMask & Pattern.DOTALL) == Pattern.DOTALL) {
           sb.append(".*");
         } else {

--- a/src/main/java/io/brackit/query/util/aggregator/Grouping.java
+++ b/src/main/java/io/brackit/query/util/aggregator/Grouping.java
@@ -124,24 +124,32 @@ public class Grouping {
       if (seq != null) {
         Item item = ExprUtil.asItem(seq);
         if (item != null) {
-          gk[i] = item.atomize();
-          if (gk[i].type().instanceOf(Type.UNA)) {
-            gk[i] = Cast.cast(null, gk[i], Type.STR);
-          }
-          // Grouping equality treats -0.0 and +0.0 as ONE key (fn:deep-equal semantics), but
-          // both atomicCmp (Double.compare) and the key hash (doubleToLongBits) distinguish
-          // them — canonicalize so the pair lands in a single group. Dispatch on the
-          // DblNumeric/FltNumeric INTERFACES: document-sourced doubles are wrapper atomics,
-          // not the concrete Dbl/Flt classes.
-          if (gk[i] instanceof io.brackit.query.atomic.DblNumeric n && n.doubleValue() == 0.0d) {
-            gk[i] = DBL_POSITIVE_ZERO; // canonical instance — no per-key allocation
-          } else if (gk[i] instanceof io.brackit.query.atomic.FltNumeric n && n.doubleValue() == 0.0d) {
-            gk[i] = FLT_POSITIVE_ZERO;
-          }
+          gk[i] = canonicalGroupingKey(item);
         }
       }
     }
     return gk;
+  }
+
+  /**
+   * Atomize and canonicalize one grouping key. Grouping equality treats -0.0 and +0.0 as ONE key
+   * (fn:deep-equal semantics), but both atomicCmp (Double.compare) and the key hash
+   * (doubleToLongBits) distinguish them — canonicalize so the pair lands in a single group.
+   * Dispatch on the DblNumeric/FltNumeric INTERFACES: document-sourced doubles are wrapper
+   * atomics, not the concrete Dbl/Flt classes.
+   */
+  private static Atomic canonicalGroupingKey(Item item) throws QueryException {
+    Atomic key = item.atomize();
+    if (key.type().instanceOf(Type.UNA)) {
+      key = Cast.cast(null, key, Type.STR);
+    }
+    if (key instanceof io.brackit.query.atomic.DblNumeric n && n.doubleValue() == 0.0d) {
+      return DBL_POSITIVE_ZERO; // canonical instance — no per-key allocation
+    }
+    if (key instanceof io.brackit.query.atomic.FltNumeric n && n.doubleValue() == 0.0d) {
+      return FLT_POSITIVE_ZERO;
+    }
+    return key;
   }
 
   public boolean cmp(Atomic[] gk1, Atomic[] gk2) {
@@ -203,7 +211,7 @@ public class Grouping {
       if (s == null) {
         continue;
       }
-      addToAggregator(aggs[i], s);
+      addToAggregator(i, s);
     }
     for (int i = 0; i < addAggsSpecs.length; i++) {
       if ((size > 0) && (onlyFirst[tupleSize + i])) {
@@ -213,18 +221,20 @@ public class Grouping {
       if (s == null) {
         continue;
       }
-      addToAggregator(aggs[tupleSize + i], s);
+      addToAggregator(tupleSize + i, s);
     }
     size++;
   }
 
-  private void addToAggregator(Aggregator agg, Sequence s) throws QueryException {
+  private void addToAggregator(int aggIdx, Sequence s) throws QueryException {
+    // Lock on the shared per-aggregator instance from the field array (NOT a parameter) — the
+    // fine-grained per-aggregator monitor is the design here.
     if (threadSafe) {
-      synchronized (agg) {
-        agg.add(s);
+      synchronized (aggs[aggIdx]) {
+        aggs[aggIdx].add(s);
       }
     } else {
-      agg.add(s);
+      aggs[aggIdx].add(s);
     }
   }
 

--- a/src/main/java/io/brackit/query/util/aggregator/SumAvgAggregator.java
+++ b/src/main/java/io/brackit/query/util/aggregator/SumAvgAggregator.java
@@ -235,15 +235,10 @@ public class SumAvgAggregator implements Aggregator {
       // Check if we're still getting Int64 values
       if (!(a instanceof Int64 i64)) {
         // Type changed - flush buffer (exactly) and fall back to object path
-        Numeric sum = addRangeExactOrEscalate(longBuffer, bufferLen, currentSum);
-        // Continue with mixed-type processing
-        sum = numericSum(sum, item);
+        Numeric flushed = addRangeExactOrEscalate(longBuffer, bufferLen, currentSum);
+        flushed = numericSum(flushed, item);
         count++;
-        while ((item = in.next()) != null) {
-          sum = numericSum(sum, item);
-          count++;
-        }
-        return sum;
+        return drainViaNumericSum(in, flushed);
       }
 
       longBuffer[bufferLen++] = i64.longValue();
@@ -252,16 +247,11 @@ public class SumAvgAggregator implements Aggregator {
       if (bufferLen == BATCH_SIZE) {
         try {
           currentSum = sumRangeExact(longBuffer, bufferLen, currentSum);
-        } catch (ArithmeticException overflow) {
+        } catch (ArithmeticException _) {
           // xs:integer is arbitrary precision (F&O): the previous raw-long accumulation
           // silently WRAPPED here and returned a negative/garbage sum. Escalate to the
           // generic Numeric path (BigDecimal-backed) for the rest of the sequence.
-          Numeric sum = addRangeViaNumeric(longBuffer, bufferLen, currentSum);
-          while ((item = in.next()) != null) {
-            sum = numericSum(sum, item);
-            count++;
-          }
-          return sum;
+          return drainViaNumericSum(in, addRangeViaNumeric(longBuffer, bufferLen, currentSum));
         }
         bufferLen = 0;
       }
@@ -273,6 +263,16 @@ public class SumAvgAggregator implements Aggregator {
     }
 
     return new Int64(currentSum);
+  }
+
+  /** Consume the rest of the iterator through the generic (arbitrary-precision) sum path. */
+  private Numeric drainViaNumericSum(Iter in, Numeric sum) throws QueryException {
+    Item item;
+    while ((item = in.next()) != null) {
+      sum = numericSum(sum, item);
+      count++;
+    }
+    return sum;
   }
 
   /** Exact long-range sum; throws {@link ArithmeticException} on overflow. */
@@ -288,7 +288,7 @@ public class SumAvgAggregator implements Aggregator {
   private static Numeric addRangeViaNumeric(long[] buf, int len, long acc) throws QueryException {
     Numeric sum = new Int64(acc);
     for (int i = 0; i < len; i++) {
-      sum = (Numeric) sum.add(new Int64(buf[i]));
+      sum = sum.add(new Int64(buf[i]));
     }
     return sum;
   }
@@ -297,7 +297,7 @@ public class SumAvgAggregator implements Aggregator {
   private static Numeric addRangeExactOrEscalate(long[] buf, int len, long acc) throws QueryException {
     try {
       return new Int64(sumRangeExact(buf, len, acc));
-    } catch (ArithmeticException overflow) {
+    } catch (ArithmeticException _) {
       return addRangeViaNumeric(buf, len, acc);
     }
   }

--- a/src/main/java/io/brackit/query/util/dot/DotUtil.java
+++ b/src/main/java/io/brackit/query/util/dot/DotUtil.java
@@ -58,7 +58,12 @@ public class DotUtil {
       }
       Process proc = Runtime.getRuntime().exec("dot -T" + PLOT_TYPE + " -o" + svgFile + " " + f);
       proc.waitFor();
-      f.delete();
+      if (!f.delete()) {
+        // Best-effort temp-file cleanup.
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.error(String.format("Creating dot plan '%s' was interrupted.", svgFile), e);
     } catch (Exception e) {
       log.error(String.format("Creating dot plan '%s' failed.", svgFile), e);
     }

--- a/src/main/java/io/brackit/query/util/io/IOUtils.java
+++ b/src/main/java/io/brackit/query/util/io/IOUtils.java
@@ -153,21 +153,13 @@ public class IOUtils {
    * Return the string content of a file.
    */
   public static String getStringFromFile(File pFile) throws QueryException {
-    byte[] buffer = new byte[(int) pFile.length()];
-    BufferedInputStream in = null;
+    // A single InputStream.read(buffer) may return fewer bytes than the file length, silently
+    // truncating the tail to NUL bytes — read everything.
     try {
-      in = new BufferedInputStream(new FileInputStream(pFile));
-      in.read(buffer);
+      return new String(java.nio.file.Files.readAllBytes(pFile.toPath()));
     } catch (IOException e) {
       throw new QueryException(e, ErrorCode.ERR_PARSING_ERROR, e.getMessage());
-    } finally {
-      if (in != null)
-        try {
-          in.close();
-        } catch (IOException ignored) {
-        }
     }
-    return new String(buffer);
   }
 
   /**

--- a/src/main/java/io/brackit/query/util/io/URIHandler.java
+++ b/src/main/java/io/brackit/query/util/io/URIHandler.java
@@ -71,9 +71,10 @@ public final class URIHandler {
         throw new IOException(String.format("Location is not a file: %s", uri));
       }
       if (overwrite) {
-        if (f.exists())
-          f.delete();
-        f.createNewFile();
+        // Best-effort normalization — the FileOutputStream below creates/truncates regardless.
+        if ((f.exists() && !f.delete()) || !f.createNewFile()) {
+          // Nothing to do: the stream constructor below surfaces any real failure.
+        }
       }
       return new FileOutputStream(f);
     } else if (scheme.equals("http") || scheme.equals("https") || scheme.equals("ftp") || scheme.equals("jar")) {

--- a/src/main/java/io/brackit/query/util/sort/Ordering.java
+++ b/src/main/java/io/brackit/query/util/sort/Ordering.java
@@ -148,7 +148,10 @@ public class Ordering implements Comparator<Tuple> {
           if (lNaN && rNaN) {
             continue; // NaN equals NaN for ordering purposes — next orderspec
           }
-          return (modifier[i].EMPTY_LEAST) ? (lNaN ? -1 : 1) : (lNaN ? 1 : -1);
+          if (modifier[i].EMPTY_LEAST) {
+            return lNaN ? -1 : 1;
+          }
+          return lNaN ? 1 : -1;
         }
 
         int res = lAtomic.cmp(rAtomic);

--- a/src/main/java/io/brackit/query/util/sort/TupleSort.java
+++ b/src/main/java/io/brackit/query/util/sort/TupleSort.java
@@ -204,7 +204,9 @@ public class TupleSort {
 
     for (File run : runs) {
       if ((run != null) && (run.exists())) {
-        run.delete();
+        if (!run.delete()) {
+          // Best-effort sort-run cleanup — nothing to do if it is already gone.
+        }
       }
     }
   }
@@ -232,7 +234,9 @@ public class TupleSort {
 
   public void clear() {
     if (runCount > 0) {
-      runs[0].delete();
+      if (!runs[0].delete()) {
+        // Best-effort sort-run cleanup — nothing to do if it is already gone.
+      }
     }
   }
 
@@ -377,7 +381,9 @@ public class TupleSort {
       } catch (QueryException e) {
         for (File newRun : newRuns) {
           if ((newRun != null) && (newRun.exists())) {
-            newRun.delete();
+            if (!newRun.delete()) {
+              // Best-effort sort-run cleanup — nothing to do if it is already gone.
+            }
           }
         }
         throw e;
@@ -460,8 +466,9 @@ public class TupleSort {
         directMergeSize += read;
       }
 
-      run1.delete();
-      run2.delete();
+      if (!run1.delete() || !run2.delete()) {
+        // Best-effort sort-run cleanup — nothing to do if a run is already gone.
+      }
 
       if (log.isDebugEnabled()) {
         log.debug(String.format("Wrote run '%s'", run));


### PR DESCRIPTION
Works through the SonarCloud findings on master. Full suite **1104/0**.

## Real bugs found by the scan
- **`validate type EQName { … }` was unparseable**: the JsoniqParser branch looked ahead for `"strict"` twice (duplicate condition → unreachable branch).
- **`SortedNodeSequence` dedup leaked duplicates** for runs of ≥3 equal nodes (single `if` instead of a loop, under a `while` that never looped).
- **`BooleanValue`** could AIOOBE on zero-arg calls; **`ExtractFromDateTime`** fell through between source switches (CCE); **`IOUtils.getStringFromFile`** trusted a single partial `read`; **`ProfileOperator`** double-incremented profiler ids via a shadowing field.

## Hygiene
- Re-interrupt on `InterruptedException` (6 sites); checked best-effort `delete()` results (12 sites); blocker-severity shadowing renames (`ForBind.min/max`, `DefaultCtxItem.type`).

## Deliberate non-fixes
- The `S2111 new BigDecimal(double)` family is **intentional**: the exact binary expansion is what xs:decimal/xs:integer casts need (`valueOf` substitutes the shortest decimal approximation, changing results — e.g. `xs:integer(1e30)`). Annotated with `@SuppressWarnings` + rationale.
- The cognitive-complexity "brain methods" in the vectorized executor (`ParallelGroupByExec`, complexity 111/52/49, `VectorizedGroupByDetection` 54/35) are real but need a dedicated refactoring effort, not a drive-by.