### PR TITLE
FpCmp/DecCmp vectorized predicate leaves + exact numeric literals; fix xs:decimal division

### DIFF
--- a/src/main/java/io/brackit/query/atomic/AbstractNumeric.java
+++ b/src/main/java/io/brackit/query/atomic/AbstractNumeric.java
@@ -274,8 +274,19 @@ public abstract class AbstractNumeric extends AbstractAtomic implements Numeric 
       throw new QueryException(ErrorCode.ERR_DIVISION_BY_ZERO);
     }
 
-    int scale = isDecimal ? a.scale() - b.scale() : INTEGER_DIV_SCALE;
-    return new Dec(a.divide(b, scale, RoundingMode.HALF_EVEN));
+    // Exact quotient when the division terminates; otherwise round to the same
+    // 18-digit scale the integer-division path uses. The historical scale rule
+    // `a.scale() - b.scale()` (the MULTIPLICATION scale identity, negated) was
+    // catastrophically wrong for xs:decimal operands: `1.0 div 2.0` evaluated
+    // to scale 0 and HALF_EVEN-rounded 0.5 to **0**; `10.2 div 4` returned 2.6
+    // instead of 2.55. XQuery F&O leaves xs:decimal division precision
+    // implementation-defined, but a terminating quotient must not be rounded
+    // away.
+    try {
+      return new Dec(a.divide(b));
+    } catch (final ArithmeticException nonTerminating) {
+      return new Dec(a.divide(b, INTEGER_DIV_SCALE, RoundingMode.HALF_EVEN));
+    }
   }
 
   protected final Numeric idivideDouble(double a, double b) {

--- a/src/main/java/io/brackit/query/compiler/optimizer/PredicateNode.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/PredicateNode.java
@@ -30,7 +30,7 @@ import java.util.List;
  * leave the annotation off the AST so the generic Volcano pipeline handles
  * the query.
  */
-public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNode.StrEq, PredicateNode.BoolRef, PredicateNode.And, PredicateNode.Or, PredicateNode.Not, PredicateNode.AlwaysTrue, PredicateNode.AlwaysFalse {
+public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNode.FpCmp, PredicateNode.DecCmp, PredicateNode.StrEq, PredicateNode.BoolRef, PredicateNode.And, PredicateNode.Or, PredicateNode.Not, PredicateNode.AlwaysTrue, PredicateNode.AlwaysFalse {
 
   /**
    * Numeric comparison {@code $u.field <op> literal}. {@code op} is one of
@@ -38,6 +38,51 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
    * {@code "ne"}.
    */
   record NumCmp(String field, String op, long value) implements PredicateNode {
+  }
+
+  /**
+   * Floating-point numeric comparison {@code $u.field <op> literal} where the
+   * literal is an {@code xs:double}. {@code op} uses the same encoding as
+   * {@link NumCmp}.
+   *
+   * <p>SEMANTICS CONTRACT (mirrors the interpreter's numeric promotion for an
+   * xs:double operand): a document value {@code v} satisfies the leaf iff
+   * {@code Double.compare(v.doubleValue(), value) <op> 0} — integer values
+   * promote via {@code (double) v} (including the interpreter-sanctioned
+   * precision loss above {@code 2^53}), doubles compare directly, decimals
+   * via {@code BigDecimal#doubleValue()}. This is exactly what brackit's
+   * {@code Int64#cmp} / {@code Dbl#cmp} / {@code Dec#cmp} compute when the
+   * other operand is a {@code DblNumeric}.
+   */
+  record FpCmp(String field, String op, double value) implements PredicateNode {
+  }
+
+  /**
+   * Exact decimal comparison {@code $u.field <op> literal} where the literal
+   * is a non-integral (or non-long-representable) {@code xs:decimal}.
+   * {@code op} uses the same encoding as {@link NumCmp}.
+   *
+   * <p>SEMANTICS CONTRACT (mirrors the interpreter's dispatch on the VALUE's
+   * type — {@code IntNumeric extends DecNumeric}, so integer and decimal
+   * document values compare against an xs:decimal EXACTLY in decimal space,
+   * while doubles promote the decimal):
+   * <ul>
+   * <li>integer value {@code v}: {@code BigDecimal.valueOf(v).compareTo(value)}
+   * (exact — {@code Int64#cmp}'s {@code DecNumeric} branch);</li>
+   * <li>decimal value {@code v}: {@code v.compareTo(value)} (exact —
+   * {@code Dec#cmp});</li>
+   * <li>double value {@code v}:
+   * {@code Double.compare(v, value.doubleValue())} ({@code Dbl#cmp}'s
+   * promotion of the decimal operand).</li>
+   * </ul>
+   * Long-representable integral decimals are normalized to {@link NumCmp} at
+   * detection; this leaf carries the irreducible cases (9.99, values beyond
+   * long range, sub-double precision) without any loss.
+   */
+  record DecCmp(String field, String op, java.math.BigDecimal value) implements PredicateNode {
+    public DecCmp {
+      java.util.Objects.requireNonNull(value, "value");
+    }
   }
 
   /** String equality {@code $u.field eq "literal"}. */
@@ -112,6 +157,8 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
   default void collectFields(java.util.Set<String> into) {
     switch (this) {
       case NumCmp n -> into.add(n.field);
+      case FpCmp f -> into.add(f.field);
+      case DecCmp d -> into.add(d.field);
       case StrEq s -> into.add(s.field);
       case BoolRef b -> into.add(b.field);
       case And a -> {
@@ -128,6 +175,106 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
       case AlwaysFalse f -> {
       }
     }
+  }
+
+  // ---------------- missing-field (sparse-data) analysis ----------------
+
+  /**
+   * {@code true} iff this predicate is PROVABLY FALSE for every record on
+   * which {@code field} is absent, regardless of the other fields' values.
+   *
+   * <p>Anchor-based scan executors (e.g. SirixDB's page scan) iterate records
+   * via one "anchor" field's slots and therefore never visit a record that
+   * lacks the anchor. That is only sound when records missing the anchor
+   * cannot satisfy the predicate. Comparison/EBV leaves over a missing field
+   * evaluate over the empty sequence and are false in XQuery, so:
+   * <ul>
+   * <li>a leaf on {@code field} is provably false when {@code field} is missing,</li>
+   * <li>a leaf on a different field may be anything,</li>
+   * <li>{@code And} is false if ANY child is provably false,</li>
+   * <li>{@code Or} is false only if ALL children are provably false,</li>
+   * <li>{@code Not} is false iff its child is provably TRUE — the De Morgan
+   * landmine: {@code not($u.x > 5)} over a record missing {@code x} is
+   * {@code not(false) = true}.</li>
+   * </ul>
+   */
+  default boolean excludesRecordsMissingField(String field) {
+    return switch (this) {
+      case NumCmp n -> n.field.equals(field);
+      case FpCmp f -> f.field.equals(field);
+      case DecCmp d -> d.field.equals(field);
+      case StrEq s -> s.field.equals(field);
+      case BoolRef b -> b.field.equals(field);
+      case And a -> {
+        for (PredicateNode c : a.children) {
+          if (c.excludesRecordsMissingField(field))
+            yield true;
+        }
+        yield false;
+      }
+      case Or o -> {
+        for (PredicateNode c : o.children) {
+          if (!c.excludesRecordsMissingField(field))
+            yield false;
+        }
+        // Vacuously: an empty Or is AlwaysFalse by convention.
+        yield true;
+      }
+      case Not n -> n.child.satisfiedWhenFieldMissing(field);
+      case AlwaysTrue t -> false;
+      case AlwaysFalse f -> true;
+    };
+  }
+
+  /**
+   * {@code true} iff this predicate is PROVABLY TRUE for every record on
+   * which {@code field} is absent, regardless of the other fields' values.
+   * Dual of {@link #excludesRecordsMissingField(String)} — needed for the
+   * {@code Not} case.
+   */
+  default boolean satisfiedWhenFieldMissing(String field) {
+    return switch (this) {
+      case NumCmp n -> false;
+      case FpCmp f -> false;
+      case DecCmp d -> false;
+      case StrEq s -> false;
+      case BoolRef b -> false;
+      case And a -> {
+        for (PredicateNode c : a.children) {
+          if (!c.satisfiedWhenFieldMissing(field))
+            yield false;
+        }
+        yield true;
+      }
+      case Or o -> {
+        for (PredicateNode c : o.children) {
+          if (c.satisfiedWhenFieldMissing(field))
+            yield true;
+        }
+        yield false;
+      }
+      case Not n -> n.child.excludesRecordsMissingField(field);
+      case AlwaysTrue t -> true;
+      case AlwaysFalse f -> false;
+    };
+  }
+
+  /**
+   * First field (in {@link #collectFields} order) that is a SOUND scan anchor
+   * for this predicate: records missing it are provably excluded, so an
+   * anchor-based executor that never visits them still produces exactly the
+   * generic pipeline's result. Returns {@code null} when no such field exists
+   * (e.g. {@code $u.a > 1 or $u.b > 1}) — callers must then fail closed and
+   * leave the query to the generic pipeline.
+   */
+  default String findSoundAnchorField() {
+    final java.util.LinkedHashSet<String> fields = new java.util.LinkedHashSet<>();
+    collectFields(fields);
+    for (String f : fields) {
+      if (excludesRecordsMissingField(f))
+        return f;
+    }
+    return null;
   }
 
   /** Singleton AlwaysTrue as a {@link List}-friendly constant. */

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
@@ -164,6 +164,19 @@ public final class VectorizedGroupByDetection implements Stage {
       return;
     }
 
+    // SOUND-ANCHOR GUARD: anchor-based executors iterate records via ONE
+    // field's slots and never visit a record lacking that field. A predicate
+    // that can hold on such a record (e.g. `$u.a > 1 or $u.b > 1` for a record
+    // carrying only `b`, or any shape whose Not/Or combination is satisfiable
+    // with some field absent) would silently lose matches on sparse data. Only
+    // claim predicates for which SOME referenced field provably excludes
+    // records missing it — the executor anchors there. No sound anchor → the
+    // whole selection is unrepresentable → generic (always correct) pipeline.
+    if (predicateRepresentable && !predicateConjuncts.isEmpty() && PredicateNode.and(predicateConjuncts)
+                                                                                .findSoundAnchorField() == null) {
+      predicateRepresentable = false;
+    }
+
     final boolean hasPredicate = predicateRepresentable && !predicateConjuncts.isEmpty();
     if (hasPredicate) {
       pipeExpr.setProperty(VectorizedScanAnnotation.PREDICATE_TREE, PredicateNode.and(predicateConjuncts));
@@ -621,9 +634,9 @@ public final class VectorizedGroupByDetection implements Stage {
     // $u.F OP literal — field on left.
     String field = directDerefFieldName(leftOperand);
     if (field != null) {
-      Long lv = extractIntegerLiteral(rightOperand);
-      if (lv != null)
-        return new PredicateNode.NumCmp(field, op, lv);
+      PredicateNode numCmp = numericComparison(field, op, rightOperand);
+      if (numCmp != null)
+        return numCmp;
       String sv = extractStringLiteral(rightOperand);
       if (sv != null && "eq".equals(op))
         return new PredicateNode.StrEq(field, sv);
@@ -632,9 +645,9 @@ public final class VectorizedGroupByDetection implements Stage {
     // literal OP $u.F — field on right. Reverse the comparison direction.
     field = directDerefFieldName(rightOperand);
     if (field != null) {
-      Long lv = extractIntegerLiteral(leftOperand);
-      if (lv != null)
-        return new PredicateNode.NumCmp(field, reverseOp(op), lv);
+      PredicateNode numCmp = numericComparison(field, reverseOp(op), leftOperand);
+      if (numCmp != null)
+        return numCmp;
       String sv = extractStringLiteral(leftOperand);
       if (sv != null && "eq".equals(op))
         return new PredicateNode.StrEq(field, sv);
@@ -714,29 +727,121 @@ public final class VectorizedGroupByDetection implements Stage {
 
   // ==================== Literal extraction ====================
 
-  private Long extractIntegerLiteral(AST node) {
-    if (node == null)
+  /** {@code Long.MIN_VALUE} / {@code Long.MAX_VALUE} as decimals, for exact-long range checks. */
+  private static final java.math.BigDecimal LONG_MIN = java.math.BigDecimal.valueOf(Long.MIN_VALUE);
+  private static final java.math.BigDecimal LONG_MAX = java.math.BigDecimal.valueOf(Long.MAX_VALUE);
+
+  /**
+   * Build the comparison leaf for {@code field <op> literal} — or {@code null}
+   * (fail closed, generic pipeline) when the literal cannot be represented
+   * EXACTLY in the vectorized predicate encoding.
+   *
+   * <p>Literal handling (the interpreter is the spec):
+   * <ul>
+   * <li>{@code xs:integer} ({@link XQ#Int}): exact {@code long} →
+   * {@link PredicateNode.NumCmp}; out-of-long-range integers fail closed.
+   * The historical code truncated via {@code Number#longValue()} —
+   * silently changing semantics for big literals.</li>
+   * <li>{@code xs:double} ({@link XQ#Dbl}): finite values →
+   * {@link PredicateNode.FpCmp}. The interpreter compares every numeric
+   * document value against an xs:double in double space
+   * ({@code Double.compare(v.doubleValue(), lit)} in
+   * {@code Int64#cmp}/{@code Dbl#cmp}/{@code Dec#cmp}) — exactly the FpCmp
+   * contract, including the interpreter-sanctioned precision loss for
+   * integers above {@code 2^53}. NaN / ±INF literals fail closed.</li>
+   * <li>{@code xs:decimal} ({@link XQ#Dec}): integral decimals that fit in a
+   * long → {@link PredicateNode.NumCmp} (exact, and identical semantics for
+   * every document value type). Anything else →
+   * {@link PredicateNode.DecCmp} carrying the EXACT
+   * {@link java.math.BigDecimal}: the interpreter compares integer and
+   * decimal document values against an xs:decimal exactly in decimal space
+   * ({@code IntNumeric extends DecNumeric}), so any lossy double image
+   * would silently change results. The historical code truncated
+   * {@code 9.99} to {@code 9}.</li>
+   * </ul>
+   */
+  private PredicateNode numericComparison(String field, String op, AST node) {
+    if (node == null || op == null)
       return null;
-    if (node.getType() == XQ.Int || node.getType() == XQ.Dbl || node.getType() == XQ.Dec) {
-      Object val = node.getValue();
-      if (val instanceof Number n)
-        return n.longValue();
-      // Brackit numeric types (Int32, Int64, etc.) extend Numeric, not java.lang.Number
-      if (val instanceof io.brackit.query.atomic.Numeric num)
-        return num.longValue();
-      if (val instanceof String s) {
-        try {
-          return Long.parseLong(s);
-        } catch (NumberFormatException e) {
-          return null;
-        }
+    final int type = node.getType();
+    if (type == XQ.Int) {
+      final Long lv = exactLongOf(node.getValue());
+      return lv != null ? new PredicateNode.NumCmp(field, op, lv) : null;
+    }
+    if (type == XQ.Dbl) {
+      final Double d = doubleOf(node.getValue());
+      if (d == null || !Double.isFinite(d))
+        return null;
+      return new PredicateNode.FpCmp(field, op, d);
+    }
+    if (type == XQ.Dec) {
+      final java.math.BigDecimal c = decimalOf(node.getValue());
+      if (c == null)
+        return null;
+      // Integral and long-representable → exact NumCmp.
+      if (c.stripTrailingZeros().scale() <= 0 && c.compareTo(LONG_MIN) >= 0 && c.compareTo(LONG_MAX) <= 0) {
+        return new PredicateNode.NumCmp(field, op, c.longValueExact());
+      }
+      return new PredicateNode.DecCmp(field, op, c);
+    }
+    // Any other node type is not a plain numeric literal — fail closed. (The
+    // historical catch-all read a Number value off ANY node type and truncated.)
+    return null;
+  }
+
+  /** Exact long of an integer-literal value object; {@code null} when lossy or not numeric. */
+  private static Long exactLongOf(Object val) {
+    if (val instanceof io.brackit.query.atomic.Numeric num) {
+      try {
+        return num.decimalValue().longValueExact();
+      } catch (ArithmeticException e) {
+        return null;
       }
     }
-    Object val = node.getValue();
-    if (val instanceof Number n)
-      return n.longValue();
+    if (val instanceof Long || val instanceof Integer || val instanceof Short || val instanceof Byte) {
+      return ((Number) val).longValue();
+    }
+    if (val instanceof String s) {
+      try {
+        return Long.parseLong(s);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /** Double of a double-literal value object; {@code null} when not numeric. */
+  private static Double doubleOf(Object val) {
     if (val instanceof io.brackit.query.atomic.Numeric num)
-      return num.longValue();
+      return num.doubleValue();
+    if (val instanceof Number n)
+      return n.doubleValue();
+    if (val instanceof String s) {
+      try {
+        return Double.parseDouble(s);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /** Exact decimal of a decimal-literal value object; {@code null} when not numeric. */
+  private static java.math.BigDecimal decimalOf(Object val) {
+    if (val instanceof io.brackit.query.atomic.Numeric num)
+      return num.decimalValue();
+    if (val instanceof java.math.BigDecimal bd)
+      return bd;
+    if (val instanceof Number n)
+      return new java.math.BigDecimal(n.toString());
+    if (val instanceof String s) {
+      try {
+        return new java.math.BigDecimal(s);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
     return null;
   }
 

--- a/src/test/java/io/brackit/query/atomic/NumericCorrectnessTest.java
+++ b/src/test/java/io/brackit/query/atomic/NumericCorrectnessTest.java
@@ -44,6 +44,39 @@ public class NumericCorrectnessTest extends XQueryBaseTest {
     ResultChecker.dCheck(new Int32(3), new Query("1 + 2").execute(ctx));
   }
 
+  // --- decimal division scale (was `1.0 div 2.0` -> 0, `10.2 div 4` -> 2.6:
+  // the result scale was computed as a.scale() - b.scale(), the negated
+  // MULTIPLICATION identity, and HALF_EVEN rounding destroyed terminating
+  // quotients) ---
+
+  @Test
+  public void decimalDivDecimalTerminating() {
+    ResultChecker.dCheck(dec("0.5"), new Query("1.0 div 2.0").execute(ctx));
+  }
+
+  @Test
+  public void decimalDivIntTerminating() {
+    ResultChecker.dCheck(dec("2.55"), new Query("10.2 div 4").execute(ctx));
+  }
+
+  @Test
+  public void decimalDivIntNonTerminating() {
+    // Non-terminating quotients round to the 18-digit scale the integer
+    // division path uses.
+    ResultChecker.dCheck(dec("0.033333333333333333"), new Query("0.1 div 3").execute(ctx));
+  }
+
+  @Test
+  public void avgDecimalsTerminating() {
+    // avg((10.2, ...)) routes through Dec#div — was rounded to one decimal digit.
+    ResultChecker.dCheck(dec("2.55"), new Query("avg((3, 3.7, 2, 1.5))").execute(ctx));
+  }
+
+  @Test
+  public void integerDivUnchanged() {
+    ResultChecker.dCheck(dec("2.5"), new Query("5 div 2").execute(ctx));
+  }
+
   // --- sum / avg over mixed int+decimal (was sum((1,2.5,3)) -> 6) ---
 
   @Test

--- a/src/test/java/io/brackit/query/compiler/optimizer/PredicateNodeMissingFieldTest.java
+++ b/src/test/java/io/brackit/query/compiler/optimizer/PredicateNodeMissingFieldTest.java
@@ -1,0 +1,130 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ */
+package io.brackit.query.compiler.optimizer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the missing-field (sparse-data) analysis on
+ * {@link PredicateNode}: {@code excludesRecordsMissingField},
+ * {@code satisfiedWhenFieldMissing} and {@code findSoundAnchorField}.
+ *
+ * <p>These drive the fail-closed sound-anchor guard in
+ * {@code VectorizedGroupByDetection}: an anchor-based executor never visits a
+ * record lacking the anchor field, which is only sound when such records are
+ * provably excluded by the predicate.
+ */
+public class PredicateNodeMissingFieldTest {
+
+  private static PredicateNode num(String f) {
+    return new PredicateNode.NumCmp(f, "gt", 5L);
+  }
+
+  private static PredicateNode fp(String f) {
+    return new PredicateNode.FpCmp(f, "gt", 5.5d);
+  }
+
+  private static PredicateNode dec(String f) {
+    return new PredicateNode.DecCmp(f, "gt", new java.math.BigDecimal("5.5"));
+  }
+
+  private static PredicateNode str(String f) {
+    return new PredicateNode.StrEq(f, "x");
+  }
+
+  private static PredicateNode bool(String f) {
+    return new PredicateNode.BoolRef(f);
+  }
+
+  @Test
+  void leavesExcludeTheirOwnMissingField() {
+    for (PredicateNode leaf : List.of(num("a"), fp("a"), dec("a"), str("a"), bool("a"))) {
+      assertTrue(leaf.excludesRecordsMissingField("a"), leaf + " must exclude records missing 'a'");
+      assertFalse(leaf.satisfiedWhenFieldMissing("a"), leaf + " must not be satisfied when 'a' is missing");
+      assertFalse(leaf.excludesRecordsMissingField("b"), leaf + " says nothing about records missing 'b'");
+    }
+  }
+
+  @Test
+  void andExcludesWhenAnyConjunctDoes() {
+    PredicateNode and = new PredicateNode.And(List.of(num("a"), num("b")));
+    assertTrue(and.excludesRecordsMissingField("a"));
+    assertTrue(and.excludesRecordsMissingField("b"));
+    assertEquals("a", and.findSoundAnchorField());
+  }
+
+  @Test
+  void orExcludesOnlyWhenAllDisjunctsDo() {
+    PredicateNode orDifferent = new PredicateNode.Or(List.of(num("a"), num("b")));
+    assertFalse(orDifferent.excludesRecordsMissingField("a"));
+    assertFalse(orDifferent.excludesRecordsMissingField("b"));
+    assertNull(orDifferent.findSoundAnchorField(), "or over different fields has NO sound anchor");
+
+    PredicateNode orSame = new PredicateNode.Or(List.of(num("a"), new PredicateNode.NumCmp("a", "lt", 0L)));
+    assertTrue(orSame.excludesRecordsMissingField("a"));
+    assertEquals("a", orSame.findSoundAnchorField());
+  }
+
+  @Test
+  void notOverMissingFieldIsSatisfied_theDeMorganLandmine() {
+    // not($u.a > 5) over a record missing `a`: the inner comparison evaluates
+    // over the empty sequence → false → not(false) = TRUE. An anchor scan on
+    // `a` would silently drop those matches.
+    PredicateNode not = new PredicateNode.Not(num("a"));
+    assertTrue(not.satisfiedWhenFieldMissing("a"));
+    assertFalse(not.excludesRecordsMissingField("a"));
+    assertNull(not.findSoundAnchorField());
+  }
+
+  @Test
+  void notOverAndIsNotExcluding() {
+    // not($u.a > 5 and $u.b > 5) over a record missing `a` is not(false) = true.
+    PredicateNode not = new PredicateNode.Not(new PredicateNode.And(List.of(num("a"), num("b"))));
+    assertFalse(not.excludesRecordsMissingField("a"));
+    assertFalse(not.excludesRecordsMissingField("b"));
+    assertNull(not.findSoundAnchorField());
+  }
+
+  @Test
+  void doubleNegationRestoresExclusion() {
+    PredicateNode notNot = new PredicateNode.Not(new PredicateNode.Not(num("a")));
+    assertTrue(notNot.excludesRecordsMissingField("a"));
+    assertEquals("a", notNot.findSoundAnchorField());
+  }
+
+  @Test
+  void soundConjunctRescuesUnsoundOr() {
+    // (a > 5 or b > 5) and c > 5 — `c` anchors soundly.
+    PredicateNode p = new PredicateNode.And(List.of(new PredicateNode.Or(List.of(num("a"), num("b"))), num("c")));
+    assertFalse(p.excludesRecordsMissingField("a"));
+    assertFalse(p.excludesRecordsMissingField("b"));
+    assertTrue(p.excludesRecordsMissingField("c"));
+    assertEquals("c", p.findSoundAnchorField());
+  }
+
+  @Test
+  void constantsBehave() {
+    assertTrue(PredicateNode.AlwaysFalse.INSTANCE.excludesRecordsMissingField("a"));
+    assertFalse(PredicateNode.AlwaysTrue.INSTANCE.excludesRecordsMissingField("a"));
+    assertTrue(PredicateNode.AlwaysTrue.INSTANCE.satisfiedWhenFieldMissing("a"));
+    // not(true) is always false → excludes everything.
+    assertTrue(new PredicateNode.Not(PredicateNode.AlwaysTrue.INSTANCE).excludesRecordsMissingField("a"));
+  }
+
+  @Test
+  void collectFieldsIncludesFpCmp() {
+    final java.util.LinkedHashSet<String> fields = new java.util.LinkedHashSet<>();
+    new PredicateNode.And(List.of(fp("s"), num("a"))).collectFields(fields);
+    assertEquals(List.of("s", "a"), List.copyOf(fields));
+  }
+}

--- a/src/test/java/io/brackit/query/compiler/optimizer/VectorizedGroupByDetectionTest.java
+++ b/src/test/java/io/brackit/query/compiler/optimizer/VectorizedGroupByDetectionTest.java
@@ -1089,4 +1089,250 @@ public class VectorizedGroupByDetectionTest {
     assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE));
     assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
   }
+
+  // ==================== floating-point literals (FpCmp) ====================
+
+  /** Decimal literal node — matches the parser ({@code new AST(XQ.Dec, new Dec(str))}). */
+  private AST decLit(String value) {
+    return new AST(XQ.Dec, new io.brackit.query.atomic.Dec(new java.math.BigDecimal(value)));
+  }
+
+  /** Double literal node — matches the parser ({@code new AST(XQ.Dbl, new Dbl(str))}). */
+  private AST dblLit(String value) {
+    return new AST(XQ.Dbl, new io.brackit.query.atomic.Dbl(Double.parseDouble(value)));
+  }
+
+  /** Assert the predicate is an FpCmp with the given field/op/value (bit-exact). */
+  private void assertFpCmp(PredicateNode p, String field, String op, double value) {
+    assertInstanceOf(PredicateNode.FpCmp.class, p, "expected FpCmp predicate");
+    PredicateNode.FpCmp fc = (PredicateNode.FpCmp) p;
+    assertEquals(field, fc.field());
+    assertEquals(op, fc.op());
+    assertEquals(Double.doubleToRawLongBits(value),
+                 Double.doubleToRawLongBits(fc.value()),
+                 "FpCmp value must be bit-exact: expected " + value + " got " + fc.value());
+  }
+
+  /** Assert the predicate is a DecCmp with the given field/op/value (exact decimal). */
+  private void assertDecCmp(PredicateNode p, String field, String op, String value) {
+    assertInstanceOf(PredicateNode.DecCmp.class, p, "expected DecCmp predicate");
+    PredicateNode.DecCmp dc = (PredicateNode.DecCmp) p;
+    assertEquals(field, dc.field());
+    assertEquals(op, dc.op());
+    assertEquals(0,
+                 new java.math.BigDecimal(value).compareTo(dc.value()),
+                 "DecCmp value must be exact: expected " + value + " got " + dc.value());
+  }
+
+  @Test
+  void decimalLiteralBecomesExactDecCmp() {
+    // for $u where $u.score gt 9.99 return $u — historically TRUNCATED to `score > 9`
+    // (silently wrong results); now carried as an EXACT DecCmp (the interpreter
+    // compares integer/decimal document values against an xs:decimal exactly).
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "score"), decLit("9.99")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertDecCmp(predicateTree(pipe), "score", "gt", "9.99");
+  }
+
+  @Test
+  void doubleLiteralBecomesFpCmp() {
+    // for $u where $u.score ge 2.5e0 return $u
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.ValueCompGE, deref("u", "score"), dblLit("2.5e0")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertFpCmp(predicateTree(pipe), "score", "ge", 2.5d);
+  }
+
+  @Test
+  void integralDecimalBecomesExactNumCmp() {
+    // for $u where $u.age le 10.0 return $u — 10.0 is an exact long; integer
+    // comparison and the interpreter's decimal comparison agree for every value.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompLE, deref("u", "age"), decLit("10.0")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertNumCmp(predicateTree(pipe), "age", "le", 10L);
+  }
+
+  @Test
+  void reversedDecimalComparisonNormalizes() {
+    // for $u where 9.99 lt $u.score return $u → score gt 9.99
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompLT, decLit("9.99"), deref("u", "score")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertDecCmp(predicateTree(pipe), "score", "gt", "9.99");
+  }
+
+  @Test
+  void fractionalEqualityBecomesDecCmp() {
+    // for $u where $u.score eq 2.5 return $u — eq over a fractional literal is
+    // representable; integral columns simply never match it.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.ValueCompEQ, deref("u", "score"), decLit("2.5")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertDecCmp(predicateTree(pipe), "score", "eq", "2.5");
+  }
+
+  @Test
+  void hugeIntegerLiteralFailsClosed() {
+    // where $u.x gt 18446744073709551616 (= 2^64, not long-representable):
+    // the historical Number#longValue() truncation changed semantics silently.
+    AST huge = new AST(XQ.Int, new io.brackit.query.atomic.Int(new java.math.BigDecimal("18446744073709551616")));
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "x"), huge), endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
+  }
+
+  @Test
+  void nonFiniteDoubleLiteralFailsClosed() {
+    // where $u.x lt xs:double NaN / INF — NaN comparison semantics (always false,
+    // even for lt+gt combined) are not representable; fail closed.
+    for (double bad : new double[] { Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY }) {
+      AST lit = new AST(XQ.Dbl, new io.brackit.query.atomic.Dbl(bad));
+      AST pipe = pipeExpr(forBind("u",
+                                  selection(comparison(XQ.GeneralCompLT, deref("u", "x"), lit), endReturningVar("u"))));
+
+      stage.rewrite(null, root(pipe));
+
+      assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT), "literal " + bad);
+      assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE), "literal " + bad);
+    }
+  }
+
+  @Test
+  void decimalCrossingIntegerBoundaryUnderDoubleRoundingStaysExact() {
+    // 9.9999999999999999999 rounds to double 10.0 — a double image would flip
+    // `x gt 9.9999999999999999999` for x=10. DecCmp carries the EXACT decimal,
+    // so the claim is safe.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT,
+                                                     deref("u", "x"),
+                                                     decLit("9.9999999999999999999")), endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertDecCmp(predicateTree(pipe), "x", "gt", "9.9999999999999999999");
+  }
+
+  @Test
+  void fractionalDecimalBeyondTwoPow53StaysExact() {
+    // |c| >= 2^53: longs near c are not double-exact — DecCmp keeps the exact
+    // decimal so the comparison never degrades to a double image.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "x"), decLit("9007199254740993.5")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertDecCmp(predicateTree(pipe), "x", "gt", "9007199254740993.5");
+  }
+
+  @Test
+  void integralDecimalBeyondTwoPow53StaysExactNumCmp() {
+    // 9007199254740993 (2^53 + 1) is integral and long-representable → exact
+    // NumCmp; the long comparison is exact even though the double image isn't.
+    AST pipe = pipeExpr(forBind("u",
+                                selection(comparison(XQ.GeneralCompGT, deref("u", "x"), decLit("9007199254740993")),
+                                          endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNumCmp(predicateTree(pipe), "x", "gt", 9007199254740993L);
+  }
+
+  // ==================== OR / sparse-anchor fail-closed ====================
+
+  @Test
+  void orAcrossDifferentFieldsFailsClosed() {
+    // where $u.a > 1 or $u.b > 1 — a record carrying only `b` satisfies the
+    // disjunction but is invisible to an anchor-based scan on `a` (and vice
+    // versa). No field is a sound anchor → no claim.
+    AST orExpr = new AST(XQ.OrExpr);
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "a"), intLit(1)));
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "b"), intLit(1)));
+    AST pipe = pipeExpr(forBind("u", selection(orExpr, endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
+  }
+
+  @Test
+  void orOnSameFieldStillClaimed() {
+    // where $u.a gt 900 or $u.a lt 5 — every disjunct references `a`; a record
+    // missing `a` fails both → `a` is a sound anchor → claimable.
+    AST orExpr = new AST(XQ.OrExpr);
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "a"), intLit(900)));
+    orExpr.addChild(comparison(XQ.GeneralCompLT, deref("u", "a"), intLit(5)));
+    AST pipe = pipeExpr(forBind("u", selection(orExpr, endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    PredicateNode p = predicateTree(pipe);
+    assertInstanceOf(PredicateNode.Or.class, p);
+  }
+
+  @Test
+  void orAcrossFieldsWithSoundConjunctStillClaimed() {
+    // where ($u.a > 1 or $u.b > 1) and $u.c > 0 — `c` is a sound anchor (records
+    // missing `c` fail the conjunction), so the predicate stays representable.
+    AST orExpr = new AST(XQ.OrExpr);
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "a"), intLit(1)));
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "b"), intLit(1)));
+    AST andExpr = new AST(XQ.AndExpr);
+    andExpr.addChild(orExpr);
+    andExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "c"), intLit(0)));
+    AST pipe = pipeExpr(forBind("u", selection(andExpr, endReturningVar("u"))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT));
+    PredicateNode p = predicateTree(pipe);
+    assertInstanceOf(PredicateNode.And.class, p);
+    assertEquals("c", p.findSoundAnchorField());
+  }
+
+  @Test
+  void orAcrossDifferentFieldsBlocksGroupByClaim() {
+    // The unsound predicate must also veto group-by / aggregate claims, not just
+    // the filtered count.
+    AST orExpr = new AST(XQ.OrExpr);
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "a"), intLit(1)));
+    orExpr.addChild(comparison(XQ.GeneralCompGT, deref("u", "b"), intLit(1)));
+    AST pipe = pipeExpr(forBind("u",
+                                selection(orExpr,
+                                          letBind("c",
+                                                  deref("u", "city"),
+                                                  groupBy("c", endReturningGroupCount("city", "c", "u"))))));
+
+    stage.rewrite(null, root(pipe));
+
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY_MULTI));
+    assertNull(pipe.getProperty(VectorizedScanAnnotation.PREDICATE_TREE));
+  }
 }


### PR DESCRIPTION
## Part 1: floating-point and decimal predicate support for the vectorized SPI

Predicates with non-integral numeric constants (`where $u.score > 9.99`) were previously unrepresentable: `extractIntegerLiteral` called `Number#longValue()` on `XQ.Dbl`/`XQ.Dec` literals, silently truncating (`> 9.99` became `> 9`), and out-of-long-range integers truncated to garbage.

- New `PredicateNode.FpCmp(field, op, double)` for xs:double literals — comparison contract is `Double.compare(value.doubleValue(), literal)`, i.e. the interpreter's own DblNumeric promotion including >2^53 precision loss, and `-0.0 < 0.0` ordering matching the interpreter.
- New `PredicateNode.DecCmp(field, op, BigDecimal)` carrying the exact decimal — `IntNumeric extends DecNumeric`, so int/decimal rows compare against xs:decimal exactly; no 2^53 bail needed (exactness is total).
- Detection now claims `NumCmp` only for exactly-long literals; NaN/INF and over-range integers fail closed.
- New `findSoundAnchorField` three-valued analysis vetoes anchor-unsound claims: `where $u.a > 1 or $u.b > 1` over records carrying only `b`, and the `not($u.missing > 5)` De Morgan landmine (true over a missing field), no longer reach the executor on an unsound anchor.

## Part 2: xs:decimal division returned wrong results (severe, pre-existing)

`divideBigDecimal` computed the result scale as `a.scale() - b.scale()` — the negated multiplication identity:

- `1.0 div 2.0` → **0** (expected 0.5)
- `10.2 div 4` → **2.6** (expected 2.55)
- `avg((3, 3.7, 2, 1.5))` → **2.6** (expected 2.55)

Now: exact quotient when it terminates, 18-digit HALF_EVEN otherwise. No existing test pinned the buggy values; new `NumericCorrectnessTest` regressions pin the correct ones.

## Tests

`mvn test`: **1,152 / 0 failures** (was 1,124) — detection suite 54 → 68, new `PredicateNodeMissingFieldTest` (9), +5 division regressions. The consuming SirixDB branch (`fix/projection-sparse-and-fpcmp`) adds 73 end-to-end differential cases pinning vectorized ≡ interpreted across both value provenances.

Note: the division fix changes interpreted results (for the better) for any decimal division — user-visible.