### PR TITLE
Fail-closed vectorized detection, FLWOR result envelope, typed multi-key group-by

### DIFF
--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
@@ -32,8 +32,59 @@ import io.brackit.query.jdm.Sequence;
  */
 public interface VectorizedExecutor {
 
-  /** Execute a vectorized group-by-count query. */
+  /**
+   * Execute a vectorized group-by-count query.
+   *
+   * <p>RESULT ENVELOPE CONTRACT: the returned {@link Sequence} must be a flat
+   * sequence of per-group record items — exactly what the replaced FLWOR's
+   * {@code return {"<groupField>": $key, "count": n}} would emit. It must NOT
+   * be a single array item wrapping the records: brackit arrays iterate as
+   * their members, so counts still come out right, but the serialized result
+   * (one {@code [...]} item vs N object items) and positional semantics would
+   * silently differ from the generic pipeline.
+   */
   Sequence executeGroupByCount(QueryContext ctx, String[] sourcePath, String groupField) throws QueryException;
+
+  /**
+   * Whether {@link #executeSortedScan} is actually implemented. The dispatcher
+   * substitutes the sorted-scan expression at TRANSLATE time, after which there
+   * is no generic pipeline to fall back to — an executor that answers
+   * {@code null} at evaluate time turns into a runtime error. Capability is
+   * therefore declared up front; the default matches the default
+   * {@code executeSortedScan} (unsupported).
+   */
+  default boolean supportsSortedScan() {
+    return false;
+  }
+
+  /**
+   * Whether {@link #executeGroupByCountMulti} is actually implemented. Same
+   * translate-time gating rationale as {@link #supportsSortedScan()}.
+   */
+  default boolean supportsMultiKeyGroupBy() {
+    return false;
+  }
+
+  /**
+   * Generalized group-by-count: group the records reached via {@code sourcePath}
+   * by one or more fields and emit ONE record per distinct key combination,
+   * shaped {@code {outNames[0]: key0, ..., outNames[M-1]: keyM-1, countName: n}}.
+   * {@code groupFields} and {@code outNames} are aligned and in RETURN-clause
+   * order; {@code predicate} may be {@code null} (unfiltered) — when non-null it
+   * is evaluated per record before grouping.
+   *
+   * <p>Key values must keep their original JSON types (a numeric field groups
+   * and serializes as numbers, booleans as booleans) — stringifying keys is a
+   * wrong result, not a degradation.
+   *
+   * <p>Same RESULT ENVELOPE CONTRACT as {@link #executeGroupByCount}: a flat
+   * sequence of per-group record items, never a single wrapping array; an empty
+   * grouping is an EMPTY sequence, {@code null} strictly means "unsupported".
+   */
+  default Sequence executeGroupByCountMulti(QueryContext ctx, String[] sourcePath, String[] groupFields,
+      String[] outNames, String countName, PredicateNode predicate) throws QueryException {
+    return null;
+  }
 
   /**
    * Execute a vectorized sorted scan.
@@ -93,6 +144,11 @@ public interface VectorizedExecutor {
    * Generic predicate-tree group-by-count: evaluate {@code predicate} against
    * records reached via {@code sourcePath}; for each distinct value of
    * {@code groupField} among the matches, emit the group key + count.
+   *
+   * <p>Same RESULT ENVELOPE CONTRACT as {@link #executeGroupByCount}: a flat
+   * sequence of per-group record items, never a single wrapping array. A
+   * legitimately empty result (predicate matches nothing) is an EMPTY sequence
+   * — {@code null} strictly means "unsupported, fall back".
    *
    * @return grouped-count Sequence, or {@code null} if unsupported
    */

--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedScanAnnotation.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedScanAnnotation.java
@@ -22,14 +22,25 @@ public final class VectorizedScanAnnotation {
   public static final String VECTORIZED_AGGREGATE = "VECTORIZED_AGGREGATE";
   /** Count-distinct over a single field (count(for ... group by $d return $d)). */
   public static final String VECTORIZED_COUNT_DISTINCT = "VECTORIZED_COUNT_DISTINCT";
-  /** Top-N pattern (order-by + slice). */
-  public static final String VECTORIZED_TOPN = "VECTORIZED_TOPN";
 
   // ---- Group-by ----
-  /** Field name to group by (String). */
+  /** Field name to group by (String) — canonical single-key claim. */
   public static final String GROUPBY_FIELD = "VECTORIZED_GROUPBY_FIELD";
-  /** Additional group-by fields for multi-key grouping (String[]). */
-  public static final String GROUPBY_FIELDS_EXTRA = "VECTORIZED_GROUPBY_FIELDS_EXTRA";
+
+  /**
+   * Generalized (multi-key and/or renamed-output) group-by detected (Boolean).
+   * Set whenever the return clause is the generalized canonical shape
+   * {@code {name1: $k1, ..., nameM: $kM, countName: count($loop)}} for let-bound
+   * direct-deref keys matching the GroupBySpec exactly. Dispatch is gated on
+   * {@link VectorizedExecutor#supportsMultiKeyGroupBy()}.
+   */
+  public static final String VECTORIZED_GROUPBY_MULTI = "VECTORIZED_GROUPBY_MULTI";
+  /** Group-by source field names in RETURN-clause order (String[]). */
+  public static final String GROUPBY_FIELDS = "VECTORIZED_GROUPBY_FIELDS";
+  /** Output object field names for the group keys, aligned with GROUPBY_FIELDS (String[]). */
+  public static final String GROUPBY_OUT_NAMES = "VECTORIZED_GROUPBY_OUT_NAMES";
+  /** Output object field name for the per-group count (String). */
+  public static final String GROUPBY_COUNT_NAME = "VECTORIZED_GROUPBY_COUNT_NAME";
 
   // ---- Filter ----
   /**
@@ -82,10 +93,6 @@ public final class VectorizedScanAnnotation {
 
   /** Count-distinct target field (local-name String). */
   public static final String COUNT_DISTINCT_FIELD = "VECTORIZED_COUNT_DISTINCT_FIELD";
-
-  // ---- Top-N ----
-  /** Number of results to return (Long). */
-  public static final String TOPN_LIMIT = "VECTORIZED_TOPN_LIMIT";
 
   private VectorizedScanAnnotation() {
   }

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
@@ -21,16 +21,25 @@ import java.util.List;
  * <p>
  * Detected patterns:
  * <ol>
- * <li>Group-by: {@code for $u in SRC let $c := $u.F group by $c return ...}</li>
- * <li>Filtered count: {@code for $u in SRC where $u.F > N return ...}</li>
- * <li>Filtered group-by: {@code for $u in SRC where $u.F > N let $c := $u.G group by $c ...}</li>
- * <li>Multi-key group-by: {@code for $u let $c := $u.F, $d := $u.G group by $c, $d ...}</li>
+ * <li>Group-by: {@code for $u in SRC let $c := $u.F group by $c return {"F": $c, "count": count($u)}}</li>
+ * <li>Generalized group-by (multi-key and/or renamed outputs):
+ * {@code for $u let $a := $u.F, $b := $u.G group by $a, $b return {"x": $a, "y": $b, "n": count($u)}}
+ * — claimed via {@code VECTORIZED_GROUPBY_MULTI}, dispatch capability-gated</li>
+ * <li>Filtered count: {@code for $u in SRC where $u.F > N return $u}</li>
+ * <li>Filtered group-by: the group-by shapes above with a representable {@code where}</li>
  * <li>Sorted scan: {@code for $u in SRC order by $u.F descending return $u}</li>
- * <li>Top-N: {@code for $u in SRC order by $u.F return $u[0:N]}</li>
- * <li>String equality filter: {@code for $u where $u.city eq "NYC" return ...}</li>
+ * <li>String equality filter: {@code for $u where $u.city eq "NYC" return $u}</li>
  * <li>Compound predicate (AND): {@code where $u.age > 30 and $u.city eq "NYC"}</li>
- * <li>Existence check: {@code where exists($u.email)}</li>
+ * <li>Pure aggregate: {@code sum(for $u in SRC return $u.F)} (and avg/min/max/count)</li>
+ * <li>Count-distinct: {@code count(for $u let $d := $u.F group by $d return $d)}</li>
  * </ol>
+ * <p>
+ * Every claim is FAIL-CLOSED: an annotation replaces the WHOLE pipeline with a
+ * vectorized executor emitting a fixed result shape, so the stage only annotates
+ * when the chain operators, the key/field sources (directly {@code $loopVar.field}),
+ * and the return expression provably match what the executor emits. Anything else —
+ * computed keys, unknown chain operators, unrepresentable predicates, non-canonical
+ * returns — falls back to the generic (always correct) Volcano pipeline.
  */
 public final class VectorizedGroupByDetection implements Stage {
 
@@ -69,14 +78,26 @@ public final class VectorizedGroupByDetection implements Stage {
     if (forBind == null || forBind.getType() != XQ.ForBind)
       return;
 
+    final QNm loopVar = extractLoopVarName(forBind);
+
     List<String> groupFields = new ArrayList<>();
     // Declared variable names for LetBinds that feed group-by — used to verify
-    // count-distinct patterns (return expr must be a VarRef matching one of these).
+    // group-by / count-distinct patterns against the GroupBySpec and return expr.
     List<QNm> letBindVars = new ArrayList<>();
+    // Variables named by GroupBySpec clauses. A claim must match them against the
+    // let-bound key variable — otherwise the query groups by something else entirely.
+    List<QNm> groupSpecVars = new ArrayList<>();
+    boolean groupSpecsExtractable = true;
     String orderField = null;
     String orderDirection = null;
     boolean hasGroupBy = false;
     boolean hasOrderBy = false;
+    boolean hasSelection = false;
+    int orderByCount = 0;
+    // Any claim replaces the WHOLE pipeline, so a chain operator this walker doesn't
+    // model (count/window/join clauses, ...) would be silently dropped by the
+    // executor. Unknown operator → no claims at all.
+    boolean chainUnderstood = true;
 
     // Selection predicates accumulated across the chain. Multiple Selection
     // operators AND-conjoin by pipeline semantics. If ANY selection is not
@@ -89,6 +110,7 @@ public final class VectorizedGroupByDetection implements Stage {
     while (current != null && current.getType() != XQ.End) {
       switch (current.getType()) {
         case XQ.Selection -> {
+          hasSelection = true;
           if (predicateRepresentable && current.getChildCount() >= 1) {
             PredicateNode pn = extractPredicate(current.getChild(0));
             if (pn == null) {
@@ -100,51 +122,96 @@ public final class VectorizedGroupByDetection implements Stage {
         }
         case XQ.LetBind -> {
           if (current.getChildCount() >= 2) {
-            String field = extractFieldFromDeref(current.getChild(1));
+            // Strict: the key source must be DIRECTLY `$loopVar.field`. Descending into a
+            // wrapper would extract `city` out of `upper-case($u.city)` and the executor
+            // would group by the RAW field values — silently wrong results.
+            String field = directLoopVarDerefField(current.getChild(1), loopVar);
             if (field != null) {
               groupFields.add(field);
               letBindVars.add(extractLetBindVarName(current));
             }
           }
         }
-        case XQ.GroupBy -> hasGroupBy = true;
+        case XQ.GroupBy -> {
+          hasGroupBy = true;
+          groupSpecsExtractable &= extractGroupSpecVars(current, groupSpecVars);
+        }
         case XQ.OrderBy -> {
           hasOrderBy = true;
-          var order = extractOrderBy(current);
+          orderByCount++;
+          var order = extractOrderBy(current, loopVar);
           if (order != null) {
             orderField = order.field;
             orderDirection = order.direction;
           }
         }
-        default -> {
-        }
+        default -> chainUnderstood = false;
       }
       current = current.getLastChild();
     }
 
-    // If the return expression is a single DerefExpr `$u.field`, capture the field.
-    // An enclosing sum()/avg()/min()/max() call can use this to vectorize
-    // (see Compiler.functionCall interception).
-    String returnField = current != null ? extractFieldFromDeref(current) : null;
+    final AST returnExpr = current != null && current.getChildCount() > 0 ? current.getChild(0) : null;
+
+    // If the return expression is DIRECTLY `$loopVar.field`, capture the field. An
+    // enclosing sum()/avg()/min()/max() call uses this to vectorize (see
+    // Compiler.functionCall interception). Direct only: recursing into the subtree
+    // would turn `return $u.a + $u.b` into an aggregate over field `a` alone.
+    final String returnField = directLoopVarDerefField(returnExpr, loopVar);
 
     // ---- Annotate based on detected pattern ----
 
-    if (hasGroupBy && !groupFields.isEmpty()) {
-      pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY, Boolean.TRUE);
-      pipeExpr.setProperty(VectorizedScanAnnotation.GROUPBY_FIELD, groupFields.getFirst());
-      if (groupFields.size() > 1) {
-        pipeExpr.setProperty(VectorizedScanAnnotation.GROUPBY_FIELDS_EXTRA,
-                             groupFields.subList(1, groupFields.size()).toArray(new String[0]));
-      }
+    if (!chainUnderstood) {
+      return;
     }
 
     final boolean hasPredicate = predicateRepresentable && !predicateConjuncts.isEmpty();
     if (hasPredicate) {
       pipeExpr.setProperty(VectorizedScanAnnotation.PREDICATE_TREE, PredicateNode.and(predicateConjuncts));
-      // No group-by and no order-by → filtered count shape.
-      if (!hasGroupBy && !hasOrderBy) {
-        pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_COUNT, Boolean.TRUE);
+    }
+
+    // Exactly one group-by key, let-bound from `$loopVar.field`, and the GroupBySpec
+    // groups by precisely that variable. (Used by the count-distinct claim below.)
+    final boolean singleGroupKey = hasGroupBy && groupFields.size() == 1 && letBindVars.getFirst() != null
+        && groupSpecsExtractable && groupSpecVars.size() == 1 && letBindVars.getFirst()
+                                                                            .equals(groupSpecVars.getFirst());
+
+    // FAIL-CLOSED: a group-by claim replaces the pipeline with an executor emitting one
+    // record per distinct key combination, shaped exactly like the query's return
+    // clause. Claim ONLY when the return expression is the generalized canonical shape
+    // {name1: $k1, ..., nameM: $kM, countName: count($loop)} whose key variables are
+    // the let-bound direct-deref vars and match the GroupBySpec exactly, and no
+    // order-by follows (the executor emits groups in ITS order, dropping the requested
+    // one). A selection is fine only when representable — it is then carried via
+    // PREDICATE_TREE and applied by the executor. Historical context: the original
+    // detection claimed multi-key group-bys while the executor emitted the
+    // single-first-key grouping with canonical field names — silently wrong results.
+    if (hasGroupBy && groupSpecsExtractable && predicateRepresentable && !hasOrderBy) {
+      final GroupReturnShape shape = matchCanonicalGroupReturn(returnExpr,
+                                                               letBindVars,
+                                                               groupFields,
+                                                               groupSpecVars,
+                                                               loopVar);
+      if (shape != null) {
+        pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI, Boolean.TRUE);
+        pipeExpr.setProperty(VectorizedScanAnnotation.GROUPBY_FIELDS, shape.sourceFields);
+        pipeExpr.setProperty(VectorizedScanAnnotation.GROUPBY_OUT_NAMES, shape.outNames);
+        pipeExpr.setProperty(VectorizedScanAnnotation.GROUPBY_COUNT_NAME, shape.countName);
+        // Canonical single-key shape ({<field>: $key, "count": count($loop)}) ALSO gets
+        // the legacy claim — executors keep their specialized single-key fast paths.
+        if (shape.sourceFields.length == 1 && shape.outNames[0].equals(shape.sourceFields[0]) && "count".equals(
+                                                                                                                shape.countName)) {
+          pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY, Boolean.TRUE);
+          pipeExpr.setProperty(VectorizedScanAnnotation.GROUPBY_FIELD, shape.sourceFields[0]);
+        }
       }
+    }
+
+    // Filtered count: the pipeline counts MATCHING RECORDS, so the return expression
+    // must be exactly the loop variable (one item per tuple, never empty):
+    // `return ($u, $u)` doubles the count and `return $u.maybeAbsent` yields zero
+    // items for records lacking the field — both silently wrong.
+    if (hasPredicate && !hasGroupBy && !hasOrderBy && isSoleLoopVarRef(returnExpr, loopVar)) {
+      pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_COUNT, Boolean.TRUE);
     }
 
     // Extract the loop variable's source path prefix (the expression supplying
@@ -159,7 +226,12 @@ public final class VectorizedGroupByDetection implements Stage {
       }
     }
 
-    if (hasOrderBy && orderField != null) {
+    // Sorted scan emits FULL RECORDS sorted by ONE direct `$loopVar.field` key — only
+    // claim it for exactly one order-by with exactly one spec, a return expression that
+    // is exactly the loop variable, no group-by (the executor would drop the grouping),
+    // and a representable (or absent) selection.
+    if (hasOrderBy && orderByCount == 1 && !hasGroupBy && predicateRepresentable && orderField != null
+        && isSoleLoopVarRef(returnExpr, loopVar)) {
       pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY, Boolean.TRUE);
       pipeExpr.setProperty(VectorizedScanAnnotation.ORDER_FIELD, orderField);
       pipeExpr.setProperty(VectorizedScanAnnotation.ORDER_DIRECTION, orderDirection);
@@ -169,7 +241,7 @@ public final class VectorizedGroupByDetection implements Stage {
     // A predicate, if present, is carried via PREDICATE_TREE — the enclosing
     // sum/avg/min/max/count() call fills AGGREGATE_FUNC at compile time and the
     // dispatcher routes to executePredicateAggregate.
-    if (!hasGroupBy && !hasOrderBy && returnField != null) {
+    if (!hasGroupBy && !hasOrderBy && predicateRepresentable && returnField != null) {
       pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE, Boolean.TRUE);
       pipeExpr.setProperty(VectorizedScanAnnotation.AGGREGATE_FIELD, returnField);
     }
@@ -182,16 +254,164 @@ public final class VectorizedGroupByDetection implements Stage {
     // Correctness guard: the return must be a VarRef whose QNm matches the first
     // group-by let-bind's declared variable; otherwise count(...) could return
     // a multiple of the distinct-count (e.g., return ($d, $d)). Also disallow
-    // predicates — an HLL is unfiltered.
-    if (hasGroupBy && !hasOrderBy && !hasPredicate && groupFields.size() == 1 && !letBindVars.isEmpty() && letBindVars
-                                                                                                                      .getFirst()
-        != null) {
+    // selections of ANY kind (representable or not) — an HLL is unfiltered.
+    if (singleGroupKey && !hasOrderBy && !hasSelection) {
       final QNm returnVar = current != null ? extractSoleVariableRef(current) : null;
       if (returnVar != null && returnVar.equals(letBindVars.getFirst())) {
         pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_COUNT_DISTINCT, Boolean.TRUE);
         pipeExpr.setProperty(VectorizedScanAnnotation.COUNT_DISTINCT_FIELD, groupFields.getFirst());
       }
     }
+  }
+
+  /**
+   * Field name iff {@code expr} is DIRECTLY {@code $loopVar.field} — a DerefExpr whose
+   * base is a VariableRef of {@code loopVar}. No descent into subtrees: extracting a
+   * field from inside a wrapping expression (function call, arithmetic, nested deref)
+   * would make the executor compute over different values than the query asks for.
+   */
+  private String directLoopVarDerefField(final AST expr, final QNm loopVar) {
+    if (expr == null || loopVar == null || expr.getType() != XQ.DerefExpr || expr.getChildCount() < 2)
+      return null;
+    final AST base = expr.getChild(0);
+    if (base.getType() != XQ.VariableRef || !loopVar.equals(base.getValue() instanceof QNm qnm ? qnm : null))
+      return null;
+    return qnmLocalName(expr.getChild(expr.getChildCount() - 1).getValue());
+  }
+
+  /**
+   * Collect the variables named by a GroupBy's {@link XQ#GroupBySpec} children into
+   * {@code out}. Returns {@code false} if any spec is not a simple variable reference
+   * — callers must then fail closed (no claim).
+   */
+  private boolean extractGroupSpecVars(final AST groupByNode, final List<QNm> out) {
+    boolean extractable = true;
+    for (int i = 0; i < groupByNode.getChildCount(); i++) {
+      final AST child = groupByNode.getChild(i);
+      if (child.getType() != XQ.GroupBySpec) {
+        continue;
+      }
+      final AST ref = child.getChildCount() > 0 ? child.getChild(0) : null;
+      if (ref != null && ref.getType() == XQ.VariableRef && ref.getValue() instanceof QNm qnm) {
+        out.add(qnm);
+      } else {
+        extractable = false;
+      }
+    }
+    return extractable;
+  }
+
+  /** The ForBind's declared loop-variable name — {@code null} if not extractable. */
+  private QNm extractLoopVarName(final AST forBind) {
+    if (forBind.getChildCount() < 1)
+      return null;
+    final AST binding = forBind.getChild(0);
+    if (binding.getType() != XQ.TypedVariableBinding || binding.getChildCount() < 1)
+      return null;
+    final Object val = binding.getChild(0).getValue();
+    return val instanceof QNm qnm ? qnm : null;
+  }
+
+  /** {@code true} iff {@code expr} is exactly a {@link XQ#VariableRef} of {@code loopVar}. */
+  private boolean isSoleLoopVarRef(final AST expr, final QNm loopVar) {
+    return loopVar != null && expr != null && expr.getType() == XQ.VariableRef && loopVar.equals(expr
+                                                                                                     .getValue() instanceof QNm qnm
+                                                                                                         ? qnm
+                                                                                                         : null);
+  }
+
+  /** Extracted generalized group-by return shape — aligned source fields + output names. */
+  private static final class GroupReturnShape {
+    final String[] sourceFields;
+    final String[] outNames;
+    final String countName;
+
+    GroupReturnShape(final String[] sourceFields, final String[] outNames, final String countName) {
+      this.sourceFields = sourceFields;
+      this.outNames = outNames;
+      this.countName = countName;
+    }
+  }
+
+  /**
+   * Match the return expression against the generalized canonical group-by-count shape:
+   * {@code {name1: $k1, ..., nameM: $kM, countName: count($loopVar)}} where
+   * <ul>
+   * <li>every {@code $k_i} is a let-bound direct {@code $loopVar.field} variable,</li>
+   * <li>the {@code $k_i} are pairwise distinct and cover the GroupBySpec variables
+   * EXACTLY (same count, same set — and the let-bound key vars are exactly the spec
+   * vars, no extras: a dead let-bind is rare and falling back is always correct),</li>
+   * <li>all output names ({@code name_i} and {@code countName}) are string literals
+   * and pairwise distinct (duplicate object keys would change the record shape).</li>
+   * </ul>
+   * Returns the aligned shape in RETURN-clause order, or {@code null} if anything
+   * deviates — the caller then leaves the pipeline to the generic (correct) path.
+   */
+  private GroupReturnShape matchCanonicalGroupReturn(final AST returnExpr, final List<QNm> letBindVars,
+      final List<String> letBindFields, final List<QNm> groupSpecVars, final QNm loopVar) {
+    final int keyCount = groupSpecVars.size();
+    if (returnExpr == null || loopVar == null || keyCount < 1 || returnExpr.getType() != XQ.ObjectConstructor
+        || returnExpr.getChildCount() != keyCount + 1) {
+      return null;
+    }
+    // Strict bijection prerequisite: the let-bound direct-deref key vars ARE the spec vars.
+    if (letBindVars.size() != keyCount || letBindVars.contains(null) || !new java.util.HashSet<>(letBindVars)
+                                                                                                             .containsAll(groupSpecVars)
+        || new java.util.HashSet<>(groupSpecVars).size() != keyCount) {
+      return null;
+    }
+    final String[] sourceFields = new String[keyCount];
+    final String[] outNames = new String[keyCount];
+    final java.util.Set<String> seenNames = new java.util.HashSet<>();
+    final java.util.Set<QNm> seenVars = new java.util.HashSet<>();
+    for (int i = 0; i < keyCount; i++) {
+      final AST kv = returnExpr.getChild(i);
+      if (kv.getType() != XQ.KeyValueField || kv.getChildCount() != 2) {
+        return null;
+      }
+      final String outName = stringLiteralValue(kv.getChild(0));
+      final AST value = kv.getChild(1);
+      if (outName == null || !seenNames.add(outName) || value.getType() != XQ.VariableRef || !(value
+                                                                                                    .getValue() instanceof QNm keyVar)
+          || !seenVars.add(keyVar)) {
+        return null;
+      }
+      final int letIdx = letBindVars.indexOf(keyVar);
+      if (letIdx < 0) {
+        return null;
+      }
+      sourceFields[i] = letBindFields.get(letIdx);
+      outNames[i] = outName;
+    }
+    // {..., countName: count($loopVar)}
+    final AST countKv = returnExpr.getChild(keyCount);
+    if (countKv.getType() != XQ.KeyValueField || countKv.getChildCount() != 2) {
+      return null;
+    }
+    final String countName = stringLiteralValue(countKv.getChild(0));
+    if (countName == null || !seenNames.add(countName)) {
+      return null;
+    }
+    final AST countCall = countKv.getChild(1);
+    if (countCall.getType() != XQ.FunctionCall || countCall.getChildCount() != 1 || !(countCall
+                                                                                               .getValue() instanceof QNm fn)
+        || !"count".equals(fn.getLocalName()) || !isSoleLoopVarRef(countCall.getChild(0), loopVar)) {
+      return null;
+    }
+    return new GroupReturnShape(sourceFields, outNames, countName);
+  }
+
+  /** String value of a string-literal AST node — {@code null} for anything else. */
+  private static String stringLiteralValue(final AST node) {
+    if (node == null || node.getType() != XQ.Str) {
+      return null;
+    }
+    final Object val = node.getValue();
+    if (val instanceof String s)
+      return s;
+    if (val instanceof io.brackit.query.atomic.Str str)
+      return str.stringValue();
+    return val != null ? val.toString() : null;
   }
 
   /** Get the declared QNm of a LetBind's variable binding — {@code null} if absent. */
@@ -448,14 +668,24 @@ public final class VectorizedGroupByDetection implements Stage {
   private record OrderInfo(String field, String direction) {
   }
 
-  private OrderInfo extractOrderBy(AST orderBy) {
-    if (orderBy.getChildCount() < 1)
+  private OrderInfo extractOrderBy(AST orderBy, QNm loopVar) {
+    // Exactly ONE sort spec — the executor sorts by a single key, so claiming the
+    // first spec of `order by $u.a, $u.b` would break ties differently than asked.
+    int specCount = 0;
+    for (int i = 0; i < orderBy.getChildCount(); i++) {
+      if (orderBy.getChild(i).getType() == XQ.OrderBySpec) {
+        specCount++;
+      }
+    }
+    if (specCount != 1 || orderBy.getChildCount() < 1)
       return null;
     AST spec = orderBy.getChild(0);
     if (spec.getType() != XQ.OrderBySpec)
       return null;
 
-    String field = spec.getChildCount() >= 1 ? extractFieldFromDeref(spec.getChild(0)) : null;
+    // Strict: the sort key must be DIRECTLY `$loopVar.field` — descending into a
+    // wrapper (`order by fn:lower-case($u.name)`) would sort by the raw field values.
+    String field = spec.getChildCount() >= 1 ? directLoopVarDerefField(spec.getChild(0), loopVar) : null;
     String direction = "ascending";
     for (int i = 1; i < spec.getChildCount(); i++) {
       if (spec.getChild(i).getType() == XQ.OrderByKind) {
@@ -479,25 +709,6 @@ public final class VectorizedGroupByDetection implements Stage {
       return qnm.getLocalName();
     if (value instanceof String s)
       return s;
-    return null;
-  }
-
-  private String extractFieldFromDeref(AST node) {
-    if (node == null)
-      return null;
-    if (node.getType() == XQ.DerefExpr && node.getChildCount() >= 2) {
-      AST fieldNode = node.getChild(node.getChildCount() - 1);
-      Object value = fieldNode.getValue();
-      if (value instanceof QNm qnm)
-        return qnm.getLocalName();
-      if (value instanceof String s)
-        return s;
-    }
-    for (int i = 0; i < node.getChildCount(); i++) {
-      String result = extractFieldFromDeref(node.getChild(i));
-      if (result != null)
-        return result;
-    }
     return null;
   }
 

--- a/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
@@ -202,6 +202,22 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
       return VectorizedGroupByExpr.groupBy(executor, sourcePath, groupField);
     }
 
+    // Pattern 1b: generalized group-by (multi-key and/or query-renamed output
+    // fields). Capability-gated at translate time, same rationale as the sorted
+    // scan below. The canonical single-key Pattern 1 is checked first so
+    // executors keep their specialized projection fast paths for that shape.
+    if (executor.supportsMultiKeyGroupBy() && Boolean.TRUE.equals(node.getProperty(
+                                                                                   VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI))) {
+      String[] groupFields = (String[]) node.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS);
+      String[] outNames = (String[]) node.getProperty(VectorizedScanAnnotation.GROUPBY_OUT_NAMES);
+      String countName = (String) node.getProperty(VectorizedScanAnnotation.GROUPBY_COUNT_NAME);
+      if (groupFields != null && outNames != null && countName != null && groupFields.length == outNames.length
+          && groupFields.length >= 1) {
+        PredicateNode predicate = (PredicateNode) node.getProperty(VectorizedScanAnnotation.PREDICATE_TREE);
+        return VectorizedGroupByExpr.groupByMulti(executor, sourcePath, groupFields, outNames, countName, predicate);
+      }
+    }
+
     // Pattern 2: Filtered count — only when wrapped in count(). Requires
     // PREDICATE_TREE; without it the query wasn't representable by the walker
     // and we fall back to the generic pipeline.
@@ -212,8 +228,12 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
       }
     }
 
-    // Pattern 3: Sorted scan.
-    if (Boolean.TRUE.equals(node.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY))) {
+    // Pattern 3: Sorted scan. Capability-gated at translate time: the substitution
+    // is irreversible (no Volcano pipeline left at evaluate time), so dispatching to
+    // an executor whose executeSortedScan answers null would turn a valid query into
+    // a runtime error instead of a fallback.
+    if (executor.supportsSortedScan() && Boolean.TRUE.equals(node.getProperty(
+                                                                              VectorizedScanAnnotation.VECTORIZED_ORDERBY))) {
       String orderField = (String) node.getProperty(VectorizedScanAnnotation.ORDER_FIELD);
       String direction = (String) node.getProperty(VectorizedScanAnnotation.ORDER_DIRECTION);
       if (orderField != null) {

--- a/src/main/java/io/brackit/query/expr/VectorizedGroupByExpr.java
+++ b/src/main/java/io/brackit/query/expr/VectorizedGroupByExpr.java
@@ -42,7 +42,7 @@ import io.brackit.query.jdm.Sequence;
 public final class VectorizedGroupByExpr implements Expr {
 
   public enum Mode {
-    GROUP_BY, SORTED_SCAN, AGGREGATE, COUNT_DISTINCT, GENERIC_PREDICATE_COUNT, GENERIC_PREDICATE_GROUPBY, GENERIC_PREDICATE_AGGREGATE
+    GROUP_BY, GROUP_BY_MULTI, SORTED_SCAN, AGGREGATE, COUNT_DISTINCT, GENERIC_PREDICATE_COUNT, GENERIC_PREDICATE_GROUPBY, GENERIC_PREDICATE_AGGREGATE
   }
 
   private final VectorizedExecutor executor;
@@ -54,9 +54,14 @@ public final class VectorizedGroupByExpr implements Expr {
   private final String orderDirection;
   private final String aggregateFunc;
   private final String aggregateField;
+  // GROUP_BY_MULTI only: source fields + output names in return-clause order, count field name.
+  private final String[] groupFields;
+  private final String[] groupOutNames;
+  private final String groupCountName;
 
   private VectorizedGroupByExpr(VectorizedExecutor executor, Mode mode, String[] sourcePath, String groupField,
-      PredicateNode predicate, String orderField, String orderDirection, String aggregateFunc, String aggregateField) {
+      PredicateNode predicate, String orderField, String orderDirection, String aggregateFunc, String aggregateField,
+      String[] groupFields, String[] groupOutNames, String groupCountName) {
     this.executor = executor;
     this.mode = mode;
     this.sourcePath = sourcePath;
@@ -66,11 +71,51 @@ public final class VectorizedGroupByExpr implements Expr {
     this.orderDirection = orderDirection;
     this.aggregateFunc = aggregateFunc;
     this.aggregateField = aggregateField;
+    this.groupFields = groupFields;
+    this.groupOutNames = groupOutNames;
+    this.groupCountName = groupCountName;
+  }
+
+  private VectorizedGroupByExpr(VectorizedExecutor executor, Mode mode, String[] sourcePath, String groupField,
+      PredicateNode predicate, String orderField, String orderDirection, String aggregateFunc, String aggregateField) {
+    this(executor,
+         mode,
+         sourcePath,
+         groupField,
+         predicate,
+         orderField,
+         orderDirection,
+         aggregateFunc,
+         aggregateField,
+         null,
+         null,
+         null);
   }
 
   /** Group-by count (no filter). */
   public static VectorizedGroupByExpr groupBy(VectorizedExecutor executor, String[] sourcePath, String groupField) {
     return new VectorizedGroupByExpr(executor, Mode.GROUP_BY, sourcePath, groupField, null, null, null, null, null);
+  }
+
+  /**
+   * Generalized group-by count: one or more key fields, query-defined output
+   * names, optional predicate. Only dispatched when the executor declares
+   * {@link VectorizedExecutor#supportsMultiKeyGroupBy()}.
+   */
+  public static VectorizedGroupByExpr groupByMulti(VectorizedExecutor executor, String[] sourcePath,
+      String[] groupFields, String[] outNames, String countName, PredicateNode predicate) {
+    return new VectorizedGroupByExpr(executor,
+                                     Mode.GROUP_BY_MULTI,
+                                     sourcePath,
+                                     null,
+                                     predicate,
+                                     null,
+                                     null,
+                                     null,
+                                     null,
+                                     groupFields,
+                                     outNames,
+                                     countName);
   }
 
   /** Sorted scan. */
@@ -164,6 +209,12 @@ public final class VectorizedGroupByExpr implements Expr {
     }
     return switch (mode) {
       case GROUP_BY -> executor.executeGroupByCount(ctx, sourcePath, groupField);
+      case GROUP_BY_MULTI -> requireSupported(executor.executeGroupByCountMulti(ctx,
+                                                                                sourcePath,
+                                                                                groupFields,
+                                                                                groupOutNames,
+                                                                                groupCountName,
+                                                                                predicate), "multi-key group-by-count");
       case SORTED_SCAN -> requireSupported(executor.executeSortedScan(ctx, sourcePath, orderField, orderDirection),
                                            "sorted scan");
       case AGGREGATE -> requireSupported(executor.executeAggregate(ctx, sourcePath, aggregateFunc, aggregateField),

--- a/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
+++ b/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
@@ -57,8 +57,8 @@ import io.brackit.query.atomic.Str;
 import io.brackit.query.compiler.optimizer.VectorizedExecutor;
 import io.brackit.query.jdm.Item;
 import io.brackit.query.jdm.Sequence;
-import io.brackit.query.jsonitem.array.DArray;
 import io.brackit.query.jsonitem.object.CompactObject;
+import io.brackit.query.sequence.ItemSequence;
 
 /**
  * 1BRC-inspired parallel group-by execution.
@@ -101,7 +101,9 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
   public Sequence executeGroupByCount(QueryContext ctx, String[] sourcePath, String groupField) throws QueryException {
     try {
       List<Item> results = executeGroupByCount(filePath, groupField);
-      return new DArray(results);
+      // Flat sequence of per-group records — the FLWOR's envelope, NOT one array item
+      // (RESULT ENVELOPE CONTRACT on VectorizedExecutor#executeGroupByCount).
+      return new ItemSequence(results.toArray(new Item[0]));
     } catch (Exception e) {
       throw new QueryException(e,
                                io.brackit.query.ErrorCode.BIT_DYN_INT_ERROR,

--- a/src/test/java/io/brackit/query/compiler/optimizer/VectorizedGroupByDetectionTest.java
+++ b/src/test/java/io/brackit/query/compiler/optimizer/VectorizedGroupByDetectionTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -90,6 +91,43 @@ public class VectorizedGroupByDetectionTest {
     return end;
   }
 
+  /** End node wrapping an arbitrary return expression. */
+  private AST endReturning(AST returnExpr) {
+    AST end = new AST(XQ.End);
+    end.addChild(returnExpr);
+    return end;
+  }
+
+  /**
+   * End node returning the canonical vectorized group-by record:
+   * {@code {"<field>": $groupVar, "count": count($loopVar)}} — the exact shape
+   * required for the legacy single-key group-by claim.
+   */
+  private AST endReturningGroupCount(String field, String groupVar, String loopVar) {
+    return endReturningGroupCountMulti(new String[] { field }, new String[] { groupVar }, "count", loopVar);
+  }
+
+  /**
+   * End node returning the generalized group-by record:
+   * {@code {outNames[0]: $groupVars[0], ..., countName: count($loopVar)}}.
+   */
+  private AST endReturningGroupCountMulti(String[] outNames, String[] groupVars, String countName, String loopVar) {
+    AST obj = new AST(XQ.ObjectConstructor);
+    for (int i = 0; i < outNames.length; i++) {
+      AST keyField = new AST(XQ.KeyValueField);
+      keyField.addChild(strLit(outNames[i]));
+      keyField.addChild(new AST(XQ.VariableRef, new QNm(groupVars[i])));
+      obj.addChild(keyField);
+    }
+    AST countField = new AST(XQ.KeyValueField);
+    countField.addChild(strLit(countName));
+    AST countCall = new AST(XQ.FunctionCall, new QNm("count"));
+    countCall.addChild(new AST(XQ.VariableRef, new QNm(loopVar)));
+    countField.addChild(countCall);
+    obj.addChild(countField);
+    return endReturning(obj);
+  }
+
   /** ForBind with a typed variable binding and a dummy source, chaining to nextOp. */
   private AST forBind(String varName, AST nextOp) {
     AST fb = new AST(XQ.ForBind);
@@ -120,12 +158,19 @@ public class VectorizedGroupByDetectionTest {
     return lb;
   }
 
-  /** GroupBy node chaining to nextOp. */
-  private AST groupBy(AST nextOp) {
+  /** GroupBy node with a single grouping spec on {@code keyVar}, chaining to nextOp. */
+  private AST groupBy(String keyVar, AST nextOp) {
+    return groupByKeys(new String[] { keyVar }, nextOp);
+  }
+
+  /** GroupBy node with one grouping spec per key variable, chaining to nextOp. */
+  private AST groupByKeys(String[] keyVars, AST nextOp) {
     AST gb = new AST(XQ.GroupBy);
-    AST spec = new AST(XQ.GroupBySpec);
-    spec.addChild(new AST(XQ.VariableRef, new QNm("g")));
-    gb.addChild(spec);
+    for (String keyVar : keyVars) {
+      AST spec = new AST(XQ.GroupBySpec);
+      spec.addChild(new AST(XQ.VariableRef, new QNm(keyVar)));
+      gb.addChild(spec);
+    }
     AST dft = new AST(XQ.DftAggregateSpec);
     gb.addChild(dft);
     gb.addChild(nextOp);
@@ -190,8 +235,11 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void groupByPattern() {
-    // for $u in SRC let $c := $u.city group by $c return ...
-    AST pipe = pipeExpr(forBind("u", letBind("c", deref("u", "city"), groupBy(end()))));
+    // for $u in SRC let $c := $u.city group by $c return {"city": $c, "count": count($u)}
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("c",
+                                        deref("u", "city"),
+                                        groupBy("c", endReturningGroupCount("city", "c", "u")))));
 
     stage.rewrite(null, root(pipe));
 
@@ -203,8 +251,10 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void filteredCountPattern() {
-    // for $u in SRC where $u.age > 30 return ...
-    AST pipe = pipeExpr(forBind("u", selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)), end())));
+    // for $u in SRC where $u.age > 30 return $u
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
+                                          endReturningVar("u"))));
 
     stage.rewrite(null, root(pipe));
 
@@ -215,10 +265,13 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void filteredGroupByPattern() {
-    // for $u in SRC where $u.age > 30 let $c := $u.city group by $c return ...
+    // for $u in SRC where $u.age > 30 let $c := $u.city group by $c
+    // return {"city": $c, "count": count($u)}
     AST pipe = pipeExpr(forBind("u",
                                 selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
-                                          letBind("c", deref("u", "city"), groupBy(end())))));
+                                          letBind("c",
+                                                  deref("u", "city"),
+                                                  groupBy("c", endReturningGroupCount("city", "c", "u"))))));
 
     stage.rewrite(null, root(pipe));
 
@@ -230,25 +283,140 @@ public class VectorizedGroupByDetectionTest {
   }
 
   @Test
-  void multiKeyGroupByPattern() {
-    // for $u let $c := $u.city, $s := $u.state group by $c, $s return ...
+  void multiKeyGroupByWithSingleKeyReturnFailsClosed() {
+    // for $u let $c := $u.city, $s := $u.state group by $c, $s return {"city": $c, "count": count($u)}
+    // The return covers only ONE of the two grouping keys — the emitted records could
+    // not represent the two-key grouping. Neither claim may fire. (Historically this
+    // shape returned the single-first-key grouping — WRONG RESULTS.)
     AST pipe = pipeExpr(forBind("u",
-                                letBind("c", deref("u", "city"), letBind("s", deref("u", "state"), groupBy(end())))));
+                                letBind("c",
+                                        deref("u", "city"),
+                                        letBind("s",
+                                                deref("u", "state"),
+                                                groupByKeys(new String[] { "c", "s" },
+                                                            endReturningGroupCount("city", "c", "u"))))));
 
     stage.rewrite(null, root(pipe));
 
-    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
-    assertEquals("city", pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELD));
-    String[] extra = (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS_EXTRA);
-    assertNotNull(extra);
-    assertEquals(1, extra.length);
-    assertEquals("state", extra[0]);
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELD));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+  }
+
+  @Test
+  void twoKeyCanonicalReturnClaimsMulti() {
+    // for $u let $d := $u.dept, $c := $u.city group by $d, $c
+    // return {"d": $d, "c": $c, "n": count($u)}  — the exact bench groupBy2Keys shape
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("d",
+                                        deref("u", "dept"),
+                                        letBind("c",
+                                                deref("u", "city"),
+                                                groupByKeys(new String[] { "d", "c" },
+                                                            endReturningGroupCountMulti(new String[] { "d", "c" },
+                                                                                        new String[] { "d", "c" },
+                                                                                        "n",
+                                                                                        "u"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+    assertArrayEquals(new String[] { "dept", "city" },
+                      (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS));
+    assertArrayEquals(new String[] { "d", "c" },
+                      (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_OUT_NAMES));
+    assertEquals("n", pipe.getProperty(VectorizedScanAnnotation.GROUPBY_COUNT_NAME));
+    // The legacy single-key claim must NOT fire for a two-key grouping.
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+  }
+
+  @Test
+  void twoKeyReturnOrderDefinesOutputOrder() {
+    // return {"c": $c, "d": $d, ...} — RETURN-clause order wins, not let/spec order.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("d",
+                                        deref("u", "dept"),
+                                        letBind("c",
+                                                deref("u", "city"),
+                                                groupByKeys(new String[] { "d", "c" },
+                                                            endReturningGroupCountMulti(new String[] { "c", "d" },
+                                                                                        new String[] { "c", "d" },
+                                                                                        "n",
+                                                                                        "u"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+    assertArrayEquals(new String[] { "city", "dept" },
+                      (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS));
+    assertArrayEquals(new String[] { "c", "d" },
+                      (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_OUT_NAMES));
+  }
+
+  @Test
+  void renamedSingleKeyClaimsMultiOnly() {
+    // for $u let $d := $u.dept group by $d return {"d": $d, "n": count($u)} — output
+    // names differ from the canonical {dept, count}, so only the generalized claim fires.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("d",
+                                        deref("u", "dept"),
+                                        groupBy("d",
+                                                endReturningGroupCountMulti(new String[] { "d" },
+                                                                            new String[] { "d" },
+                                                                            "n",
+                                                                            "u")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+    assertArrayEquals(new String[] { "dept" }, (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS));
+    assertArrayEquals(new String[] { "d" }, (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_OUT_NAMES));
+    assertEquals("n", pipe.getProperty(VectorizedScanAnnotation.GROUPBY_COUNT_NAME));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+  }
+
+  @Test
+  void multiKeyDuplicateOutNamesFailsClosed() {
+    // return {"x": $d, "x": $c, "n": count($u)} — duplicate object keys change the shape.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("d",
+                                        deref("u", "dept"),
+                                        letBind("c",
+                                                deref("u", "city"),
+                                                groupByKeys(new String[] { "d", "c" },
+                                                            endReturningGroupCountMulti(new String[] { "x", "x" },
+                                                                                        new String[] { "d", "c" },
+                                                                                        "n",
+                                                                                        "u"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+  }
+
+  @Test
+  void multiKeyRepeatedKeyVarFailsClosed() {
+    // return {"a": $d, "b": $d, "n": count($u)} — $c never appears; $d twice.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("d",
+                                        deref("u", "dept"),
+                                        letBind("c",
+                                                deref("u", "city"),
+                                                groupByKeys(new String[] { "d", "c" },
+                                                            endReturningGroupCountMulti(new String[] { "a", "b" },
+                                                                                        new String[] { "d", "d" },
+                                                                                        "n",
+                                                                                        "u"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
   }
 
   @Test
   void orderByAscending() {
-    // for $u in SRC order by $u.name ascending return ...
-    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "name"), "ascending", end())));
+    // for $u in SRC order by $u.name ascending return $u
+    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "name"), "ascending", endReturningVar("u"))));
 
     stage.rewrite(null, root(pipe));
 
@@ -259,8 +427,8 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void orderByDescending() {
-    // for $u in SRC order by $u.score descending return ...
-    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "score"), "descending", end())));
+    // for $u in SRC order by $u.score descending return $u
+    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "score"), "descending", endReturningVar("u"))));
 
     stage.rewrite(null, root(pipe));
 
@@ -271,8 +439,10 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void stringEqualityFilter() {
-    // for $u where $u.city eq "NYC" return ...
-    AST pipe = pipeExpr(forBind("u", selection(comparison(XQ.ValueCompEQ, deref("u", "city"), strLit("NYC")), end())));
+    // for $u where $u.city eq "NYC" return $u
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.ValueCompEQ, deref("u", "city"), strLit("NYC")),
+                                          endReturningVar("u"))));
 
     stage.rewrite(null, root(pipe));
 
@@ -365,10 +535,10 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void filterWithOrderByDetectsBoth() {
-    // for $u where $u.age > 21 order by $u.name ascending return ...
+    // for $u where $u.age > 21 order by $u.name ascending return $u
     AST pipe = pipeExpr(forBind("u",
                                 selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(21)),
-                                          orderBy(deref("u", "name"), "ascending", end()))));
+                                          orderBy(deref("u", "name"), "ascending", endReturningVar("u")))));
 
     stage.rewrite(null, root(pipe));
 
@@ -399,7 +569,7 @@ public class VectorizedGroupByDetectionTest {
   @Test
   void groupByWithNoLetBindNoFields() {
     // GroupBy without preceding LetBind — groupFields will be empty, so no VECTORIZED_GROUPBY
-    AST pipe = pipeExpr(forBind("u", groupBy(end())));
+    AST pipe = pipeExpr(forBind("u", groupBy("g", end())));
 
     stage.rewrite(null, root(pipe));
 
@@ -410,10 +580,14 @@ public class VectorizedGroupByDetectionTest {
   @Test
   void nestedPipeExprBothAnnotated() {
     // Two PipeExpr nodes in a tree — both should be independently annotated
-    AST innerPipe = pipeExpr(forBind("v", letBind("d", deref("v", "dept"), groupBy(end()))));
+    AST innerPipe = pipeExpr(forBind("v",
+                                     letBind("d",
+                                             deref("v", "dept"),
+                                             groupBy("d", endReturningGroupCount("dept", "d", "v")))));
 
     AST outerPipe = pipeExpr(forBind("u",
-                                     selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(25)), end())));
+                                     selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(25)),
+                                               endReturningVar("u"))));
 
     AST root = new AST(XQ.Start);
     root.addChild(outerPipe);
@@ -441,30 +615,58 @@ public class VectorizedGroupByDetectionTest {
   }
 
   @Test
-  void threeKeyGroupBy() {
-    // for $u let $a := $u.city, $b := $u.state, $c := $u.country group by ... return ...
+  void threeKeyGroupByWithSingleKeyReturnFailsClosed() {
+    // for $u let $a := $u.city, $b := $u.state, $c := $u.country group by $a, $b, $c
+    // return {"city": $a, "count": count($u)} — return covers 1 of 3 keys.
     AST pipe = pipeExpr(forBind("u",
                                 letBind("a",
                                         deref("u", "city"),
                                         letBind("b",
                                                 deref("u", "state"),
-                                                letBind("c", deref("u", "country"), groupBy(end()))))));
+                                                letBind("c",
+                                                        deref("u", "country"),
+                                                        groupByKeys(new String[] { "a", "b", "c" },
+                                                                    endReturningGroupCount("city", "a", "u")))))));
 
     stage.rewrite(null, root(pipe));
 
-    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
-    assertEquals("city", pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELD));
-    String[] extra = (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS_EXTRA);
-    assertNotNull(extra);
-    assertEquals(2, extra.length);
-    assertEquals("state", extra[0]);
-    assertEquals("country", extra[1]);
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELD));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+  }
+
+  @Test
+  void threeKeyCanonicalReturnClaimsMulti() {
+    // for $u let $a := $u.city, $b := $u.state, $c := $u.country group by $a, $b, $c
+    // return {"city": $a, "state": $b, "country": $c, "count": count($u)}
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("a",
+                                        deref("u", "city"),
+                                        letBind("b",
+                                                deref("u", "state"),
+                                                letBind("c",
+                                                        deref("u", "country"),
+                                                        groupByKeys(new String[] { "a", "b", "c" },
+                                                                    endReturningGroupCountMulti(new String[] { "city",
+                                                                        "state", "country" },
+                                                                                                new String[] { "a", "b",
+                                                                                                    "c" },
+                                                                                                "count",
+                                                                                                "u")))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+    assertArrayEquals(new String[] { "city", "state", "country" },
+                      (String[]) pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELDS));
+    assertEquals("count", pipe.getProperty(VectorizedScanAnnotation.GROUPBY_COUNT_NAME));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
   }
 
   @Test
   void orderByWithDefaultDirection() {
-    // for $u order by $u.name return ...  (no explicit direction → "ascending")
-    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "name"), null, end())));
+    // for $u order by $u.name return $u  (no explicit direction → "ascending")
+    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "name"), null, endReturningVar("u"))));
 
     stage.rewrite(null, root(pipe));
 
@@ -474,24 +676,28 @@ public class VectorizedGroupByDetectionTest {
   }
 
   @Test
-  void filterAndGroupByAndOrderByAllDetected() {
-    // for $u where $u.age > 18 let $c := $u.city group by $c order by $u.name return ...
+  void groupByFollowedByOrderByFailsClosed() {
+    // for $u where $u.age > 18 let $c := $u.city group by $c order by $u.name
+    // return {"city": $c, "count": count($u)}
+    // The vectorized group-by executor emits groups in ITS order — claiming this
+    // pipeline would silently drop the requested ordering. The sorted-scan claim
+    // can't stand either (group-by changes the tuple shape). Only the predicate
+    // tree survives as information.
     AST pipe = pipeExpr(forBind("u",
                                 selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(18)),
                                           letBind("c",
                                                   deref("u", "city"),
-                                                  groupBy(orderBy(deref("u", "name"), "ascending", end()))))));
+                                                  groupBy("c",
+                                                          orderBy(deref("u", "name"),
+                                                                  "ascending",
+                                                                  endReturningGroupCount("city", "c", "u")))))));
 
     stage.rewrite(null, root(pipe));
 
-    // All three patterns detected
-    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
-    assertEquals("city", pipe.getProperty(VectorizedScanAnnotation.GROUPBY_FIELD));
-    assertNumCmp(predicateTree(pipe), "age", "gt", 18L);
-    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
-    assertEquals("name", pipe.getProperty(VectorizedScanAnnotation.ORDER_FIELD));
-    // Not a count pattern (group-by is present)
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
     assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertNumCmp(predicateTree(pipe), "age", "gt", 18L);
   }
 
   // ==================== ComparisonExpr wrapper tests (real parser output) ====================
@@ -500,7 +706,8 @@ public class VectorizedGroupByDetectionTest {
   void comparisonExprWrappedFilter() {
     // Real parser output: Selection → ComparisonExpr(GeneralCompGT, DerefExpr, Int)
     AST pipe = pipeExpr(forBind("u",
-                                selection(comparisonExpr(XQ.GeneralCompGT, deref("u", "age"), intLit(30)), end())));
+                                selection(comparisonExpr(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
+                                          endReturningVar("u"))));
 
     stage.rewrite(null, root(pipe));
 
@@ -533,10 +740,12 @@ public class VectorizedGroupByDetectionTest {
 
   @Test
   void comparisonExprFilteredGroupBy() {
-    // Real parser: where $u.age > 30 (as ComparisonExpr) + group by
+    // Real parser: where $u.age > 30 (as ComparisonExpr) + group by + canonical return
     AST pipe = pipeExpr(forBind("u",
                                 selection(comparisonExpr(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
-                                          letBind("c", deref("u", "city"), groupBy(end())))));
+                                          letBind("c",
+                                                  deref("u", "city"),
+                                                  groupBy("c", endReturningGroupCount("city", "c", "u"))))));
 
     stage.rewrite(null, root(pipe));
 
@@ -555,7 +764,7 @@ public class VectorizedGroupByDetectionTest {
   @Test
   void countDistinctGroupByLetReturnsKey() {
     // for $u let $d := $u.dept group by $d return $d  — the exact bench shape
-    AST pipe = pipeExpr(forBind("u", letBind("d", deref("u", "dept"), groupBy(endReturningVar("d")))));
+    AST pipe = pipeExpr(forBind("u", letBind("d", deref("u", "dept"), groupBy("d", endReturningVar("d")))));
 
     stage.rewrite(null, root(pipe));
 
@@ -568,9 +777,7 @@ public class VectorizedGroupByDetectionTest {
   @Test
   void countDistinctReturnMismatchNotAnnotated() {
     // for $u let $d := $u.dept group by $d return "x"  — return is not the group key
-    AST end = new AST(XQ.End);
-    end.addChild(strLit("x"));
-    AST pipe = pipeExpr(forBind("u", letBind("d", deref("u", "dept"), groupBy(end))));
+    AST pipe = pipeExpr(forBind("u", letBind("d", deref("u", "dept"), groupBy("d", endReturning(strLit("x"))))));
 
     stage.rewrite(null, root(pipe));
 
@@ -651,7 +858,7 @@ public class VectorizedGroupByDetectionTest {
   @Test
   void predicateTreeNoSelectionNotAnnotated() {
     // Pure group-by pattern with no WHERE clause → no PREDICATE_TREE.
-    AST pipe = pipeExpr(forBind("u", letBind("c", deref("u", "city"), groupBy(end()))));
+    AST pipe = pipeExpr(forBind("u", letBind("c", deref("u", "city"), groupBy("c", end()))));
     stage.rewrite(null, root(pipe));
     assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
   }
@@ -665,6 +872,221 @@ public class VectorizedGroupByDetectionTest {
     funcCall.addChild(deref("u", "age"));
     AST pipe = pipeExpr(forBind("u", selection(funcCall, end())));
     stage.rewrite(null, root(pipe));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
+  }
+
+  // ==================== Fail-closed negative tests ====================
+  // Every claim swaps the WHOLE pipeline for a vectorized executor with a fixed
+  // output shape, so any mismatch between query and executor must produce NO
+  // annotation — falling back to the generic pipeline is always correct.
+
+  @Test
+  void groupBySpecVarMismatchFailsClosed() {
+    // for $u let $c := $u.city group by $g — the spec groups by a DIFFERENT variable
+    // than the let-bound key; grouping by city would be wrong results.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("c",
+                                        deref("u", "city"),
+                                        groupBy("g", endReturningGroupCount("city", "c", "u")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT_DISTINCT));
+  }
+
+  @Test
+  void groupByComputedKeyFailsClosed() {
+    // for $u let $c := upper-case($u.city) group by $c — the key is COMPUTED; grouping
+    // by the raw `city` values (what lenient extraction used to find) is wrong results.
+    AST upper = new AST(XQ.FunctionCall, new QNm("upper-case"));
+    upper.addChild(deref("u", "city"));
+    AST pipe = pipeExpr(forBind("u", letBind("c", upper, groupBy("c", endReturningGroupCount("city", "c", "u")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT_DISTINCT));
+  }
+
+  @Test
+  void groupByWrongReturnFieldNameFailsClosed() {
+    // Canonical SHAPE but the first key is "town", not the grouping field "city" —
+    // the executor emits {"city": ...}, which is not what the query returns.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("c",
+                                        deref("u", "city"),
+                                        groupBy("c", endReturningGroupCount("town", "c", "u")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+  }
+
+  @Test
+  void groupByCountOverWrongVarFailsClosed() {
+    // return {"city": $c, "count": count($c)} — counts the KEY var, not the group tuples.
+    AST pipe = pipeExpr(forBind("u",
+                                letBind("c",
+                                        deref("u", "city"),
+                                        groupBy("c", endReturningGroupCount("city", "c", "c")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+  }
+
+  @Test
+  void unrepresentableSelectionBlocksGroupBy() {
+    // where some-fn($u.age) ... group by — the filter can't ride along as a
+    // PREDICATE_TREE, so a group-by claim would scan UNFILTERED. No claim.
+    AST funcCall = new AST(XQ.FunctionCall, new QNm("some-fn"));
+    funcCall.addChild(deref("u", "age"));
+    AST pipe = pipeExpr(forBind("u",
+                                selection(funcCall,
+                                          letBind("c",
+                                                  deref("u", "city"),
+                                                  groupBy("c", endReturningGroupCount("city", "c", "u"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
+  }
+
+  @Test
+  void unrepresentableSelectionBlocksOrderBy() {
+    // where some-fn($u.age) order by $u.name return $u — same unfiltered-scan hazard.
+    AST funcCall = new AST(XQ.FunctionCall, new QNm("some-fn"));
+    funcCall.addChild(deref("u", "age"));
+    AST pipe = pipeExpr(forBind("u",
+                                selection(funcCall, orderBy(deref("u", "name"), "ascending", endReturningVar("u")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+  }
+
+  @Test
+  void countDistinctWithSelectionFailsClosed() {
+    // count(for $u where $u.age > 30 let $d := $u.dept group by $d return $d) —
+    // an HLL cardinality sketch is unfiltered, so ANY selection blocks the claim.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
+                                          letBind("d", deref("u", "dept"), groupBy("d", endReturningVar("d"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT_DISTINCT));
+    // The filter itself is representable — only the count-distinct claim is blocked.
+    assertNumCmp(predicateTree(pipe), "age", "gt", 30L);
+  }
+
+  @Test
+  void orderByTwoSpecsFailsClosed() {
+    // order by $u.name, $u.age return $u — the executor sorts by ONE key; claiming
+    // the first spec would break ties differently than the query asks.
+    AST ob = new AST(XQ.OrderBy);
+    for (String f : new String[] { "name", "age" }) {
+      AST spec = new AST(XQ.OrderBySpec);
+      spec.addChild(deref("u", f));
+      ob.addChild(spec);
+    }
+    ob.addChild(endReturningVar("u"));
+    AST pipe = pipeExpr(forBind("u", ob));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
+  }
+
+  @Test
+  void orderByComputedKeyFailsClosed() {
+    // order by lower-case($u.name) return $u — sorting by the raw field is wrong.
+    AST lower = new AST(XQ.FunctionCall, new QNm("lower-case"));
+    lower.addChild(deref("u", "name"));
+    AST pipe = pipeExpr(forBind("u", orderBy(lower, "ascending", endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
+  }
+
+  @Test
+  void orderByReturningDerefFailsClosed() {
+    // order by $u.name return $u.name — the sorted scan emits FULL RECORDS, not a field.
+    AST pipe = pipeExpr(forBind("u", orderBy(deref("u", "name"), "ascending", endReturning(deref("u", "name")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
+  }
+
+  @Test
+  void countSequenceReturnFailsClosed() {
+    // where $u.age > 30 return ($u, $u) — doubles the count; must not claim.
+    AST seq = new AST(XQ.SequenceExpr);
+    seq.addChild(new AST(XQ.VariableRef, new QNm("u")));
+    seq.addChild(new AST(XQ.VariableRef, new QNm("u")));
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
+                                          endReturning(seq))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertNumCmp(predicateTree(pipe), "age", "gt", 30L);
+  }
+
+  @Test
+  void aggregateDirectFieldReturn() {
+    // for $u where $u.age > 30 return $u.amount — aggregate candidate (the enclosing
+    // sum/avg/... call fills AGGREGATE_FUNC); the count claim must NOT fire since the
+    // return is a field, which yields zero items for records lacking it.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)),
+                                          endReturning(deref("u", "amount")))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE));
+    assertEquals("amount", pipe.getProperty(VectorizedScanAnnotation.AGGREGATE_FIELD));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+  }
+
+  @Test
+  void aggregateCompositeReturnFailsClosed() {
+    // return $u.a + $u.b — lenient extraction would aggregate over field `a` alone.
+    AST sum = new AST(XQ.ArithmeticExpr);
+    sum.addChild(deref("u", "a"));
+    sum.addChild(deref("u", "b"));
+    AST pipe = pipeExpr(forBind("u", endReturning(sum)));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.AGGREGATE_FIELD));
+  }
+
+  @Test
+  void unknownChainOperatorFailsClosed() {
+    // for $u where $u.age > 30 count $pos return $u — the walker doesn't model the
+    // count clause; a claim would silently drop it. NOTHING may be annotated.
+    AST countClause = new AST(XQ.Count);
+    AST tvb = new AST(XQ.TypedVariableBinding);
+    tvb.addChild(new AST(XQ.Variable, new QNm("pos")));
+    countClause.addChild(tvb);
+    countClause.addChild(endReturningVar("u"));
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "age"), intLit(30)), countClause)));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_ORDERBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE));
     assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
   }
 }


### PR DESCRIPTION
Three silent wrong-results classes in the vectorized fast paths, fixed fail-closed, plus generalized (multi-key / renamed-output) group-by claims:

**1. Over-claiming detection.** `VectorizedGroupByDetection` annotated multi-key group-bys and never validated the return clause, the `GroupBySpec` variable, or the key/order/aggregate field sources — a two-key `group by $d, $c` silently returned the single-first-key grouping with canonical field names. Claims now require the exact canonical return shape, a `GroupBySpec`↔let-binding bijection, direct `$loopVar.field` sources (no `upper-case($u.city)` extraction), representable predicates (otherwise the executor would scan unfiltered), no trailing order-by, exactly one order-by spec, and a whitelisted operator chain. Dead `GROUPBY_FIELDS_EXTRA`/`TOPN` annotations removed.

**2. Result envelope.** Executors returned one array item where the FLWOR emits a sequence of records — counts coincidentally matched (brackit arrays iterate as members) but serialized results and positional semantics diverged from the generic pipeline. The `VectorizedExecutor` SPI now pins the RESULT ENVELOPE CONTRACT; `ParallelGroupByExec` returns a flat `ItemSequence`.

**3. Sorted-scan dispatch landmine.** A claimed order-by dispatched to an executor lacking `executeSortedScan` threw `BIT_DYN_INT_ERROR` at runtime (substitution is irreversible at translate time). Dispatch is now capability-gated via `supportsSortedScan()`.

**New capability:** `VECTORIZED_GROUPBY_MULTI` claims carry source fields, query-defined output names, and the count field name in return-clause order; dispatch is capability-gated via `supportsMultiKeyGroupBy()`/`executeGroupByCountMulti(...)`. SirixDB's executor implements it with a typed kernel (validated end-to-end there: 12/12 scale differential, byte-identical to the interpreted pipeline, two-key group-by 17.9s → 1.58s at 1M records).

`VectorizedGroupByDetectionTest` rewritten faithful (the old dummy-return fixtures asserted the over-claiming bug): 54 tests. Full suite **1124/0**.
