### PR TITLE
JSONiq bare-member filter semantics + temporal/regex/QName correctness wave

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -186,6 +186,11 @@ echo '[{"cat":"A","v":1},{"cat":"B","v":2},{"cat":"A","v":3}]' | \
 | **Automatic join optimization** | Hash-joins for FLWOR with multiple `for` clauses |
 | **JSON updates** | `insert`, `delete`, `replace`, `rename` |
 
+A `[? ... ]` predicate that references the current item `$$` is a truthiness filter: it keeps the
+items for which the expression has a true effective boolean value (`null`, `false`, `0`, `""`, and
+a missing member are falsy). Predicates that do not reference `$$` — such as `[?1]` or `[?last()]` —
+select by position, as in XQuery.
+
 ## Mutable JSON with Update Expressions
 
 Brackit supports the full JSONiq Update Facility - modify JSON data with declarative expressions:

--- a/src/main/java/io/brackit/query/atomic/Date.java
+++ b/src/main/java/io/brackit/query/atomic/Date.java
@@ -73,7 +73,9 @@ public class Date extends AbstractTimeInstant {
 
     if (end - start < 4) {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:date", str);
-    } else if (end - start > 4 && negative) {
+    } else if (end - start > 4 && charArray[start] == '0') {
+      // XSD: leading zeros are prohibited when the year has more than four digits; the sign
+      // does not restrict the number of digits.
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:date", str);
     }
     int v = start != end ? Integer.parseInt(str.substring(start, end)) : -1; // parse leading value

--- a/src/main/java/io/brackit/query/atomic/DateTime.java
+++ b/src/main/java/io/brackit/query/atomic/DateTime.java
@@ -85,7 +85,9 @@ public class DateTime extends AbstractTimeInstant {
 
     if (end - start < 4) {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:dateTime", str);
-    } else if (end - start > 4 && negative) {
+    } else if (end - start > 4 && charArray[start] == '0') {
+      // XSD: leading zeros are prohibited when the year has more than four digits; the sign
+      // does not restrict the number of digits.
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:dateTime", str);
     }
     int v = start != end ? Integer.parseInt(str.substring(start, end)) : -1; // parse leading value

--- a/src/main/java/io/brackit/query/atomic/GYE.java
+++ b/src/main/java/io/brackit/query/atomic/GYE.java
@@ -68,7 +68,9 @@ public class GYE extends AbstractTimeInstant {
 
     if (end - start < 4) {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gYear", str);
-    } else if ((end - start > 4) && (negative)) {
+    } else if ((end - start > 4) && (charArray[start] == '0')) {
+      // XSD: leading zeros are prohibited when the year has more than four digits; the sign
+      // does not restrict the number of digits.
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gYear", str);
     }
     int v = (start != end) ? Integer.parseInt(str.substring(start, end)) : -1; // parse leading value

--- a/src/main/java/io/brackit/query/atomic/GYM.java
+++ b/src/main/java/io/brackit/query/atomic/GYM.java
@@ -72,7 +72,9 @@ public class GYM extends AbstractTimeInstant {
 
     if (end - start < 4) {
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gYearMonth", str);
-    } else if ((end - start > 4) && (negative)) {
+    } else if ((end - start > 4) && (charArray[start] == '0')) {
+      // XSD: leading zeros are prohibited when the year has more than four digits; the sign
+      // does not restrict the number of digits.
       throw new QueryException(ErrorCode.ERR_INVALID_VALUE_FOR_CAST, "Cannot cast '%s' to xs:gYearMonth", str);
     }
     int v = (start != end) ? Integer.parseInt(str.substring(start, end)) : -1; // parse leading value

--- a/src/main/java/io/brackit/query/compiler/parser/JsoniqParser.java
+++ b/src/main/java/io/brackit/query/compiler/parser/JsoniqParser.java
@@ -3000,6 +3000,12 @@ public class JsoniqParser extends Tokenizer {
       }
     }
     AST pred = new AST(XQ.Predicate);
+    if (isJsoniq) {
+      // Mark predicates stemming from the JSONiq filter syntax "[? ... ]" so that the
+      // compiler can apply filter (truthiness) semantics to context-item-dependent
+      // predicates instead of XQuery's numeric-equals-position rule.
+      pred.setProperty("jsoniqFilter", Boolean.TRUE);
+    }
     pred.addChild(expr());
     consumeSkipWS("]");
     return pred;

--- a/src/main/java/io/brackit/query/compiler/translator/Compiler.java
+++ b/src/main/java/io/brackit/query/compiler/translator/Compiler.java
@@ -585,21 +585,29 @@ public class Compiler implements Translator {
     boolean[] bindItem = new boolean[noOfPredicates];
     boolean[] bindPos = new boolean[noOfPredicates];
     boolean[] bindSize = new boolean[noOfPredicates];
+    boolean[] ebvFilter = new boolean[noOfPredicates];
 
     for (int i = 0; i < noOfPredicates; i++) {
+      AST predicate = node.getChild(1 + i);
       Binding itemBinding = table.bind(Bits.FS_DOT, SequenceType.ITEM);
       Binding posBinding = table.bind(Bits.FS_POSITION, SequenceType.INTEGER);
       Binding sizeBinding = table.bind(Bits.FS_LAST, SequenceType.INTEGER);
-      predicates[i] = expr(node.getChild(1 + i).getChild(0), true);
+      predicates[i] = expr(predicate.getChild(0), true);
       table.unbind();
       table.unbind();
       table.unbind();
       bindItem[i] = itemBinding.isReferenced();
       bindPos[i] = posBinding.isReferenced();
       bindSize[i] = sizeBinding.isReferenced();
+      // A JSONiq "[? ... ]" filter that references the context item ($$) is a pure
+      // truthiness filter: the predicate value is reduced to its effective boolean
+      // value and is never compared against the context position. Context-item
+      // independent predicates such as [?1] or [?last()] retain XQuery's positional
+      // semantics.
+      ebvFilter[i] = bindItem[i] && predicate.checkProperty("jsoniqFilter");
     }
 
-    return new FilterExpr(expr, predicates, bindItem, bindPos, bindSize);
+    return new FilterExpr(expr, predicates, bindItem, bindPos, bindSize, ebvFilter);
   }
 
   protected Expr insertExpr(AST node) throws QueryException {

--- a/src/main/java/io/brackit/query/expr/FilterExpr.java
+++ b/src/main/java/io/brackit/query/expr/FilterExpr.java
@@ -52,6 +52,12 @@ public class FilterExpr extends PredicateExpr {
     this.expr = expr;
   }
 
+  public FilterExpr(Expr expr, Expr[] filter, boolean[] bindItem, boolean[] bindPos, boolean[] bindSize,
+      boolean[] ebvFilter) {
+    super(filter, bindItem, bindPos, bindSize, ebvFilter);
+    this.expr = expr;
+  }
+
   @Override
   public Sequence evaluate(final QueryContext ctx, final Tuple tuple) {
     Sequence s = expr.evaluate(ctx, tuple);
@@ -121,7 +127,9 @@ public class FilterExpr extends PredicateExpr {
           return null;
         }
 
-        if (fRes instanceof Numeric && ((Numeric) fRes).intValue() != 1) {
+        // JSONiq [? ... ] filters over the context item are pure truthiness checks; only
+        // ordinary XQuery predicates treat a numeric predicate value as a positional test.
+        if (!ebvFilter[i] && fRes instanceof Numeric && ((Numeric) fRes).intValue() != 1) {
           return null;
         }
 

--- a/src/main/java/io/brackit/query/expr/PredicateExpr.java
+++ b/src/main/java/io/brackit/query/expr/PredicateExpr.java
@@ -49,12 +49,24 @@ public abstract class PredicateExpr implements Expr {
   protected final boolean[] bindPos;
   protected final boolean[] bindSize;
   protected final int[] bindCount;
+  /**
+   * Per predicate: {@code true} if the predicate is a JSONiq {@code [? ... ]} filter referencing
+   * the context item ({@code $$}). Such filters apply effective-boolean-value (truthiness)
+   * semantics unconditionally — a numeric predicate value is NOT interpreted as a positional
+   * test against the context position.
+   */
+  protected final boolean[] ebvFilter;
 
   public PredicateExpr(Expr[] filter, boolean[] bindItem, boolean[] bindPos, boolean[] bindSize) {
+    this(filter, bindItem, bindPos, bindSize, new boolean[filter.length]);
+  }
+
+  public PredicateExpr(Expr[] filter, boolean[] bindItem, boolean[] bindPos, boolean[] bindSize, boolean[] ebvFilter) {
     this.filter = filter;
     this.bindItem = bindItem;
     this.bindPos = bindPos;
     this.bindSize = bindSize;
+    this.ebvFilter = ebvFilter;
     this.bindCount = new int[filter.length];
     for (int i = 0; i < filter.length; i++) {
       bindCount[i] = (bindItem[i] ? 1 : 0) + (bindPos[i] ? 1 : 0) + (bindSize[i] ? 1 : 0);
@@ -137,6 +149,11 @@ public abstract class PredicateExpr implements Expr {
 
           if (res == null) {
             return false;
+          }
+
+          if (ebvFilter[i]) {
+            // JSONiq [? ... ] filter over the context item: pure truthiness check.
+            return res.booleanValue();
           }
 
           if (res instanceof Numeric) {

--- a/src/main/java/io/brackit/query/function/fn/AdjustToTimezone.java
+++ b/src/main/java/io/brackit/query/function/fn/AdjustToTimezone.java
@@ -73,7 +73,10 @@ public class AdjustToTimezone extends AbstractFunction {
     DTD timezone;
     if (args.length > 1) {
       timezone = (DTD) args[1];
-      if (timezone != null && (timezone.getMinutes() != 0 || timezone.getDays() != 0 || timezone.getHours() > 14)) {
+      // A timezone must be a whole number of minutes within -PT14H..PT14H. Sub-hour
+      // offsets such as PT5H30M are valid.
+      if (timezone != null && (timezone.getDays() != 0 || timezone.getMicros() != 0 || timezone.getHours() > 14
+          || (timezone.getHours() == 14 && timezone.getMinutes() != 0))) {
         throw new QueryException(ErrorCode.ERR_INVALID_TIMEZONE, "Invalid value for timezone.");
       }
     } else {
@@ -104,22 +107,12 @@ public class AdjustToTimezone extends AbstractFunction {
                                                        dt.getMicros(),
                                                        null);
         } else {
-          byte old = dt.getTimezone().getHours();
-          if (dt.getTimezone().isNegative()) {
-            old *= -1;
-          }
-
-          byte nw = timezone.getHours();
-          if (timezone.isNegative()) {
-            nw *= -1;
-          }
-
-          int diff = nw - old;
+          int diff = offsetInMinutes(timezone) - offsetInMinutes(dt.getTimezone());
           if (diff == 0) {
             return dt;
           }
 
-          dtNew = dt.add(new DTD(diff < 0, 0, (byte) Math.abs(diff), (byte) 0, 0));
+          dtNew = dt.add(minutesToDTD(diff));
           dtNew = new DateTime(dtNew.getYear(),
                                dtNew.getMonth(),
                                dtNew.getDay(),
@@ -142,22 +135,12 @@ public class AdjustToTimezone extends AbstractFunction {
         } else if (timezone == null) {
           dateNew = new Date(date.getYear(), date.getMonth(), date.getDay(), null);
         } else {
-          byte old = date.getTimezone().getHours();
-          if (date.getTimezone().isNegative()) {
-            old *= -1;
-          }
-
-          byte nw = timezone.getHours();
-          if (timezone.isNegative()) {
-            nw *= -1;
-          }
-
-          int diff = nw - old;
+          int diff = offsetInMinutes(timezone) - offsetInMinutes(date.getTimezone());
           if (diff == 0) {
             return date;
           }
 
-          dateNew = date.add(new DTD(diff < 0, 0, (byte) Math.abs(diff), (byte) 0, 0));
+          dateNew = date.add(minutesToDTD(diff));
           dateNew = new Date(dateNew.getYear(), dateNew.getMonth(), dateNew.getDay(), timezone);
         }
 
@@ -174,22 +157,12 @@ public class AdjustToTimezone extends AbstractFunction {
         } else if (timezone == null) {
           timeNew = new Time(time.getHours(), time.getMinutes(), time.getMicros(), null);
         } else {
-          byte old = time.getTimezone().getHours();
-          if (time.getTimezone().isNegative()) {
-            old *= -1;
-          }
-
-          byte nw = timezone.getHours();
-          if (timezone.isNegative()) {
-            nw *= -1;
-          }
-
-          int diff = nw - old;
+          int diff = offsetInMinutes(timezone) - offsetInMinutes(time.getTimezone());
           if (diff == 0) {
             return time;
           }
 
-          timeNew = time.add(new DTD(diff < 0, 0, (byte) Math.abs(diff), (byte) 0, 0));
+          timeNew = time.add(minutesToDTD(diff));
           timeNew = new Time(timeNew.getHours(), timeNew.getMinutes(), timeNew.getMicros(), timezone);
         }
 
@@ -197,6 +170,21 @@ public class AdjustToTimezone extends AbstractFunction {
     }
 
     return null;
+  }
+
+  /**
+   * The signed total offset of a timezone in minutes. Timezone offsets are not restricted to
+   * whole hours (e.g., +05:30); dropping the minutes component shifts the adjusted value to a
+   * different instant.
+   */
+  private static int offsetInMinutes(DTD timezone) {
+    int minutes = timezone.getHours() * 60 + timezone.getMinutes();
+    return timezone.isNegative() ? -minutes : minutes;
+  }
+
+  private static DTD minutesToDTD(int diffInMinutes) {
+    int abs = Math.abs(diffInMinutes);
+    return new DTD(diffInMinutes < 0, 0, (byte) (abs / 60), (byte) (abs % 60), 0);
   }
 
 }

--- a/src/main/java/io/brackit/query/function/fn/QNameComponent.java
+++ b/src/main/java/io/brackit/query/function/fn/QNameComponent.java
@@ -1,0 +1,78 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.function.fn;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.AnyURI;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.function.AbstractFunction;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Signature;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.module.StaticContext;
+
+/**
+ * Implements the QName component accessors fn:local-name-from-QName($arg),
+ * fn:namespace-uri-from-QName($arg), and fn:prefix-from-QName($arg) as per
+ * http://www.w3.org/TR/xpath-functions/#func-local-name-from-QName ff.
+ */
+public class QNameComponent extends AbstractFunction {
+  public enum Component {
+    LOCAL_NAME, NAMESPACE_URI, PREFIX
+  }
+
+  private final Component component;
+
+  public QNameComponent(QNm name, Component component, Signature signature) {
+    super(name, signature, true);
+    this.component = component;
+  }
+
+  @Override
+  public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
+    if (args[0] == null) {
+      return null;
+    }
+
+    final QNm qname = (QNm) args[0];
+    switch (component) {
+      case LOCAL_NAME:
+        return new Str(qname.getLocalName()).asType(Type.NCN);
+      case NAMESPACE_URI:
+        // A QName in no namespace yields the zero-length xs:anyURI.
+        return new AnyURI(qname.getNamespaceURI() != null ? qname.getNamespaceURI() : "");
+      case PREFIX:
+        final String prefix = qname.getPrefix();
+        return prefix != null && !prefix.isEmpty() ? new Str(prefix).asType(Type.NCN) : null;
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/java/io/brackit/query/module/Functions.java
+++ b/src/main/java/io/brackit/query/module/Functions.java
@@ -510,6 +510,18 @@ public final class Functions {
                         new Signature(new SequenceType(AtomicType.QNM, Cardinality.One),
                                       new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
                                       new SequenceType(AtomicType.STR, Cardinality.One))));
+    predefine(new QNameComponent(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "local-name-from-QName"),
+                                 QNameComponent.Component.LOCAL_NAME,
+                                 new Signature(new SequenceType(new AtomicType(Type.NCN), Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.QNM, Cardinality.ZeroOrOne))));
+    predefine(new QNameComponent(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "namespace-uri-from-QName"),
+                                 QNameComponent.Component.NAMESPACE_URI,
+                                 new Signature(new SequenceType(AtomicType.AURI, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.QNM, Cardinality.ZeroOrOne))));
+    predefine(new QNameComponent(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "prefix-from-QName"),
+                                 QNameComponent.Component.PREFIX,
+                                 new Signature(new SequenceType(new AtomicType(Type.NCN), Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.QNM, Cardinality.ZeroOrOne))));
 
     // See XQuery Functions and Operators 14 Functions and Operators on
     // Nodes

--- a/src/main/java/io/brackit/query/util/Regex.java
+++ b/src/main/java/io/brackit/query/util/Regex.java
@@ -70,8 +70,14 @@ public class Regex {
 
     // parse flags
     boolean removeWhitespace = false;
+    boolean literal = false;
     int flagMask = Pattern.UNIX_LINES;
     if (flags != null) {
+      if (flags.contains("q")) {
+        literal = true;
+        flags = flags.replace("q", "");
+      }
+
       if (flags.contains("x")) {
         removeWhitespace = true;
         flags = flags.replace("x", "");
@@ -95,13 +101,20 @@ public class Regex {
       if (!flags.isEmpty()) {
         throw new QueryException(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION_FLAGS, "Unknown flags specified.");
       }
+
+      if (literal) {
+        // Flag "q": all characters of the pattern represent themselves. It may be combined
+        // with "i"; the "m", "s", and "x" flags have no effect in its presence.
+        flagMask &= ~(Pattern.DOTALL | Pattern.MULTILINE);
+        removeWhitespace = false;
+      }
     }
 
     if (mode != Mode.MATCH) {
       // Pattern.matches runs on the RAW pattern OUTSIDE the compile try/catch below — an invalid
       // pattern (e.g. fn:tokenize('a','[')) threw a raw PatternSyntaxException instead of FORX0002.
       try {
-        if (Pattern.matches(pattern, "")) {
+        if (literal ? pattern.isEmpty() : Pattern.matches(pattern, "")) {
           throw (new QueryException(ErrorCode.ERR_REGULAR_EXPRESSION_EMPTY_STRING, "Pattern matches empty string."));
         }
       } catch (PatternSyntaxException e) {
@@ -115,8 +128,12 @@ public class Regex {
 
     Pattern cpattern;
     try {
-      String regex = adaptRegEx(mode, pattern, flagMask, removeWhitespace);
-      cpattern = Pattern.compile(regex, flagMask);
+      if (literal) {
+        cpattern = Pattern.compile(pattern, flagMask | Pattern.LITERAL);
+      } else {
+        String regex = adaptRegEx(mode, pattern, flagMask, removeWhitespace);
+        cpattern = Pattern.compile(regex, flagMask);
+      }
     } catch (PatternSyntaxException e) {
       throw (new QueryException(e, ErrorCode.ERR_INVALID_REGULAR_EXPRESSION));
     }
@@ -124,8 +141,22 @@ public class Regex {
 
     switch (mode) {
       case MATCH:
-        return new Bool(matcher.matches());
+        // fn:matches has substring semantics. For translated patterns adaptRegEx pads the
+        // pattern with ".*" on both sides; a literal ("q") pattern must not be padded, so
+        // search for it instead.
+        return new Bool(literal ? matcher.find() : matcher.matches());
       case REPLACE:
+        if (literal) {
+          // Flag "q": the characters of the replacement string also represent themselves —
+          // "$" and "\" have no special significance.
+          StringBuffer literalSb = new StringBuffer();
+          while (matcher.find()) {
+            matcher.appendReplacement(literalSb, Matcher.quoteReplacement(replace));
+          }
+          matcher.appendTail(literalSb);
+          return new Str(literalSb.toString());
+        }
+
         // Disallowed in replacement string: backslash or dollar sign as
         // only character in string, or dollar sign not preceded by
         // backslash and not followed by a digit, or backslash not

--- a/src/test/java/io/brackit/query/JsoniqFilterPredicateTest.java
+++ b/src/test/java/io/brackit/query/JsoniqFilterPredicateTest.java
@@ -1,0 +1,137 @@
+package io.brackit.query;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for the JSONiq {@code [? ... ]} filter over literal (non-store) items.
+ *
+ * <p>A bare member lookup such as {@code $a[][?$$.price]} used to return an empty sequence
+ * whenever the member values were numeric: the predicate machinery applied XQuery's
+ * numeric-equals-position rule to the looked-up value, so {@code price} was compared against the
+ * context position instead of being reduced to its effective boolean value. String and boolean
+ * members were unaffected (they always took the EBV path), which made the failure data-dependent.
+ *
+ * <p>Semantics under test: a JSONiq {@code [? ... ]} predicate that references the context item
+ * ({@code $$}) is a pure truthiness filter — the predicate value's effective boolean value decides,
+ * with brackit's usual EBV rules (missing member/empty sequence, {@code null}, {@code false},
+ * {@code 0}, {@code ""} are all falsy). Context-item independent predicates such as {@code [?1]},
+ * {@code [?last()]}, or {@code [?position() gt 1]} keep XQuery's positional semantics, as do plain
+ * {@code [...]} predicates in XQuery syntax mode.
+ */
+public final class JsoniqFilterPredicateTest extends XQueryBaseTest {
+
+  private static final String BOOKS =
+      "let $a := [{\"title\":\"A\",\"price\":12.5},{\"title\":\"B\"},{\"title\":\"C\",\"price\":42}] return ";
+
+  private static final String A_AND_C = "{\"title\":\"A\",\"price\":12.5} {\"title\":\"C\",\"price\":42}";
+
+  @Test
+  public void bareNumericMemberFiltersByTruthiness() {
+    // The original wrong-result repro: objects with a (numeric) price member are kept.
+    assertEquals(A_AND_C, query(BOOKS + "$a[][?$$.price]"));
+  }
+
+  @Test
+  public void bareNumericMemberOnSingleObject() {
+    // Single-item input goes through evaluateToItem: 3 is truthy, not "position 3".
+    assertEquals("{\"key\":3,\"foo\":0}", query("{\"key\": 3, \"foo\": 0}[?$$.key]"));
+    assertEquals("", query("{\"key\": 3, \"foo\": 0}[?$$.foo]"));
+  }
+
+  @Test
+  public void bareStringMemberKeepsAllObjects() {
+    assertEquals("{\"title\":\"A\",\"price\":12.5} {\"title\":\"B\"} {\"title\":\"C\",\"price\":42}",
+                 query(BOOKS + "$a[][?$$.title]"));
+  }
+
+  @Test
+  public void missingMemberIsExcluded() {
+    assertEquals("", query("[{\"a\":1},{\"a\":2}][][?$$.nope]"));
+  }
+
+  @Test
+  public void nullMemberIsExcluded() {
+    // EBV of JSON null is false (matches brackit's Null.booleanValue() convention).
+    assertEquals("{\"x\":1}", query("[{\"x\":null},{\"x\":1}][][?$$.x]"));
+  }
+
+  @Test
+  public void falsyMemberValuesAreExcluded() {
+    assertEquals("{\"x\":true}", query("[{\"x\":false},{\"x\":true}][][?$$.x]"));
+    assertEquals("{\"x\":7}", query("[{\"x\":0},{\"x\":7}][][?$$.x]"));
+    assertEquals("{\"x\":\"y\"}", query("[{\"x\":\"\"},{\"x\":\"y\"}][][?$$.x]"));
+  }
+
+  @Test
+  public void numericValueEqualToPositionIsNotPositional() {
+    // {"a":2} sits at position 2: under the old positional rule it was (accidentally) kept and
+    // {"a":5} dropped; under filter semantics both are truthy.
+    assertEquals("{\"a\":2} {\"a\":5}", query("[{\"a\":2},{\"a\":5}][][?$$.a]"));
+  }
+
+  @Test
+  public void bareContextItemFiltersByTruthiness() {
+    assertEquals("1 2", query("(0, 1, 2)[?$$]"));
+  }
+
+  @Test
+  public void predicateAgreesWithFlworWhere() {
+    // Differential sanity: [?pred($$)] must agree with "for ... where pred($b)".
+    final String[][] cases = { { "$a[][?$$.price]", "for $b in $a[] where $b.price return $b" }, { "$a[][?$$.title]",
+        "for $b in $a[] where $b.title return $b" }, { "$a[][?$$.nope]", "for $b in $a[] where $b.nope return $b" }, {
+            "$a[][?$$.price gt 10]", "for $b in $a[] where $b.price gt 10 return $b" } };
+    for (String[] c : cases) {
+      assertEquals(query(BOOKS + c[1]), query(BOOKS + c[0]), "predicate vs FLWOR for " + c[0]);
+    }
+    assertEquals(query("for $b in [{\"x\":null},{\"x\":1}][] where $b.x return $b"),
+                 query("[{\"x\":null},{\"x\":1}][][?$$.x]"));
+    assertEquals(query("for $b in [{\"x\":false},{\"x\":0},{\"x\":\"\"},{\"x\":\"y\"}][] where $b.x return $b"),
+                 query("[{\"x\":false},{\"x\":0},{\"x\":\"\"},{\"x\":\"y\"}][][?$$.x]"));
+  }
+
+  @Test
+  public void comparisonPredicatesAreUnchanged() {
+    assertEquals(A_AND_C, query(BOOKS + "$a[][?$$.price gt 10]"));
+    assertEquals(A_AND_C, query(BOOKS + "$a[][?boolean($$.price)]"));
+    assertEquals(A_AND_C, query(BOOKS + "$a[][?exists($$.price)]"));
+  }
+
+  @Test
+  public void contextIndependentPredicatesStayPositional() {
+    // No $$ reference: XQuery positional semantics must be preserved.
+    assertEquals("b", query("(\"a\", \"b\", \"c\")[?2]"));
+    assertEquals("a", query("(\"a\", \"b\", \"c\")[?1]"));
+    assertEquals("c", query("(\"a\", \"b\", \"c\")[?last()]"));
+    assertEquals("b c", query("(\"a\", \"b\", \"c\")[?position() gt 1]"));
+    assertEquals("20", query("(10, 20, 30)[?2]"));
+  }
+
+  @Test
+  public void chainedFiltersCompose() {
+    assertEquals("{\"title\":\"A\",\"price\":12.5}", query(BOOKS + "$a[][?$$.price][?$$.title eq \"A\"]"));
+  }
+
+  @Test
+  public void xquerySyntaxPredicatesKeepPositionalSemantics() {
+    // In XQuery syntax mode the plain [...] predicate retains the spec rule: a numeric
+    // (even a context-dependent one) is compared against the context position.
+    assertEquals("20", query("xquery version \"3.0\";\n(10, 20, 30)[2]"));
+    // Only 2 sits at its own position; positional-by-value must still apply in XQuery mode.
+    assertEquals("2", query("xquery version \"3.0\";\n(3, 2, 1)[.]"));
+  }
+
+  private String query(final String query) {
+    try (final var out = new ByteArrayOutputStream()) {
+      new Query(query).serialize(ctx, new PrintStream(out));
+      return out.toString(StandardCharsets.UTF_8);
+    } catch (final java.io.IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/io/brackit/query/atomic/WideYearTest.java
+++ b/src/test/java/io/brackit/query/atomic/WideYearTest.java
@@ -1,0 +1,53 @@
+package io.brackit.query.atomic;
+
+import io.brackit.query.QueryException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Year fields with more than four digits (XSD: a year is {@code -?([1-9][0-9]{3,}|0[0-9]{3})}).
+ *
+ * <p>Previously the temporal parsers rejected NEGATIVE years with more than four digits (the sign
+ * does not restrict the number of digits) while wrongly accepting leading zeros in 5+ digit years
+ * (which the schema spec prohibits).
+ */
+public class WideYearTest {
+
+  @Test
+  public void negativeWideYearsParseAndRoundTrip() {
+    assertEquals("-10000-01-01", new Date("-10000-01-01").stringValue());
+    assertEquals("-10000-01-01T00:00:00", new DateTime("-10000-01-01T00:00:00").stringValue());
+    assertEquals("-12025", new GYE("-12025").stringValue());
+    assertEquals("-12025-06", new GYM("-12025-06").stringValue());
+  }
+
+  @Test
+  public void positiveWideYearsStillParse() {
+    assertEquals("10000-01-01", new Date("10000-01-01").stringValue());
+    assertEquals("12025", new GYE("12025").stringValue());
+  }
+
+  @Test
+  public void fourDigitYearsUnchanged() {
+    assertEquals("2026-05-01", new Date("2026-05-01").stringValue());
+    assertEquals("-0044-03-15", new Date("-0044-03-15").stringValue());
+  }
+
+  @Test
+  public void leadingZerosInWideYearsRejected() {
+    assertThrows(QueryException.class, () -> new Date("010000-01-01"));
+    assertThrows(QueryException.class, () -> new Date("-010000-01-01"));
+    assertThrows(QueryException.class, () -> new DateTime("010000-01-01T00:00:00"));
+    assertThrows(QueryException.class, () -> new GYE("012345"));
+    assertThrows(QueryException.class, () -> new GYM("012345-06"));
+  }
+
+  @Test
+  public void wideYearsOrderCorrectly() throws QueryException {
+    assertTrue(new Date("-10000-01-01").cmp(new Date("-0044-01-01")) < 0);
+    assertTrue(new Date("10000-01-01").cmp(new Date("9999-12-31")) > 0);
+  }
+}

--- a/src/test/java/io/brackit/query/function/fn/AdjustToTimezoneTest.java
+++ b/src/test/java/io/brackit/query/function/fn/AdjustToTimezoneTest.java
@@ -1,0 +1,74 @@
+package io.brackit.query.function.fn;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.atomic.Str;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression tests for fn:adjust-dateTime-to-timezone, fn:adjust-date-to-timezone, and
+ * fn:adjust-time-to-timezone with sub-hour timezone offsets.
+ *
+ * <p>Previously (a) the timezone argument was rejected with FODT0003 whenever it had a minutes
+ * component (PT5H30M is a perfectly valid timezone), and (b) the adjustment arithmetic dropped
+ * the minutes of BOTH the old and the new offset, so values carrying a sub-hour timezone (e.g.
+ * +05:30 from a parsed literal) were silently shifted to a wrong instant.
+ */
+public class AdjustToTimezoneTest extends XQueryBaseTest {
+
+  private static String adjust(String value, String tz) {
+    return "string(adjust-dateTime-to-timezone(xs:dateTime('" + value + "'), xs:dayTimeDuration('" + tz + "')))";
+  }
+
+  @Test
+  public void subHourTargetTimezone() {
+    ResultChecker.dCheck(new Str("2026-05-01T15:30:00+05:30"),
+                         new Query(adjust("2026-05-01T10:00:00Z", "PT5H30M")).execute(ctx));
+    ResultChecker.dCheck(new Str("2026-05-01T06:30:00-03:30"),
+                         new Query(adjust("2026-05-01T10:00:00Z", "-PT3H30M")).execute(ctx));
+    ResultChecker.dCheck(new Str("15:30:00+05:30"),
+                         new Query("string(adjust-time-to-timezone(xs:time('10:00:00Z'), xs:dayTimeDuration('PT5H30M')))").execute(ctx));
+    ResultChecker.dCheck(new Str("2026-04-30-10:30"),
+                         new Query("string(adjust-date-to-timezone(xs:date('2026-05-01Z'), xs:dayTimeDuration('-PT10H30M')))").execute(ctx));
+  }
+
+  @Test
+  public void subHourSourceTimezone() {
+    // The input's +05:30 offset must be honoured in full: 10:00+05:30 is 04:30Z (the old code
+    // dropped the 30 minutes and produced 05:00Z).
+    ResultChecker.dCheck(new Str("2026-05-01T04:30:00Z"),
+                         new Query(adjust("2026-05-01T10:00:00+05:30", "PT0S")).execute(ctx));
+  }
+
+  @Test
+  public void adjustingBackAndForthPreservesInstant() {
+    ResultChecker.dCheck(new Str("2026-05-01T10:00:00Z"),
+                         new Query("string(adjust-dateTime-to-timezone("
+                             + "adjust-dateTime-to-timezone(xs:dateTime('2026-05-01T10:00:00Z'), xs:dayTimeDuration('PT5H45M'))"
+                             + ", xs:dayTimeDuration('PT0S')))").execute(ctx));
+  }
+
+  @Test
+  public void wholeHourTimezonesUnchanged() {
+    ResultChecker.dCheck(new Str("2026-05-01T15:00:00+05:00"),
+                         new Query(adjust("2026-05-01T10:00:00Z", "PT5H")).execute(ctx));
+    ResultChecker.dCheck(new Str("2026-05-02T00:00:00+14:00"),
+                         new Query(adjust("2026-05-01T10:00:00Z", "PT14H")).execute(ctx));
+  }
+
+  @Test
+  public void invalidTimezonesRejected() {
+    for (String tz : new String[] { "PT14H1M", "PT15H", "-PT15H", "PT1H1S", "PT1H0.5S", "P1D" }) {
+      QueryException ex = assertThrows(QueryException.class,
+                                       () -> new Query(adjust("2026-05-01T10:00:00Z", tz)).execute(ctx),
+                                       tz);
+      assertEquals(ErrorCode.ERR_INVALID_TIMEZONE, ex.getCode(), tz);
+    }
+  }
+}

--- a/src/test/java/io/brackit/query/function/fn/QNameComponentTest.java
+++ b/src/test/java/io/brackit/query/function/fn/QNameComponentTest.java
@@ -1,0 +1,60 @@
+package io.brackit.query.function.fn;
+
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Int32;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for the QName component accessors fn:local-name-from-QName, fn:namespace-uri-from-QName,
+ * and fn:prefix-from-QName (XQuery F&amp;O 11), which were previously not implemented (XPST0017).
+ */
+public class QNameComponentTest extends XQueryBaseTest {
+
+  @Test
+  public void localNameFromQName() {
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("local-name-from-QName(fn:QName('urn:x', 'p:foo')) eq xs:NCName('foo')").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("local-name-from-QName(fn:QName('urn:x', 'p:foo')) instance of xs:NCName").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("local-name-from-QName(xs:QName('bar')) eq xs:NCName('bar')").execute(ctx));
+  }
+
+  @Test
+  public void namespaceUriFromQName() {
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("string(namespace-uri-from-QName(fn:QName('urn:x', 'p:foo'))) eq 'urn:x'").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("namespace-uri-from-QName(fn:QName('urn:x', 'p:foo')) instance of xs:anyURI").execute(ctx));
+    // A QName in no namespace yields the zero-length xs:anyURI, not the empty sequence.
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("string(namespace-uri-from-QName(fn:QName('', 'foo'))) eq ''").execute(ctx));
+    ResultChecker.dCheck(new Int32(1), new Query("count(namespace-uri-from-QName(fn:QName('', 'foo')))").execute(ctx));
+  }
+
+  @Test
+  public void prefixFromQName() {
+    ResultChecker.dCheck(Bool.TRUE,
+                         new Query("prefix-from-QName(fn:QName('urn:x', 'p:foo')) eq xs:NCName('p')").execute(ctx));
+    // No prefix: empty sequence.
+    ResultChecker.dCheck(new Int32(0), new Query("count(prefix-from-QName(fn:QName('urn:x', 'foo')))").execute(ctx));
+  }
+
+  @Test
+  public void emptySequenceArgumentYieldsEmpty() {
+    ResultChecker.dCheck(new Int32(0), new Query("count(local-name-from-QName(()))").execute(ctx));
+    ResultChecker.dCheck(new Int32(0), new Query("count(namespace-uri-from-QName(()))").execute(ctx));
+    ResultChecker.dCheck(new Int32(0), new Query("count(prefix-from-QName(()))").execute(ctx));
+  }
+
+  @Test
+  public void nonQNameArgumentRejected() {
+    assertThrows(QueryException.class, () -> new Query("local-name-from-QName('notaqname')").execute(ctx));
+  }
+}

--- a/src/test/java/io/brackit/query/function/fn/RegexQFlagTest.java
+++ b/src/test/java/io/brackit/query/function/fn/RegexQFlagTest.java
@@ -1,0 +1,72 @@
+package io.brackit.query.function.fn;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.Str;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for the regular-expression flag {@code q} (XQuery F&amp;O 5.6.1.1): all characters of the
+ * pattern represent themselves. The flag may be combined with {@code i}; {@code m}, {@code s},
+ * and {@code x} have no effect in its presence. With fn:replace, the replacement string is also
+ * interpreted literally ({@code $} and {@code \} have no special significance). The flag was
+ * previously rejected with FORX0001.
+ */
+public class RegexQFlagTest extends XQueryBaseTest {
+
+  @Test
+  public void matchesTreatsPatternAsLiteral() {
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('a.b', '.', 'q')").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE, new Query("fn:matches('ab', '.', 'q')").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('a[0-9]b', '[0-9]', 'q')").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE, new Query("fn:matches('a5b', '[0-9]', 'q')").execute(ctx));
+    // The empty literal pattern matches every string (substring semantics).
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('abc', '', 'q')").execute(ctx));
+  }
+
+  @Test
+  public void replaceTreatsPatternAndReplacementAsLiteral() {
+    ResultChecker.dCheck(new Str("a-b-c"), new Query("fn:replace('a.b.c', '.', '-', 'q')").execute(ctx));
+    // "$" and "\" lose their special significance in the replacement string.
+    ResultChecker.dCheck(new Str("a$0"), new Query("fn:replace('ab', 'b', '$0', 'q')").execute(ctx));
+    ResultChecker.dCheck(new Str("a\\"), new Query("fn:replace('ab', 'b', '\\', 'q')").execute(ctx));
+  }
+
+  @Test
+  public void tokenizeSplitsOnLiteralSeparator() {
+    ResultChecker.dCheck(new Int32(3), new Query("count(fn:tokenize('a.b.c', '.', 'q'))").execute(ctx));
+    ResultChecker.dCheck(new Str("a|b|c"), new Query("string-join(fn:tokenize('a.b.c', '.', 'q'), '|')").execute(ctx));
+  }
+
+  @Test
+  public void qCombinesWithIgnoreCaseAndNeutralizesOtherFlags() {
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('AB', 'a', 'iq')").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('A.B', 'a.b', 'qi')").execute(ctx));
+    // With q, the x flag has no effect: the pattern whitespace is significant.
+    ResultChecker.dCheck(Bool.TRUE, new Query("fn:matches('a b', 'a b', 'qx')").execute(ctx));
+    ResultChecker.dCheck(Bool.FALSE, new Query("fn:matches('ab', 'a b', 'qx')").execute(ctx));
+  }
+
+  @Test
+  public void emptyLiteralPatternIsRejectedForReplaceAndTokenize() {
+    QueryException ex = assertThrows(QueryException.class,
+                                     () -> new Query("fn:replace('abc', '', '-', 'q')").execute(ctx));
+    assertEquals(ErrorCode.ERR_REGULAR_EXPRESSION_EMPTY_STRING, ex.getCode());
+    ex = assertThrows(QueryException.class, () -> new Query("fn:tokenize('abc', '', 'q')").execute(ctx));
+    assertEquals(ErrorCode.ERR_REGULAR_EXPRESSION_EMPTY_STRING, ex.getCode());
+  }
+
+  @Test
+  public void unknownFlagsAreStillRejected() {
+    QueryException ex = assertThrows(QueryException.class, () -> new Query("fn:matches('a', 'a', 'qz')").execute(ctx));
+    assertEquals(ErrorCode.ERR_INVALID_REGULAR_EXPRESSION_FLAGS, ex.getCode());
+  }
+}


### PR DESCRIPTION
Four runtime correctness fixes, each with a failing-pre-fix test. Full suite: **1,158 / 0 failures** (master baseline 1,124/0; +34 tests).

## 1. `[?$$.x]` bare member filters returned empty over numeric members (`adec3828`)

JSONiq `[?expr]` compiled into the XQuery predicate machinery where a **numeric predicate value is a positional test** — `$a[][?$$.price]` kept only items whose price equals their position (12.5≠1, 42≠3 → empty), while string/boolean members took the EBV path and worked. The failure was data-type-dependent and disagreed with the equivalent FLWOR `where`.

Decision (documented in the README): a `[?` predicate referencing `$$` is a pure truthiness (EBV) filter — never positional; predicates not referencing `$$` (`[?1]`, `[?last()]`, `[?position() gt 1]`) keep positional semantics, and XQuery-mode `[...]` is untouched. Parser marks `[?` predicates with an AST property; both evaluation paths honor it. 13-test matrix incl. differential equality with `where` and preservation of `(3,2,1)[.]` → `2`.

## 2. `adjust-*-to-timezone` produced wrong instants for sub-hour offsets (`1cd0d6e1`)

Two stacked bugs: timezone args with minutes (+05:30) were rejected outright (FODT0003), and the adjustment arithmetic read only `getHours()` from both offsets — a value carrying +05:30 adjusted to UTC silently became `05:00Z` instead of `04:30Z`. Delta now computed in minutes across all three functions; validation per spec (whole minutes within ±PT14H). Also fixed in the same temporal family: negative years >4 digits failed to parse while positive ones worked, and prohibited leading zeros were accepted.

## 3. XQuery `q` regex flag unsupported (`52e44d18`)

`fn:matches/replace/tokenize(..., 'q')` threw FORX0001. Now `Pattern.LITERAL`-based with literal replacement semantics per F&O; combines with `i`; empty literal pattern still FORX0003.

## 4. QName component accessors missing (`bb95038c`)

`fn:local-name-from-QName`, `fn:namespace-uri-from-QName`, `fn:prefix-from-QName` were XPST0017 — a gap left documented when the `xs:QName` cast was repaired in the alpha3 wave. Implemented with proper result types.

## Audit context

This wave also re-verified the full 2026-06-10 17-finding correctness ledger against master (every item has a green gate in `RoundTwoCorrectnessTest`); all 17 were confirmed fixed pre-alpha3. Known deviations left documented rather than changed: `format-dateTime`/`format-*` family and `fn:resolve-QName` not implemented (XPST0017), EBV-of-object/array stays an error (global convention), `xs:QName` undeclared-prefix error code, year range bounded by internal `short`.