### PR TITLE
Implement fn:format-dateTime/format-date/format-time, fn:resolve-QName, fn:format-integer

### DIFF
--- a/src/main/java/io/brackit/query/ErrorCode.java
+++ b/src/main/java/io/brackit/query/ErrorCode.java
@@ -435,6 +435,27 @@ public class ErrorCode {
   public static final QNm ERR_INVALID_TIMEZONE = new QNm(Namespaces.ERR_NSURI, Namespaces.ERR_PREFIX, "FODT0003");
 
   /**
+   * err:FODF1310 - invalid format token / picture string in fn:format-integer (or fn:format-number)
+   */
+  public static final QNm ERR_INVALID_FORMAT_INTEGER_PICTURE = new QNm(Namespaces.ERR_NSURI,
+                                                                       Namespaces.ERR_PREFIX,
+                                                                       "FODF1310");
+
+  /**
+   * err:FOFD1340 - invalid date/time formatting parameters (picture syntax, calendar, language, place)
+   */
+  public static final QNm ERR_INVALID_DATETIME_PICTURE = new QNm(Namespaces.ERR_NSURI,
+                                                                 Namespaces.ERR_PREFIX,
+                                                                 "FOFD1340");
+
+  /**
+   * err:FOFD1350 - component in date/time picture not available in the supplied value type
+   */
+  public static final QNm ERR_DATETIME_COMPONENT_NOT_AVAILABLE = new QNm(Namespaces.ERR_NSURI,
+                                                                         Namespaces.ERR_PREFIX,
+                                                                         "FOFD1350");
+
+  /**
    * err:FODC0005
    */
   public static final QNm ERR_DOCUMENT_NOT_FOUND = new QNm(Namespaces.ERR_NSURI, Namespaces.ERR_PREFIX, "FODC0005");

--- a/src/main/java/io/brackit/query/function/fn/FormatDateTime.java
+++ b/src/main/java/io/brackit/query/function/fn/FormatDateTime.java
@@ -1,0 +1,72 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.function.fn;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.atomic.TimeInstant;
+import io.brackit.query.function.AbstractFunction;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Signature;
+import io.brackit.query.module.StaticContext;
+import io.brackit.query.util.format.DateTimeFormatter;
+
+/**
+ * Implements the date formatting functions fn:format-dateTime($value, $picture),
+ * fn:format-dateTime($value, $picture, $language, $calendar, $place), and the corresponding
+ * two- and five-argument forms of fn:format-date and fn:format-time, as per
+ * https://www.w3.org/TR/xpath-functions-31/#func-format-dateTime ff.
+ *
+ * <p>See {@link DateTimeFormatter} for the supported picture string subset and the documented
+ * implementation-defined choices.</p>
+ */
+public class FormatDateTime extends AbstractFunction {
+
+  private final DateTimeFormatter.Source source;
+
+  public FormatDateTime(QNm name, DateTimeFormatter.Source source, Signature signature) {
+    super(name, signature, true);
+    this.source = source;
+  }
+
+  @Override
+  public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
+    if (args[0] == null) {
+      return null;
+    }
+    final TimeInstant value = (TimeInstant) args[0];
+    final String picture = ((Atomic) args[1]).stringValue();
+    final String language = args.length > 2 && args[2] != null ? ((Atomic) args[2]).stringValue() : null;
+    final String calendar = args.length > 3 && args[3] != null ? ((Atomic) args[3]).stringValue() : null;
+    final String place = args.length > 4 && args[4] != null ? ((Atomic) args[4]).stringValue() : null;
+    return new Str(DateTimeFormatter.format(source, value, picture, language, calendar, place));
+  }
+}

--- a/src/main/java/io/brackit/query/function/fn/FormatInteger.java
+++ b/src/main/java/io/brackit/query/function/fn/FormatInteger.java
@@ -1,0 +1,68 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.function.fn;
+
+import java.math.BigInteger;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.function.AbstractFunction;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Signature;
+import io.brackit.query.module.StaticContext;
+import io.brackit.query.util.format.IntegerFormatter;
+
+/**
+ * Implements fn:format-integer($value, $picture) and fn:format-integer($value, $picture, $lang)
+ * as per https://www.w3.org/TR/xpath-functions-31/#func-format-integer.
+ *
+ * <p>The only supported language is English. Per the spec, an unsupported (or absent) $lang is
+ * not an error: the number is formatted using the default language.</p>
+ */
+public class FormatInteger extends AbstractFunction {
+
+  public FormatInteger(QNm name, Signature signature) {
+    super(name, signature, true);
+  }
+
+  @Override
+  public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
+    if (args[0] == null) {
+      // an empty $value yields a zero-length string (not an empty sequence)
+      return Str.EMPTY;
+    }
+    final BigInteger value = new BigInteger(((Atomic) args[0]).stringValue());
+    final String picture = ((Atomic) args[1]).stringValue();
+    // args[2] ($lang) is intentionally not inspected: only English is supported, and the spec
+    // mandates falling back to the default language without error
+    return new Str(IntegerFormatter.formatInteger(value, picture));
+  }
+}

--- a/src/main/java/io/brackit/query/function/fn/ResolveQName.java
+++ b/src/main/java/io/brackit/query/function/fn/ResolveQName.java
@@ -1,0 +1,95 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.function.fn;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.function.AbstractFunction;
+import io.brackit.query.jdm.Kind;
+import io.brackit.query.jdm.Scope;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Signature;
+import io.brackit.query.jdm.XMLChar;
+import io.brackit.query.jdm.node.Node;
+import io.brackit.query.module.StaticContext;
+import io.brackit.query.util.Whitespace;
+
+/**
+ * Implements fn:resolve-QName($qname as xs:string?, $element as element()) as xs:QName? as per
+ * https://www.w3.org/TR/xpath-functions-31/#func-resolve-QName.
+ *
+ * <p>The lexical QName is resolved against the in-scope namespaces of the supplied element.
+ * Unlike the xs:QName constructor, an unprefixed name IS resolved against the element's default
+ * namespace (if any); without a default namespace binding the resulting QName is in no
+ * namespace.</p>
+ */
+public class ResolveQName extends AbstractFunction {
+
+  public ResolveQName(QNm name, Signature signature) {
+    super(name, signature, true);
+  }
+
+  @Override
+  public Sequence execute(StaticContext sctx, QueryContext ctx, Sequence[] args) throws QueryException {
+    if (args[0] == null) {
+      return null;
+    }
+    final String lexical = Whitespace.collapseTrimOnly(((Atomic) args[0]).stringValue());
+    if (!XMLChar.isQName(lexical)) {
+      throw new QueryException(ErrorCode.ERR_INVALID_LEXICAL_VALUE,
+                               "Invalid lexical QName in fn:resolve-QName: '%s'",
+                               lexical);
+    }
+    final Node<?> element = (Node<?>) args[1];
+    if (element.getKind() != Kind.ELEMENT) {
+      throw new QueryException(ErrorCode.ERR_TYPE_INAPPROPRIATE_TYPE,
+                               "Second argument of fn:resolve-QName must be an element");
+    }
+    final Scope scope = element.getScope();
+
+    final int colon = lexical.indexOf(':');
+    if (colon < 0) {
+      // an unprefixed QName resolves against the default namespace of the element
+      final String defaultNs = scope.defaultNS();
+      return new QNm(defaultNs == null ? "" : defaultNs, null, lexical);
+    }
+    final String prefix = lexical.substring(0, colon);
+    final String local = lexical.substring(colon + 1);
+    final String uri = scope.resolvePrefix(prefix);
+    if (uri == null || uri.isEmpty()) {
+      throw new QueryException(ErrorCode.ERR_NO_NAMESPACE_FOR_PREFIX,
+                               "No namespace binding for prefix '%s' in scope of element %s",
+                               prefix,
+                               element.getName());
+    }
+    return new QNm(uri, prefix, local);
+  }
+}

--- a/src/main/java/io/brackit/query/module/Functions.java
+++ b/src/main/java/io/brackit/query/module/Functions.java
@@ -39,6 +39,7 @@ import io.brackit.query.function.json.JSONFun;
 import io.brackit.query.function.json.Keys;
 import io.brackit.query.function.json.Size;
 import io.brackit.query.util.Regex;
+import io.brackit.query.util.format.DateTimeFormatter;
 import io.brackit.query.jdm.Function;
 import io.brackit.query.jdm.Signature;
 import io.brackit.query.jdm.Type;
@@ -158,6 +159,17 @@ public final class Functions {
                                 new Signature(new SequenceType(NumericType.INSTANCE, Cardinality.ZeroOrOne),
                                               new SequenceType(NumericType.INSTANCE, Cardinality.ZeroOrOne),
                                               new SequenceType(AtomicType.INR, Cardinality.One))));
+
+    // See XQuery Functions and Operators 4.6.1 fn:format-integer
+    predefine(new FormatInteger(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-integer"),
+                                new Signature(new SequenceType(AtomicType.STR, Cardinality.One),
+                                              new SequenceType(AtomicType.INR, Cardinality.ZeroOrOne),
+                                              new SequenceType(AtomicType.STR, Cardinality.One))));
+    predefine(new FormatInteger(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-integer"),
+                                new Signature(new SequenceType(AtomicType.STR, Cardinality.One),
+                                              new SequenceType(AtomicType.INR, Cardinality.ZeroOrOne),
+                                              new SequenceType(AtomicType.STR, Cardinality.One),
+                                              new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne))));
 
     // See XQuery Functions and Operators 7.2 Functions to Assemble and
     // Disassemble Strings
@@ -505,11 +517,56 @@ public final class Functions {
                                                  new SequenceType(AtomicType.TIME, Cardinality.ZeroOrOne),
                                                  new SequenceType(AtomicType.DTD, Cardinality.ZeroOrOne))));
 
+    // See XQuery Functions and Operators 9.8 Formatting dates and times
+    predefine(new FormatDateTime(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-dateTime"),
+                                 DateTimeFormatter.Source.DATE_TIME,
+                                 new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.DATI, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.One))));
+    predefine(new FormatDateTime(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-dateTime"),
+                                 DateTimeFormatter.Source.DATE_TIME,
+                                 new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.DATI, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.One),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne))));
+    predefine(new FormatDateTime(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-date"),
+                                 DateTimeFormatter.Source.DATE,
+                                 new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.DATE, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.One))));
+    predefine(new FormatDateTime(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-date"),
+                                 DateTimeFormatter.Source.DATE,
+                                 new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.DATE, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.One),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne))));
+    predefine(new FormatDateTime(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-time"),
+                                 DateTimeFormatter.Source.TIME,
+                                 new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.TIME, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.One))));
+    predefine(new FormatDateTime(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "format-time"),
+                                 DateTimeFormatter.Source.TIME,
+                                 new Signature(new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.TIME, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.One),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                               new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne))));
+
     // See XQuery Functions and Operators 11 Functions Related to QNames
     predefine(new QName(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "QName"),
                         new Signature(new SequenceType(AtomicType.QNM, Cardinality.One),
                                       new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
                                       new SequenceType(AtomicType.STR, Cardinality.One))));
+    predefine(new ResolveQName(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "resolve-QName"),
+                               new Signature(new SequenceType(AtomicType.QNM, Cardinality.ZeroOrOne),
+                                             new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne),
+                                             new SequenceType(ElementType.ELEMENT, Cardinality.One))));
     predefine(new QNameComponent(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "local-name-from-QName"),
                                  QNameComponent.Component.LOCAL_NAME,
                                  new Signature(new SequenceType(new AtomicType(Type.NCN), Cardinality.ZeroOrOne),

--- a/src/main/java/io/brackit/query/util/format/DateTimeFormatter.java
+++ b/src/main/java/io/brackit/query/util/format/DateTimeFormatter.java
@@ -1,0 +1,764 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.util.format;
+
+import java.math.BigInteger;
+import java.util.Set;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.DTD;
+import io.brackit.query.atomic.TimeInstant;
+import io.brackit.query.jdm.XMLChar;
+import io.brackit.query.util.Whitespace;
+
+/**
+ * Implements the date/time picture string of <code>fn:format-dateTime</code>,
+ * <code>fn:format-date</code>, and <code>fn:format-time</code> (XQuery F&amp;O 3.1, section 9.8).
+ *
+ * <p>Faithfully implemented: literal text with <code>[[</code>/<code>]]</code> escapes; the
+ * component specifiers <code>Y M D d F W w H h P m s f Z z C E</code> with decimal-digit-pattern,
+ * name (<code>n</code>/<code>N</code>/<code>Nn</code>), roman, alphabetic, and word presentations;
+ * second presentation modifiers <code>c</code>/<code>o</code> (cardinal/ordinal) and
+ * <code>a</code>/<code>t</code> (for timezones, <code>t</code> selects "Z" for UTC); width
+ * modifiers; year truncation (modulo 10^maxWidth); fractional second truncation/padding; and the
+ * numeric, military (<code>Z</code>), and GMT-prefixed (<code>z</code>) timezone presentations.</p>
+ *
+ * <p>Implementation-defined choices (documented here once, asserted by the unit tests):</p>
+ * <ul>
+ * <li>The only supported language is English; any other non-empty <code>$language</code> falls
+ * back to English with the spec-mandated <code>[Language: en]</code> output prefix.</li>
+ * <li>The supported calendars are <code>AD</code> (default) and <code>ISO</code>. Other calendar
+ * designators from the spec's list fall back to AD with the spec-mandated
+ * <code>[Calendar: AD]</code> output prefix; a calendar QName in a namespace is likewise treated
+ * as unsupported (fallback), and any other value is rejected with err:FOFD1340.</li>
+ * <li><code>$place</code> is accepted but not used (no geographical/timezone database); the spec
+ * permits falling back to the default place for unrecognized values.</li>
+ * <li>Day-of-week and week numbers use the ISO 8601 conventions (Monday=1, first-Thursday rule)
+ * for both calendars; weeks-in-month follow the spec's Thursday rule.</li>
+ * <li>The year component formats the absolute value of the year (per the spec's component table);
+ * the era component yields <code>AD</code>/<code>BC</code> in the AD calendar (brackit's value
+ * space has no year zero, so <code>-0044</code> is 44 BC) and the ISO convention (empty string or
+ * <code>-</code>) in the ISO calendar. Era and calendar names ignore the name-case modifiers
+ * (their output is implementation-defined).</li>
+ * <li>Timezone names (<code>[ZN]</code>) are not available without a timezone database; the
+ * spec-mandated fallback format <code>01:01</code> is used instead.</li>
+ * <li>Grouping separators are not supported inside fractional-second patterns and are rejected
+ * loudly with err:FOFD1340 (the spec leaves several of these combinations
+ * implementation-defined).</li>
+ * </ul>
+ */
+public final class DateTimeFormatter {
+
+  public enum Source {
+    DATE_TIME("YMDdFWwHhPmsfZzCE", "xs:dateTime"), DATE("YMDdFWwCEZz", "xs:date"), TIME("HhPmsfZzC", "xs:time");
+
+    final String components;
+    final String typeName;
+
+    Source(String components, String typeName) {
+      this.components = components;
+      this.typeName = typeName;
+    }
+  }
+
+  private enum CalendarKind {
+    AD, ISO
+  }
+
+  private static final String ALL_COMPONENTS = "YMDdFWwHhPmsfZzCE";
+
+  /** Calendar designators enumerated by the spec (all valid; only AD and ISO are supported). */
+  private static final Set<String> KNOWN_CALENDARS = Set.of("AD",
+                                                            "AH",
+                                                            "AME",
+                                                            "AM",
+                                                            "AP",
+                                                            "AS",
+                                                            "BE",
+                                                            "CB",
+                                                            "CE",
+                                                            "CL",
+                                                            "CS",
+                                                            "EE",
+                                                            "FE",
+                                                            "ISO",
+                                                            "JE",
+                                                            "KE",
+                                                            "KY",
+                                                            "ME",
+                                                            "MS",
+                                                            "NS",
+                                                            "OS",
+                                                            "RS",
+                                                            "SE",
+                                                            "SH",
+                                                            "SS",
+                                                            "TE",
+                                                            "VS",
+                                                            "VE");
+
+  private static final String[] MONTHS = { "January", "February", "March", "April", "May", "June", "July", "August",
+      "September", "October", "November", "December" };
+
+  /** Index 0 = Monday, matching the ISO day-of-week derived from the Julian day number. */
+  private static final String[] DAYS = { "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" };
+
+  private DateTimeFormatter() {
+  }
+
+  public static String format(Source source, TimeInstant value, String picture, String language, String calendar,
+      String place) {
+    final StringBuilder prefix = new StringBuilder();
+
+    if (language != null) {
+      final String lang = Whitespace.collapseTrimOnly(language);
+      if (!lang.isEmpty() && !"en".equalsIgnoreCase(lang) && !lang.toLowerCase().startsWith("en-")) {
+        // fallback to the supported language, identifying it as the spec requires
+        prefix.append("[Language: en]");
+      }
+    }
+
+    CalendarKind calendarKind = CalendarKind.AD;
+    if (calendar != null) {
+      final String cal = Whitespace.collapseTrimOnly(calendar);
+      if (!cal.isEmpty()) {
+        if (cal.startsWith("Q{") || cal.indexOf(':') >= 0) {
+          // a calendar identified by a namespaced EQName is implementation-defined territory;
+          // we support none, so use the spec-mandated fallback representation
+          prefix.append("[Calendar: AD]");
+        } else if (!XMLChar.isNCName(cal)) {
+          throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                   "Invalid calendar value '%s': not a valid EQName",
+                                   cal);
+        } else if ("AD".equals(cal)) {
+          calendarKind = CalendarKind.AD;
+        } else if ("ISO".equals(cal)) {
+          calendarKind = CalendarKind.ISO;
+        } else if (KNOWN_CALENDARS.contains(cal)) {
+          prefix.append("[Calendar: AD]");
+        } else {
+          throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE, "Unknown calendar designator '%s'", cal);
+        }
+      }
+    }
+
+    // $place is accepted but not used: without a geographical/timezone database the spec
+    // prescribes using the default place for unrecognized values.
+
+    final StringBuilder out = new StringBuilder(prefix);
+    final int length = picture.length();
+    int i = 0;
+    while (i < length) {
+      final char c = picture.charAt(i);
+      if (c == '[') {
+        if (i + 1 < length && picture.charAt(i + 1) == '[') {
+          out.append('[');
+          i += 2;
+          continue;
+        }
+        final int close = picture.indexOf(']', i + 1);
+        if (close < 0) {
+          throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                   "Invalid picture string '%s': unclosed variable marker",
+                                   picture);
+        }
+        out.append(formatMarker(source, value, calendarKind, picture.substring(i + 1, close)));
+        i = close + 1;
+      } else if (c == ']') {
+        if (i + 1 < length && picture.charAt(i + 1) == ']') {
+          out.append(']');
+          i += 2;
+          continue;
+        }
+        throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                 "Invalid picture string '%s': ']' in literal text must be doubled",
+                                 picture);
+      } else {
+        out.append(c);
+        i++;
+      }
+    }
+    return out.toString();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Variable markers
+  // ---------------------------------------------------------------------------------------------
+
+  private static final class Marker {
+    char component;
+    String first = "";
+    char second = 0;
+    boolean hasWidth;
+    int minWidth = -1;
+    int maxWidth = -1;
+  }
+
+  private static String formatMarker(Source source, TimeInstant value, CalendarKind calendarKind, String rawMarker) {
+    // whitespace within a variable marker is ignored
+    final StringBuilder collapsed = new StringBuilder(rawMarker.length());
+    for (int i = 0; i < rawMarker.length(); i++) {
+      final char c = rawMarker.charAt(i);
+      if (!Character.isWhitespace(c)) {
+        collapsed.append(c);
+      }
+    }
+    final String body = collapsed.toString();
+    if (body.isEmpty()) {
+      throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE, "Empty variable marker in picture string");
+    }
+
+    final Marker marker = new Marker();
+    marker.component = body.charAt(0);
+    if (ALL_COMPONENTS.indexOf(marker.component) < 0) {
+      throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                               "Invalid component specifier '%s' in picture string",
+                               marker.component);
+    }
+    if (source.components.indexOf(marker.component) < 0) {
+      throw new QueryException(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE,
+                               "Component specifier '%s' is not available in a value of type %s",
+                               marker.component,
+                               source.typeName);
+    }
+
+    String rest = body.substring(1);
+
+    // the last comma (if any) introduces the width modifier; earlier commas are grouping separators
+    final int lastComma = rest.lastIndexOf(',');
+    if (lastComma >= 0) {
+      parseWidth(marker, rest.substring(lastComma + 1));
+      rest = rest.substring(0, lastComma);
+    }
+
+    // split first/second presentation modifiers
+    if (rest.length() > 1) {
+      final char last = rest.charAt(rest.length() - 1);
+      if (last == 'a' || last == 't' || last == 'c' || last == 'o') {
+        marker.second = last;
+        rest = rest.substring(0, rest.length() - 1);
+      }
+    }
+    marker.first = rest;
+
+    return formatComponent(source, value, calendarKind, marker);
+  }
+
+  private static void parseWidth(Marker marker, String width) {
+    if (!width.matches("(\\d+|\\*)(-(\\d+|\\*))?")) {
+      throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                               "Invalid width modifier ',%s' in picture string",
+                               width);
+    }
+    marker.hasWidth = true;
+    final int dash = width.indexOf('-');
+    final String min = dash < 0 ? width : width.substring(0, dash);
+    final String max = dash < 0 ? "*" : width.substring(dash + 1);
+    if (!"*".equals(min)) {
+      marker.minWidth = Integer.parseInt(min);
+      if (marker.minWidth < 1) {
+        throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                 "Invalid width modifier ',%s': minimum width must be at least one",
+                                 width);
+      }
+    }
+    if (!"*".equals(max)) {
+      marker.maxWidth = Integer.parseInt(max);
+      if (marker.maxWidth < 1 || (marker.minWidth != -1 && marker.maxWidth < marker.minWidth)) {
+        throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                 "Invalid width modifier ',%s': maximum width must be at least one and not less than the minimum width",
+                                 width);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Component dispatch
+  // ---------------------------------------------------------------------------------------------
+
+  private static String formatComponent(Source source, TimeInstant value, CalendarKind calendarKind, Marker marker) {
+    switch (marker.component) {
+      case 'Y':
+        return formatYear(value, marker);
+      case 'M':
+        if (isNameForm(effectiveFirst(marker, "1"))) {
+          return formatName(MONTHS[value.getMonth() - 1], marker, "n");
+        }
+        return formatIntegerComponent(value.getMonth(), marker, "1");
+      case 'D':
+        return formatIntegerComponent(value.getDay(), marker, "1");
+      case 'd':
+        return formatIntegerComponent(dayOfYear(value), marker, "1");
+      case 'F':
+        if (isNameForm(effectiveFirst(marker, "n"))) {
+          return formatName(DAYS[dayOfWeekIndex(value)], marker, "n");
+        }
+        return formatIntegerComponent(dayOfWeekIndex(value) + 1, marker, "n");
+      case 'W':
+        return formatIntegerComponent(weekOfYear(value), marker, "1");
+      case 'w':
+        return formatIntegerComponent(weekOfMonth(value), marker, "1");
+      case 'H':
+        return formatIntegerComponent(value.getHours(), marker, "1");
+      case 'h': {
+        final int hour12 = value.getHours() % 12 == 0 ? 12 : value.getHours() % 12;
+        return formatIntegerComponent(hour12, marker, "1");
+      }
+      case 'P':
+        return formatName(value.getHours() < 12 ? "am" : "pm", marker, "n");
+      case 'm':
+        return formatIntegerComponent(value.getMinutes(), marker, "01");
+      case 's':
+        return formatIntegerComponent(value.getMicros() / 1_000_000, marker, "01");
+      case 'f':
+        return formatFractionalSeconds(value.getMicros() % 1_000_000, marker);
+      case 'Z':
+      case 'z':
+        return formatTimezone(value, marker);
+      case 'C':
+        // the output of the calendar component is implementation-defined: the designator in use
+        return applyWidthToName(calendarKind == CalendarKind.ISO ? "ISO" : "AD", marker);
+      case 'E': {
+        // implementation-defined era names: AD/BC for the AD calendar; the ISO convention is a
+        // minus sign for negative years and a zero-length string otherwise
+        final String era;
+        if (calendarKind == CalendarKind.ISO) {
+          era = value.getYear() < 0 ? "-" : "";
+        } else {
+          era = value.getYear() < 0 ? "BC" : "AD";
+        }
+        return applyWidthToName(era, marker);
+      }
+      default:
+        // unreachable: validated above
+        throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                 "Invalid component specifier '%s'",
+                                 marker.component);
+    }
+  }
+
+  private static String effectiveFirst(Marker marker, String defaultPresentation) {
+    return marker.first.isEmpty() ? defaultPresentation : marker.first;
+  }
+
+  private static boolean isNameForm(String first) {
+    return "n".equals(first) || "N".equals(first) || "Nn".equals(first);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Integer-valued components
+  // ---------------------------------------------------------------------------------------------
+
+  private static String formatIntegerComponent(long componentValue, Marker marker, String defaultPresentation) {
+    String first = effectiveFirst(marker, defaultPresentation);
+    if (isNameForm(first)) {
+      // a name form was requested for a component we cannot output by name:
+      // the spec requires using the default presentation modifier instead
+      first = IntegerFormatter.containsDecimalDigit(defaultPresentation) ? defaultPresentation : "1";
+    }
+    final boolean ordinal = marker.second == 'o';
+    if (IntegerFormatter.containsDecimalDigit(first)) {
+      final String pattern = adjustPatternToMinWidth(first, marker);
+      return formatViaIntegerFormatter(BigInteger.valueOf(componentValue), pattern, ordinal);
+    }
+    // roman/alphabetic/words/unknown tokens: never truncated, padded to the minimum width
+    final String result = formatViaIntegerFormatter(BigInteger.valueOf(componentValue), first, ordinal);
+    return padRight(result, marker.minWidth);
+  }
+
+  private static String formatYear(TimeInstant value, Marker marker) {
+    // per the component table the year component formats the absolute value of the year;
+    // the era component carries the BC/AD distinction
+    long year = Math.abs((long) value.getYear());
+
+    final String first = effectiveFirst(marker, "1");
+    int n = -1;
+    if (marker.maxWidth > 0) {
+      n = marker.maxWidth;
+    } else if (IntegerFormatter.containsDecimalDigit(first)) {
+      final int digitSigns = countDigitSigns(first);
+      if (digitSigns >= 2) {
+        n = digitSigns;
+      }
+    }
+    if (n > 0 && n < 19) {
+      long modulus = 1;
+      for (int i = 0; i < n; i++) {
+        modulus *= 10;
+      }
+      year %= modulus;
+    }
+    return formatIntegerComponent(year, marker, "1");
+  }
+
+  private static int countDigitSigns(String pattern) {
+    int count = 0;
+    for (int i = 0; i < pattern.length();) {
+      final int cp = pattern.codePointAt(i);
+      if (cp == '#' || Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER) {
+        count++;
+      }
+      i += Character.charCount(cp);
+    }
+    return count;
+  }
+
+  /**
+   * Applies a width modifier to a decimal digit pattern: optional digit signs are converted to
+   * mandatory ones starting from the right, then mandatory digit signs are prepended until the
+   * minimum width is reached. The maximum width is ignored for integer-valued components.
+   */
+  private static String adjustPatternToMinWidth(String pattern, Marker marker) {
+    if (!marker.hasWidth || marker.minWidth <= 0) {
+      return pattern;
+    }
+    int mandatory = 0;
+    int zeroDigit = '0';
+    boolean hasGrouping = false;
+    for (int i = 0; i < pattern.length();) {
+      final int cp = pattern.codePointAt(i);
+      if (Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER) {
+        if (mandatory == 0) {
+          zeroDigit = cp - Character.digit(cp, 10);
+        }
+        mandatory++;
+      } else if (cp != '#') {
+        hasGrouping = true;
+      }
+      i += Character.charCount(cp);
+    }
+    if (hasGrouping || mandatory >= marker.minWidth) {
+      // combining width modifiers with grouping separators is implementation-defined;
+      // we leave the pattern untouched
+      return pattern;
+    }
+    final StringBuilder sb = new StringBuilder(pattern);
+    for (int i = sb.length() - 1; i >= 0 && mandatory < marker.minWidth; i--) {
+      if (sb.charAt(i) == '#') {
+        sb.setCharAt(i, (char) zeroDigit);
+        mandatory++;
+      }
+    }
+    while (mandatory < marker.minWidth) {
+      sb.insert(0, (char) zeroDigit);
+      mandatory++;
+    }
+    return sb.toString();
+  }
+
+  private static String formatViaIntegerFormatter(BigInteger value, String token, boolean ordinal) {
+    try {
+      return IntegerFormatter.format(value, token, ordinal);
+    } catch (final QueryException e) {
+      if (ErrorCode.ERR_INVALID_FORMAT_INTEGER_PICTURE.equals(e.getCode())) {
+        // a syntactically invalid presentation modifier is a picture syntax error here;
+        // the (QNm, Object) constructor concatenates and never re-format-interprets the message
+        throw new QueryException(e, ErrorCode.ERR_INVALID_DATETIME_PICTURE, (Object) e.getMessage());
+      }
+      throw e;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Names (months, days, am/pm)
+  // ---------------------------------------------------------------------------------------------
+
+  /** Formats a title-case base name according to the requested name form and width. */
+  private static String formatName(String titleCaseName, Marker marker, String defaultPresentation) {
+    final String first = effectiveFirst(marker, defaultPresentation);
+    final String form = isNameForm(first) ? first : defaultPresentation;
+    String name = switch (form) {
+      case "N" -> titleCaseName.toUpperCase();
+      case "Nn" -> Character.toUpperCase(titleCaseName.charAt(0)) + titleCaseName.substring(1).toLowerCase();
+      default -> titleCaseName.toLowerCase();
+    };
+    return applyWidthToName(name, marker);
+  }
+
+  private static String applyWidthToName(String name, Marker marker) {
+    if (marker.maxWidth > 0 && name.length() > marker.maxWidth) {
+      // conventional English month/day abbreviations are prefixes of the full name
+      name = name.substring(0, marker.maxWidth);
+    }
+    return padRight(name, marker.minWidth);
+  }
+
+  private static String padRight(String value, int minWidth) {
+    if (minWidth <= 0 || value.length() >= minWidth) {
+      return value;
+    }
+    final StringBuilder sb = new StringBuilder(value);
+    while (sb.length() < minWidth) {
+      sb.append(' ');
+    }
+    return sb.toString();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Fractional seconds
+  // ---------------------------------------------------------------------------------------------
+
+  private static String formatFractionalSeconds(int micros, Marker marker) {
+    String pattern = effectiveFirst(marker, "1");
+    if (!IntegerFormatter.containsDecimalDigit(pattern)) {
+      // a presentation modifier without digits is implementation-defined: use the default
+      pattern = "1";
+    }
+    // a fractional pattern mirrors a decimal digit pattern: mandatory digits first, then '#'
+    int mandatory = 0;
+    int optional = 0;
+    int zeroDigit = '0';
+    for (int i = 0; i < pattern.length();) {
+      final int cp = pattern.codePointAt(i);
+      if (Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER) {
+        if (optional > 0) {
+          throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                   "Invalid fractional seconds pattern '%s': mandatory digits must precede optional digit signs",
+                                   pattern);
+        }
+        if (mandatory == 0) {
+          zeroDigit = cp - Character.digit(cp, 10);
+        }
+        mandatory++;
+      } else if (cp == '#') {
+        optional++;
+      } else {
+        // grouping separators within fractional seconds are not supported: fail loudly rather
+        // than risk a wrong rendering
+        throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                 "Unsupported character '%s' in fractional seconds pattern '%s'",
+                                 new String(Character.toChars(cp)),
+                                 pattern);
+      }
+      i += Character.charCount(cp);
+    }
+    final boolean singleMandatoryDigit = mandatory == 1 && optional == 0;
+    int total = mandatory + optional;
+    if (marker.hasWidth) {
+      if (marker.minWidth > mandatory) {
+        // optional signs become mandatory (from the left), further mandatory signs are appended
+        final int converted = Math.min(optional, marker.minWidth - mandatory);
+        optional -= converted;
+        mandatory = marker.minWidth;
+        total = mandatory + optional;
+      }
+      if (marker.maxWidth > 0 && total < marker.maxWidth) {
+        total = marker.maxWidth;
+      }
+    }
+
+    // six (zero-padded) decimal places, then drop insignificant trailing zeroes
+    final StringBuilder digits = new StringBuilder(Integer.toString(micros));
+    while (digits.length() < 6) {
+      digits.insert(0, '0');
+    }
+    int significant = digits.length();
+    while (significant > 0 && digits.charAt(significant - 1) == '0') {
+      significant--;
+    }
+    if (!marker.hasWidth && singleMandatoryDigit) {
+      // a single mandatory digit pattern extends to the actual precision of the value
+      total = Math.max(1, significant);
+    }
+
+    // truncate towards zero, then pad with trailing zeroes up to the mandatory width
+    final StringBuilder out = new StringBuilder(digits.substring(0, Math.min(significant, total)));
+    while (out.length() < mandatory) {
+      out.append('0');
+    }
+    if (zeroDigit != '0') {
+      for (int i = 0; i < out.length(); i++) {
+        out.setCharAt(i, (char) (zeroDigit + (out.charAt(i) - '0')));
+      }
+    }
+    return out.toString();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Timezones
+  // ---------------------------------------------------------------------------------------------
+
+  private static String formatTimezone(TimeInstant value, Marker marker) {
+    final DTD timezone = value.getTimezone();
+    String presentation = effectiveFirst(marker, "01:01");
+    final String prefix = marker.component == 'z' ? "GMT" : "";
+
+    if (timezone == null) {
+      // a missing timezone produces no output, except in the military presentation
+      if ("Z".equals(presentation)) {
+        return padRight(prefix + "J", marker.minWidth);
+      }
+      return "";
+    }
+
+    final int hours = timezone.getHours();
+    final int minutes = timezone.getMinutes();
+    final boolean zeroOffset = hours == 0 && minutes == 0;
+    final boolean negative = timezone.isNegative() && !zeroOffset;
+
+    if ("Z".equals(presentation)) {
+      if (minutes == 0 && hours <= 12) {
+        final char letter;
+        if (zeroOffset) {
+          letter = 'Z';
+        } else if (!negative) {
+          final char candidate = (char) ('A' + hours - 1);
+          // the letter J is reserved for local time and skipped in the military sequence
+          letter = candidate >= 'J' ? (char) (candidate + 1) : candidate;
+        } else {
+          letter = (char) ('N' + hours - 1);
+        }
+        return padRight(prefix + letter, marker.minWidth);
+      }
+      // offsets without a military letter fall back to the 01:01 presentation
+      presentation = "01:01";
+    }
+
+    if ("N".equals(presentation)) {
+      // timezone names require a timezone database; the spec-mandated fallback is 01:01
+      presentation = "01:01";
+    }
+
+    final String body;
+    if (marker.second == 't' && zeroOffset) {
+      body = "Z";
+    } else {
+      body = formatNumericTimezone(presentation, negative, hours, minutes);
+    }
+    return padRight(prefix + body, marker.minWidth);
+  }
+
+  private static String formatNumericTimezone(String presentation, boolean negative, int hours, int minutes) {
+    // split the presentation into digit groups around a single separator
+    final StringBuilder hourGroup = new StringBuilder();
+    final StringBuilder minuteGroup = new StringBuilder();
+    String separator = null;
+    for (int i = 0; i < presentation.length();) {
+      final int cp = presentation.codePointAt(i);
+      if (Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER) {
+        (separator == null ? hourGroup : minuteGroup).appendCodePoint(cp);
+      } else if (separator == null && hourGroup.length() > 0 && IntegerFormatter.isGroupingSeparator(cp)) {
+        separator = new String(Character.toChars(cp));
+      } else {
+        throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                                 "Unsupported timezone presentation modifier '%s'",
+                                 presentation);
+      }
+      i += Character.charCount(cp);
+    }
+    if (hourGroup.length() == 0 || (separator != null && minuteGroup.length() == 0)) {
+      throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                               "Unsupported timezone presentation modifier '%s'",
+                               presentation);
+    }
+
+    final String sign = negative ? "-" : "+";
+    if (separator != null) {
+      // e.g. 01:01 or 0.00: hours and minutes, always both
+      return sign + IntegerFormatter.format(BigInteger.valueOf(hours), hourGroup.toString(), false) + separator
+          + IntegerFormatter.format(BigInteger.valueOf(minutes), minuteGroup.toString(), false);
+    }
+    final int digitCount = hourGroup.length();
+    if (digitCount <= 2) {
+      // hours only; minutes are appended (colon-separated) when the offset is not whole hours
+      String result = sign + IntegerFormatter.format(BigInteger.valueOf(hours), hourGroup.toString(), false);
+      if (minutes != 0) {
+        result += ":" + IntegerFormatter.format(BigInteger.valueOf(minutes), "01", false);
+      }
+      return result;
+    }
+    if (digitCount <= 4) {
+      // combined hours and minutes without separator, e.g. -0500
+      return sign + IntegerFormatter.format(BigInteger.valueOf(hours * 100L + minutes), hourGroup.toString(), false);
+    }
+    throw new QueryException(ErrorCode.ERR_INVALID_DATETIME_PICTURE,
+                             "Unsupported timezone presentation modifier '%s'",
+                             presentation);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Calendar arithmetic (proleptic Gregorian, via Julian day numbers)
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * Fliegel–Van Flandern Julian day number. Like the engine's date arithmetic in
+   * {@code AbstractTimeInstant}, the stored year value is fed in unchanged.
+   */
+  private static long julianDayNumber(int year, int month, int day) {
+    final int a = (14 - month) / 12;
+    final long y = year + 4800L - a;
+    final int m = month + 12 * a - 3;
+    return day + (153L * m + 2) / 5 + 365L * y + y / 4 - y / 100 + y / 400 - 32045L;
+  }
+
+  /** Inverse of {@link #julianDayNumber}: {year, month, day}. */
+  private static int[] gregorianFromJdn(long jdn) {
+    final long a = jdn + 32044;
+    final long b = (4 * a + 3) / 146097;
+    final long c = a - 146097 * b / 4;
+    final long d = (4 * c + 3) / 1461;
+    final long e = c - 1461 * d / 4;
+    final long m = (5 * e + 2) / 153;
+    final int day = (int) (e - (153 * m + 2) / 5 + 1);
+    final int month = (int) (m + 3 - 12 * (m / 10));
+    final int year = (int) (100 * b + d - 4800 + m / 10);
+    return new int[] { year, month, day };
+  }
+
+  /** 0 = Monday ... 6 = Sunday. */
+  private static int dayOfWeekIndex(TimeInstant value) {
+    return (int) Math.floorMod(julianDayNumber(value.getYear(), value.getMonth(), value.getDay()), 7);
+  }
+
+  private static int dayOfYear(TimeInstant value) {
+    return (int) (julianDayNumber(value.getYear(), value.getMonth(), value.getDay()) - julianDayNumber(value.getYear(),
+                                                                                                       1,
+                                                                                                       1)) + 1;
+  }
+
+  /** ISO 8601 week of year: the week (Monday-Sunday) containing the first Thursday is week 1. */
+  private static int weekOfYear(TimeInstant value) {
+    final long jdn = julianDayNumber(value.getYear(), value.getMonth(), value.getDay());
+    final long thursday = jdn + (3 - Math.floorMod(jdn, 7));
+    final int[] thursdayDate = gregorianFromJdn(thursday);
+    final long jan1 = julianDayNumber(thursdayDate[0], 1, 1);
+    return (int) ((thursday - jan1) / 7) + 1;
+  }
+
+  /**
+   * Week of month: per the spec, a Monday-Sunday week belongs to the month containing its
+   * Thursday, and the weeks of a month are numbered from 1.
+   */
+  private static int weekOfMonth(TimeInstant value) {
+    final long jdn = julianDayNumber(value.getYear(), value.getMonth(), value.getDay());
+    final long thursday = jdn + (3 - Math.floorMod(jdn, 7));
+    final int[] thursdayDate = gregorianFromJdn(thursday);
+    return (thursdayDate[2] - 1) / 7 + 1;
+  }
+}

--- a/src/main/java/io/brackit/query/util/format/IntegerFormatter.java
+++ b/src/main/java/io/brackit/query/util/format/IntegerFormatter.java
@@ -1,0 +1,572 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.util.format;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.QueryException;
+
+/**
+ * Implements the integer formatting rules of <code>fn:format-integer</code> (XQuery F&amp;O 3.1,
+ * section 4.6.1). The same machinery is reused by the date/time formatting functions for their
+ * numeric presentation modifiers.
+ *
+ * <p>Supported primary format tokens: decimal-digit-patterns (mandatory digits of any single
+ * Unicode decimal digit family, optional digit signs <code>#</code>, and grouping separators),
+ * <code>a</code>/<code>A</code> (alphabetic), <code>i</code>/<code>I</code> (roman numerals),
+ * and <code>w</code>/<code>W</code>/<code>Ww</code> (English words). Any other token falls back
+ * to <code>1</code>, as required by the spec for unsupported numbering sequences.</p>
+ *
+ * <p>The format modifier (<code>;</code>-separated) supports cardinal/ordinal selection
+ * (<code>c</code>/<code>o</code>, with an optionally parenthesized variation string that is
+ * accepted and ignored) and accepts <code>a</code>/<code>t</code> (the choice between alphabetic
+ * and traditional numbering is implementation-defined; this implementation always uses the
+ * alphabetic interpretation). Ordinal numbering is implemented for English (suffixes
+ * <code>1st 2nd 3rd ...</code> for decimal digit patterns, and spelled-out ordinals for word
+ * tokens); for other tokens the ordinal request is ignored as the spec prescribes.</p>
+ *
+ * <p>Implementation-defined bounds: roman numerals support 1..999999 and words support values
+ * with an absolute value below 10^19; outside these ranges the value is formatted with the
+ * fallback token <code>1</code> (the spec only mandates support up to 1000).</p>
+ */
+public final class IntegerFormatter {
+
+  private static final String[] UNITS = { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
+      "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen",
+      "nineteen" };
+
+  private static final String[] TENS = { "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty",
+      "ninety" };
+
+  private static final String[] SCALES = { "", "thousand", "million", "billion", "trillion", "quadrillion",
+      "quintillion" };
+
+  private static final int[] ROMAN_VALUES = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
+
+  private static final String[] ROMAN_SYMBOLS = { "m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv",
+      "i" };
+
+  private IntegerFormatter() {
+  }
+
+  /**
+   * Implements the full <code>fn:format-integer</code> picture: a primary format token optionally
+   * followed by a <code>;</code>-separated format modifier.
+   */
+  public static String formatInteger(BigInteger value, String picture) {
+    final String primary;
+    final String modifier;
+    final int semicolon = picture.lastIndexOf(';');
+    if (semicolon >= 0) {
+      primary = picture.substring(0, semicolon);
+      modifier = picture.substring(semicolon + 1);
+    } else {
+      primary = picture;
+      modifier = "";
+    }
+    if (primary.isEmpty()) {
+      throw new QueryException(ErrorCode.ERR_INVALID_FORMAT_INTEGER_PICTURE,
+                               "The primary format token of fn:format-integer must not be zero-length");
+    }
+    if (!modifier.matches("([co](\\(.+\\))?)?[at]?")) {
+      throw new QueryException(ErrorCode.ERR_INVALID_FORMAT_INTEGER_PICTURE,
+                               "Invalid format modifier in fn:format-integer picture: '%s'",
+                               modifier);
+    }
+    final boolean ordinal = !modifier.isEmpty() && modifier.charAt(0) == 'o';
+    return format(value, primary, ordinal);
+  }
+
+  /**
+   * Formats a value with a single primary format token (no <code>;</code> modifier part). Used
+   * directly by the date/time formatting functions, which carry the cardinal/ordinal selection in
+   * their own (second) presentation modifier.
+   */
+  public static String format(BigInteger value, String token, boolean ordinal) {
+    if (containsDecimalDigit(token)) {
+      return formatDecimalPattern(value, token, ordinal);
+    }
+    switch (token) {
+      case "A":
+        return formatBounded(value, ordinal, v -> alphabetic(v).toUpperCase(), v -> v.signum() > 0);
+      case "a":
+        return formatBounded(value, ordinal, IntegerFormatter::alphabetic, v -> v.signum() > 0);
+      case "I":
+        return formatBounded(value, ordinal, v -> roman(v).toUpperCase(), IntegerFormatter::inRomanRange);
+      case "i":
+        return formatBounded(value, ordinal, IntegerFormatter::roman, IntegerFormatter::inRomanRange);
+      case "w":
+        return formatWords(value, ordinal, WordCase.LOWER);
+      case "W":
+        return formatWords(value, ordinal, WordCase.UPPER);
+      case "Ww":
+        return formatWords(value, ordinal, WordCase.TITLE);
+      default:
+        // Unsupported numbering sequence: the spec mandates falling back to the format token "1".
+        return formatDecimalPattern(value, "1", ordinal);
+    }
+  }
+
+  /**
+   * True iff the token contains at least one Unicode decimal digit (category Nd) and must hence be
+   * interpreted as a decimal digit pattern.
+   */
+  public static boolean containsDecimalDigit(String token) {
+    for (int i = 0; i < token.length();) {
+      final int cp = token.codePointAt(i);
+      if (Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER) {
+        return true;
+      }
+      i += Character.charCount(cp);
+    }
+    return false;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Decimal digit patterns
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * A parsed decimal-digit-pattern: counts of mandatory/optional digit signs, the digit family,
+   * and the grouping separator template.
+   */
+  static final class DecimalPattern {
+    final int mandatory;
+    final int optional;
+    /** Codepoint of the zero digit of the mandatory digit family ('0' when none specified). */
+    final int zeroDigit;
+    /** Regular grouping (extrapolated): size of group, or -1 if not regular. */
+    final int groupSize;
+    final int groupChar;
+    /** Irregular grouping: (position, separator codepoint) pairs; empty if none/regular. */
+    final List<int[]> separators;
+
+    DecimalPattern(int mandatory, int optional, int zeroDigit, int groupSize, int groupChar, List<int[]> separators) {
+      this.mandatory = mandatory;
+      this.optional = optional;
+      this.zeroDigit = zeroDigit;
+      this.groupSize = groupSize;
+      this.groupChar = groupChar;
+      this.separators = separators;
+    }
+  }
+
+  static DecimalPattern parseDecimalPattern(String token) {
+    int mandatory = 0;
+    int optional = 0;
+    int zeroDigit = -1;
+    boolean mandatorySeen = false;
+    boolean lastWasSeparator = false;
+    // Separator positions counted as the number of digit signs to the right of the separator.
+    final List<int[]> separatorsLeftToRight = new ArrayList<>();
+    final List<Integer> digitSignsBeforeSeparator = new ArrayList<>();
+
+    final int length = token.length();
+    int digitSigns = 0;
+    for (int i = 0; i < length;) {
+      final int cp = token.codePointAt(i);
+      final int charCount = Character.charCount(cp);
+      if (Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER) {
+        final int familyZero = cp - Character.digit(cp, 10);
+        if (zeroDigit == -1) {
+          zeroDigit = familyZero;
+        } else if (zeroDigit != familyZero) {
+          throw invalidPattern(token, "all mandatory digit signs must belong to the same digit family");
+        }
+        mandatory++;
+        mandatorySeen = true;
+        digitSigns++;
+        lastWasSeparator = false;
+      } else if (cp == '#') {
+        if (mandatorySeen) {
+          throw invalidPattern(token, "optional digit signs must precede all mandatory digit signs");
+        }
+        optional++;
+        digitSigns++;
+        lastWasSeparator = false;
+      } else if (isGroupingSeparator(cp)) {
+        if (i == 0) {
+          throw invalidPattern(token, "a grouping separator must not appear at the start");
+        }
+        if (lastWasSeparator) {
+          throw invalidPattern(token, "adjacent grouping separators are not allowed");
+        }
+        separatorsLeftToRight.add(new int[] { -1, cp });
+        digitSignsBeforeSeparator.add(digitSigns);
+        lastWasSeparator = true;
+      } else {
+        throw invalidPattern(token, "invalid character '" + new String(Character.toChars(cp)) + "'");
+      }
+      i += charCount;
+    }
+    if (mandatory == 0) {
+      throw invalidPattern(token, "at least one mandatory digit sign is required");
+    }
+    if (lastWasSeparator) {
+      throw invalidPattern(token, "a grouping separator must not appear at the end");
+    }
+
+    // Convert "digit signs before separator" into "digit signs to the right of the separator".
+    for (int i = 0; i < separatorsLeftToRight.size(); i++) {
+      separatorsLeftToRight.get(i)[0] = digitSigns - digitSignsBeforeSeparator.get(i);
+    }
+
+    // Determine whether the grouping separators are "regular" and can be extrapolated.
+    int groupSize = -1;
+    int groupChar = -1;
+    if (!separatorsLeftToRight.isEmpty()) {
+      boolean regular = true;
+      final int candidateChar = separatorsLeftToRight.get(0)[1];
+      int minPosition = Integer.MAX_VALUE;
+      for (final int[] sep : separatorsLeftToRight) {
+        if (sep[1] != candidateChar) {
+          regular = false;
+          break;
+        }
+        minPosition = Math.min(minPosition, sep[0]);
+      }
+      if (regular) {
+        final int g = minPosition;
+        // every separator position must be a multiple of g
+        for (final int[] sep : separatorsLeftToRight) {
+          if (sep[0] % g != 0) {
+            regular = false;
+            break;
+          }
+        }
+        // every positive multiple of g below the number of digit signs must be a separator position
+        if (regular) {
+          for (int multiple = g; multiple < digitSigns; multiple += g) {
+            boolean found = false;
+            for (final int[] sep : separatorsLeftToRight) {
+              if (sep[0] == multiple) {
+                found = true;
+                break;
+              }
+            }
+            if (!found) {
+              regular = false;
+              break;
+            }
+          }
+        }
+        if (regular) {
+          groupSize = g;
+          groupChar = candidateChar;
+        }
+      }
+    }
+
+    return new DecimalPattern(mandatory,
+                              optional,
+                              zeroDigit == -1 ? '0' : zeroDigit,
+                              groupSize,
+                              groupChar,
+                              groupSize != -1 ? List.of() : separatorsLeftToRight);
+  }
+
+  private static QueryException invalidPattern(String token, String reason) {
+    return new QueryException(ErrorCode.ERR_INVALID_FORMAT_INTEGER_PICTURE,
+                              "Invalid decimal digit pattern '%s': %s",
+                              token,
+                              reason);
+  }
+
+  static boolean isGroupingSeparator(int cp) {
+    // any non-alphanumeric character: category other than Nd, Nl, No, Lu, Ll, Lt, Lm, or Lo
+    return switch (Character.getType(cp)) {
+      case Character.DECIMAL_DIGIT_NUMBER, Character.LETTER_NUMBER, Character.OTHER_NUMBER, Character.UPPERCASE_LETTER,
+          Character.LOWERCASE_LETTER, Character.TITLECASE_LETTER, Character.MODIFIER_LETTER, Character.OTHER_LETTER ->
+        false;
+      default -> true;
+    };
+  }
+
+  private static String formatDecimalPattern(BigInteger value, String token, boolean ordinal) {
+    final DecimalPattern pattern = parseDecimalPattern(token);
+    final boolean negative = value.signum() < 0;
+    final BigInteger abs = value.abs();
+
+    // S1/S2: decimal representation, left-padded with zeroes to the number of mandatory digits
+    final StringBuilder digits = new StringBuilder(abs.toString());
+    while (digits.length() < pattern.mandatory) {
+      digits.insert(0, '0');
+    }
+
+    // S3: translate into the requested digit family
+    if (pattern.zeroDigit != '0') {
+      for (int i = 0; i < digits.length(); i++) {
+        // safe: family zero digits of all Nd families used here are BMP codepoints
+        digits.setCharAt(i, (char) (pattern.zeroDigit + (digits.charAt(i) - '0')));
+      }
+    }
+
+    // S4: insert grouping separators (position counted from the right-hand end)
+    final StringBuilder grouped = new StringBuilder();
+    final int digitCount = digits.length();
+    for (int i = 0; i < digitCount; i++) {
+      final int positionFromRight = digitCount - i;
+      if (i > 0 && separatorAt(pattern, positionFromRight) != -1) {
+        grouped.appendCodePoint(separatorAt(pattern, positionFromRight));
+      }
+      grouped.append(digits.charAt(i));
+    }
+
+    // S5: ordinal suffix (English)
+    String result = grouped.toString();
+    if (ordinal) {
+      result += ordinalSuffix(abs);
+    }
+    return negative ? "-" + result : result;
+  }
+
+  private static int separatorAt(DecimalPattern pattern, int positionFromRight) {
+    if (pattern.groupSize > 0) {
+      return positionFromRight % pattern.groupSize == 0 ? pattern.groupChar : -1;
+    }
+    for (final int[] sep : pattern.separators) {
+      if (sep[0] == positionFromRight) {
+        return sep[1];
+      }
+    }
+    return -1;
+  }
+
+  private static String ordinalSuffix(BigInteger abs) {
+    final int mod100 = abs.mod(BigInteger.valueOf(100)).intValue();
+    if (mod100 >= 11 && mod100 <= 13) {
+      return "th";
+    }
+    return switch (mod100 % 10) {
+      case 1 -> "st";
+      case 2 -> "nd";
+      case 3 -> "rd";
+      default -> "th";
+    };
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Alphabetic and roman sequences
+  // ---------------------------------------------------------------------------------------------
+
+  private interface BoundedFormatter {
+    String apply(BigInteger value);
+  }
+
+  private interface RangeCheck {
+    boolean test(BigInteger value);
+  }
+
+  private static String formatBounded(BigInteger value, boolean ordinal, BoundedFormatter formatter, RangeCheck range) {
+    final BigInteger abs = value.abs();
+    if (!range.test(abs) || abs.signum() == 0) {
+      // out of the supported range: fall back to format token "1" per spec
+      return formatDecimalPattern(value, "1", ordinal);
+    }
+    // ordinal numbering is not supported for these sequences; the request is ignored (cardinal)
+    final String formatted = formatter.apply(abs);
+    return value.signum() < 0 ? "-" + formatted : formatted;
+  }
+
+  private static boolean inRomanRange(BigInteger abs) {
+    return abs.signum() > 0 && abs.compareTo(BigInteger.valueOf(999_999)) <= 0;
+  }
+
+  /** Bijective base-26 sequence: a b c ... z aa ab ... */
+  private static String alphabetic(BigInteger value) {
+    final StringBuilder sb = new StringBuilder();
+    BigInteger n = value;
+    final BigInteger twentySix = BigInteger.valueOf(26);
+    while (n.signum() > 0) {
+      n = n.subtract(BigInteger.ONE);
+      final BigInteger[] divRem = n.divideAndRemainder(twentySix);
+      sb.append((char) ('a' + divRem[1].intValue()));
+      n = divRem[0];
+    }
+    return sb.reverse().toString();
+  }
+
+  private static String roman(BigInteger value) {
+    int n = value.intValueExact();
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < ROMAN_VALUES.length; i++) {
+      while (n >= ROMAN_VALUES[i]) {
+        sb.append(ROMAN_SYMBOLS[i]);
+        n -= ROMAN_VALUES[i];
+      }
+    }
+    return sb.toString();
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // English words
+  // ---------------------------------------------------------------------------------------------
+
+  private enum WordCase {
+    LOWER, UPPER, TITLE
+  }
+
+  private static String formatWords(BigInteger value, boolean ordinal, WordCase wordCase) {
+    final BigInteger abs = value.abs();
+    if (abs.compareTo(BigInteger.TEN.pow(19)) >= 0) {
+      // beyond the supported (implementation-defined) range: fall back to format token "1"
+      return formatDecimalPattern(value, "1", ordinal);
+    }
+    String words = cardinalWords(abs);
+    if (ordinal) {
+      words = toOrdinalWords(words);
+    }
+    if (value.signum() < 0) {
+      words = "minus " + words;
+    }
+    return switch (wordCase) {
+      case LOWER -> words;
+      case UPPER -> words.toUpperCase();
+      case TITLE -> titleCase(words);
+    };
+  }
+
+  /**
+   * English cardinal number words using the "hundred and two" convention (cf. the spec example
+   * "Two Thousand and Three").
+   */
+  private static String cardinalWords(BigInteger value) {
+    if (value.signum() == 0) {
+      return UNITS[0];
+    }
+    // split into groups of three digits, most significant first
+    final String digits = value.toString();
+    final int groupCount = (digits.length() + 2) / 3;
+    final int[] groups = new int[groupCount];
+    int end = digits.length();
+    for (int i = groupCount - 1; i >= 0; i--) {
+      final int start = Math.max(0, end - 3);
+      groups[i] = Integer.parseInt(digits.substring(start, end));
+      end = start;
+    }
+
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < groupCount; i++) {
+      final int group = groups[i];
+      if (group == 0) {
+        continue;
+      }
+      final int scale = groupCount - 1 - i;
+      if (sb.length() > 0) {
+        // "and" joins a final tens-and-units group to the preceding larger parts
+        if (scale == 0 && group < 100) {
+          sb.append(" and ");
+        } else {
+          sb.append(' ');
+        }
+      }
+      sb.append(groupWords(group));
+      if (scale > 0) {
+        sb.append(' ').append(SCALES[scale]);
+      }
+    }
+    return sb.toString();
+  }
+
+  /** Words for 1..999. */
+  private static String groupWords(int group) {
+    final StringBuilder sb = new StringBuilder();
+    final int hundreds = group / 100;
+    final int rest = group % 100;
+    if (hundreds > 0) {
+      sb.append(UNITS[hundreds]).append(" hundred");
+      if (rest > 0) {
+        sb.append(" and ");
+      }
+    }
+    if (rest > 0) {
+      if (rest < 20) {
+        sb.append(UNITS[rest]);
+      } else {
+        sb.append(TENS[rest / 10]);
+        if (rest % 10 > 0) {
+          sb.append('-').append(UNITS[rest % 10]);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
+  /** Converts the final word of an English cardinal into its ordinal form. */
+  private static String toOrdinalWords(String cardinal) {
+    int lastWordStart = 0;
+    for (int i = cardinal.length() - 1; i >= 0; i--) {
+      final char c = cardinal.charAt(i);
+      if (c == ' ' || c == '-') {
+        lastWordStart = i + 1;
+        break;
+      }
+    }
+    final String head = cardinal.substring(0, lastWordStart);
+    final String last = cardinal.substring(lastWordStart);
+    final String ordinalLast = switch (last) {
+      case "zero" -> "zeroth";
+      case "one" -> "first";
+      case "two" -> "second";
+      case "three" -> "third";
+      case "five" -> "fifth";
+      case "eight" -> "eighth";
+      case "nine" -> "ninth";
+      case "twelve" -> "twelfth";
+      default -> last.endsWith("y") ? last.substring(0, last.length() - 1) + "ieth" : last + "th";
+    };
+    return head + ordinalLast;
+  }
+
+  /** Title-case: capitalize the first letter of each (space- or hyphen-separated) word but "and". */
+  private static String titleCase(String words) {
+    final StringBuilder sb = new StringBuilder(words.length());
+    boolean atWordStart = true;
+    for (int i = 0; i < words.length(); i++) {
+      final char c = words.charAt(i);
+      if (c == ' ' || c == '-') {
+        sb.append(c);
+        atWordStart = true;
+      } else if (atWordStart) {
+        // keep the conjunction "and" in lower-case ("Two Thousand and Three")
+        if (c == 'a' && words.startsWith("and", i) && (i + 3 == words.length() || words.charAt(i + 3) == ' ')) {
+          sb.append(c);
+        } else {
+          sb.append(Character.toUpperCase(c));
+        }
+        atWordStart = false;
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/src/test/java/io/brackit/query/function/fn/FormatDateTimeTest.java
+++ b/src/test/java/io/brackit/query/function/fn/FormatDateTimeTest.java
@@ -1,0 +1,367 @@
+package io.brackit.query.function.fn;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for fn:format-dateTime, fn:format-date, and fn:format-time, covering the examples of
+ * XQuery F&amp;O 3.1 section 9.8.4.8 (adapted where the spec example text contradicts its own
+ * input data) plus edge cases: bracket escapes, width modifiers, fractional second
+ * truncation/padding, negative years, timezone presentations, and the spec'd error conditions
+ * (err:FOFD1340 and err:FOFD1350).
+ */
+public class FormatDateTimeTest extends XQueryBaseTest {
+
+  /** The spec's example date: a Tuesday. */
+  private static final String DATE = "2002-12-31";
+  private static final String TIME = "15:58:45.762";
+  private static final String DATE_TIME = "2002-12-31T15:58:45.762";
+
+  private static String fd(String picture) {
+    return "format-date(xs:date('" + DATE + "'), '" + picture + "')";
+  }
+
+  private static String fd5(String picture, String lang, String cal) {
+    return "format-date(xs:date('" + DATE + "'), '" + picture + "', " + lang + ", " + cal + ", ())";
+  }
+
+  private static String ft(String picture) {
+    return "format-time(xs:time('" + TIME + "'), '" + picture + "')";
+  }
+
+  private static String fdt(String picture) {
+    return "format-dateTime(xs:dateTime('" + DATE_TIME + "'), '" + picture + "')";
+  }
+
+  private void check(String expected, String query) {
+    ResultChecker.dCheck(new Str(expected), new Query(query).execute(ctx));
+  }
+
+  private void checkErr(QNm code, String query) {
+    final QueryException ex = assertThrows(QueryException.class, () -> new Query(query).execute(ctx), query);
+    assertEquals(code, ex.getCode(), query);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Spec examples (F&O 3.1, 9.8.4.8)
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void specExamplesFormatDate() {
+    check("2002-12-31", fd("[Y0001]-[M01]-[D01]"));
+    check("12-31-2002", fd("[M]-[D]-[Y]"));
+    check("31-12-2002", fd("[D]-[M]-[Y]"));
+    check("31 XII 2002", fd("[D1] [MI] [Y]"));
+    check("31st December, 2002", fd5("[D1o] [MNn], [Y]", "'en'", "()"));
+    check("31 DEC 2002", fd5("[D01] [MN,*-3] [Y0001]", "'en'", "()"));
+    check("December 31, 2002", fd5("[MNn] [D], [Y]", "'en'", "()"));
+    check("[2002-12-31]", fd("[[[Y0001]-[M01]-[D01]]]"));
+    // the spec displays "Two Thousand and Three" for this picture, but its example input date is
+    // 2002-12-31 (the original XSLT 2.0 example used the year 2003)
+    check("Two Thousand and Two", fd5("[YWw]", "'en'", "()"));
+  }
+
+  @Test
+  public void specExamplesFormatTime() {
+    check("3:58 PM", "format-time(xs:time('" + TIME + "'), '[h]:[m01] [PN]', 'en', (), ())");
+    check("3:58:45 pm", "format-time(xs:time('" + TIME + "'), '[h]:[m01]:[s01] [Pn]', 'en', (), ())");
+    check("15:58", ft("[H01]:[m01]"));
+    check("15:58:45.762", ft("[H01]:[m01]:[s01].[f001]"));
+    check("15:58:45 GMT+02:00",
+          "format-time(xs:time('15:58:45.762+02:00'), '[H01]:[m01]:[s01] [z,6-6]', 'en', (), ())");
+  }
+
+  @Test
+  public void specExamplesFormatDateTime() {
+    check("3.58pm on Tuesday, 31st December", fdt("[h].[m01][Pn] on [FNn], [D1o] [MNn]"));
+    check("12/31/2002 at 15:58:45", fdt("[M01]/[D01]/[Y0001] at [H01]:[m01]:[s01]"));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Empty sequence and literal handling
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void emptyValueYieldsEmptySequence() {
+    ResultChecker.dCheck(Bool.TRUE, new Query("empty(format-date((), '[Y]'))").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("empty(format-time((), '[H]'))").execute(ctx));
+    ResultChecker.dCheck(Bool.TRUE, new Query("empty(format-dateTime((), '[Y]', (), (), ()))").execute(ctx));
+  }
+
+  @Test
+  public void literalOnlyAndEscapedBrackets() {
+    check("plain text", fd("plain text"));
+    check("", fd(""));
+    check("[Y]", fd("[[Y]]"));
+    check("a[b]c", fd("a[[b]]c"));
+    check("31[", fd("[D][["));
+  }
+
+  @Test
+  public void whitespaceInsideMarkerIsIgnored() {
+    check("2002-12-31", fd("[Y 0001]-[M 01]-[D 01]"));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Width modifiers and year truncation
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void yearTruncation() {
+    check("02", fd("[Y01]"));
+    check("02", fd("[Y,2-2]"));
+    check("2002", fd("[Y]"));
+    check("2002", fd("[Y,2]"));
+    check("0031", "format-date(xs:date('0031-01-01'), '[Y0001]')");
+    // grouping separator in the year pattern; the trailing ,* is the width modifier
+    check("2,008", "format-date(xs:date('2008-01-01'), '[Y9,999,*]')");
+  }
+
+  @Test
+  public void widthModifiers() {
+    check("031", fd("[D,3]"));
+    check("31", fd("[D,2]"));
+    check("Dec", fd("[MNn,3-3]"));
+    check("DECEMBER", fd("[MN]"));
+    check("december ", fd("[Mn,9]"));
+    check("Tue", fdt("[FNn,3-3]"));
+  }
+
+  @Test
+  public void invalidWidthModifiers() {
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Y,0]"));
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Y,3-2]"));
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Y,]"));
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Y,x]"));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Component coverage
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void dayInYearWeekInYearWeekInMonth() {
+    check("365", fd("[d]"));
+    // 2002-12-31 falls into ISO week 1 of 2003
+    check("1", fd("[W]"));
+    // spec example: 29 January 2013 falls in week 5 of the month, and so does 1 February 2013
+    check("5", "format-date(xs:date('2013-01-29'), '[w]')");
+    check("5", "format-date(xs:date('2013-02-01'), '[w]')");
+    // ISO week of year: week 1 of 2013 starts on Monday 2012-12-31
+    check("5", "format-date(xs:date('2013-01-29'), '[W]')");
+    check("1", "format-date(xs:date('2013-01-01'), '[W]')");
+  }
+
+  @Test
+  public void dayOfWeek() {
+    check("tuesday", fdt("[F]"));
+    check("Tuesday", fdt("[FNn]"));
+    check("TUESDAY", fdt("[FN]"));
+    // ISO numbering: Monday=1 ... Sunday=7
+    check("2", fdt("[F1]"));
+    check("6", "format-date(xs:date('2000-01-01'), '[F1]')"); // a Saturday
+  }
+
+  @Test
+  public void twelveHourClockAndAmPm() {
+    check("12 am", "format-time(xs:time('00:30:00'), '[h] [P]')");
+    check("12 pm", "format-time(xs:time('12:00:00'), '[h] [P]')");
+    check("1 pm", "format-time(xs:time('13:00:00'), '[h] [P]')");
+    check("11 AM", "format-time(xs:time('11:59:59'), '[h] [PN]')");
+    check("Pm", "format-time(xs:time('13:00:00'), '[PNn]')");
+  }
+
+  @Test
+  public void ordinalAndOtherNumberings() {
+    check("31st", fd("[D1o]"));
+    check("1st", "format-date(xs:date('2002-12-01'), '[D1o]')");
+    check("2nd", "format-date(xs:date('2002-12-02'), '[D1o]')");
+    check("3rd", "format-date(xs:date('2002-12-03'), '[D1o]')");
+    check("11th", "format-date(xs:date('2002-12-11'), '[D1o]')");
+    check("thirty-first", fd("[Dwo]"));
+    check("xii", fd("[Mi]"));
+    check("e", "format-date(xs:date('2002-05-01'), '[Ma]')");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Fractional seconds
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void fractionalSeconds() {
+    check("762", ft("[f]"));
+    check("762", ft("[f1]"));
+    check("76", ft("[f01]"));
+    check("7620", ft("[f0001]"));
+    check("7", ft("[f1,1-1]"));
+    check("76", ft("[f,2-2]"));
+    check("762000", ft("[f,6-6]"));
+    check("5", "format-time(xs:time('10:00:00.5'), '[f1]')");
+    check("500", "format-time(xs:time('10:00:00.5'), '[f001]')");
+    check("000", "format-time(xs:time('10:00:00'), '[f001]')");
+    check("0", "format-time(xs:time('10:00:00'), '[f]')");
+    // 1 mandatory digit plus optional digits: truncates, strips trailing zeroes down to one digit
+    check("762", ft("[f1##]"));
+    check("5", "format-time(xs:time('10:00:00.5'), '[f1##]')");
+  }
+
+  @Test
+  public void fractionalSecondsGroupingSeparatorIsRejected() {
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, ft("[f0,0]"));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Negative years and eras
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void negativeYears() {
+    // the year component formats the absolute year value; the era carries the BC/AD distinction
+    check("0044 BC", "format-date(xs:date('-0044-03-15'), '[Y0001] [E]')");
+    check("44", "format-date(xs:date('-0044-03-15'), '[Y]')");
+    check("2002 AD", fd("[Y] [E]"));
+    // the ISO calendar's era is a minus sign for negative years, an empty string otherwise
+    check("-0044", "format-date(xs:date('-0044-03-15'), '[E][Y0001]', (), 'ISO', ())");
+    check("2002", fd5("[E][Y]", "()", "'ISO'"));
+  }
+
+  @Test
+  public void wideYears() {
+    check("12345", "format-date(xs:date('12345-06-07'), '[Y]')");
+    // four-digit pattern: the year is output modulo 10^4
+    check("2345", "format-date(xs:date('12345-06-07'), '[Y0001]')");
+  }
+
+  @Test
+  public void calendarComponent() {
+    check("AD", fd("[C]"));
+    check("ISO", fd5("[C]", "()", "'ISO'"));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Timezones
+  // -------------------------------------------------------------------------------------------
+
+  private static String fdtTz(String tz, String picture) {
+    return "format-dateTime(xs:dateTime('2002-12-31T12:00:00" + tz + "'), '" + picture + "')";
+  }
+
+  @Test
+  public void timezoneNumericPresentations() {
+    check("+05:30", fdtTz("+05:30", "[Z]"));
+    check("-05:00", fdtTz("-05:00", "[Z]"));
+    check("+00:00", fdtTz("Z", "[Z]"));
+    check("-10", fdtTz("-10:00", "[Z0]"));
+    check("-5", fdtTz("-05:00", "[Z0]"));
+    check("+0", fdtTz("Z", "[Z0]"));
+    check("+5:30", fdtTz("+05:30", "[Z0]"));
+    check("-5:00", fdtTz("-05:00", "[Z0:00]"));
+    check("+05:30", fdtTz("+05:30", "[Z00:00]"));
+    check("-0500", fdtTz("-05:00", "[Z0000]"));
+    check("+0530", fdtTz("+05:30", "[Z0000]"));
+    check("+13:00", fdtTz("+13:00", "[Z]"));
+  }
+
+  @Test
+  public void timezoneTraditionalModifierAndMilitary() {
+    check("Z", fdtTz("Z", "[Z00:00t]"));
+    check("-05:00", fdtTz("-05:00", "[Z00:00t]"));
+    check("W", fdtTz("-10:00", "[ZZ]"));
+    check("R", fdtTz("-05:00", "[ZZ]"));
+    check("Z", fdtTz("Z", "[ZZ]"));
+    check("A", fdtTz("+01:00", "[ZZ]"));
+    check("K", fdtTz("+10:00", "[ZZ]"));
+    // offsets without a military letter fall back to the 01:01 presentation
+    check("+05:30", fdtTz("+05:30", "[ZZ]"));
+    check("+13:00", fdtTz("+13:00", "[ZZ]"));
+  }
+
+  @Test
+  public void timezoneGmtPrefix() {
+    check("GMT+05:30", fdtTz("+05:30", "[z]"));
+    check("GMT-10:00", fdtTz("-10:00", "[z]"));
+    check("GMT+00:00", fdtTz("Z", "[z]"));
+    check("GMT+1", fdtTz("+01:00", "[z0]"));
+  }
+
+  @Test
+  public void timezoneAbsentFromValue() {
+    // not an error: the timezone component produces no output, except military "J" (local time)
+    check("", fdt("[Z]"));
+    check("", fdt("[z]"));
+    check("12:00", "format-time(xs:time('12:00:00'), '[H01]:[m01][Z01:01]')");
+    check("J", fdt("[ZZ]"));
+    // a timezone name needs a timezone database; the spec'd fallback is the 01:01 format
+    check("+05:30", fdtTz("+05:30", "[ZN]"));
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Language, calendar, and place arguments
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void unsupportedLanguageFallsBackLoudly() {
+    check("[Language: en]December", fd5("[MNn]", "'de'", "()"));
+    check("December", fd5("[MNn]", "'en'", "()"));
+    check("December", fd5("[MNn]", "'EN-GB'", "()"));
+    check("December", fd5("[MNn]", "()", "()"));
+  }
+
+  @Test
+  public void unsupportedCalendarFallsBackLoudly() {
+    check("[Calendar: AD]31 December 2002", fd5("[D] [MNn] [Y]", "'en'", "'OS'"));
+    check("[Calendar: AD]2002", fd5("[Y]", "()", "'AH'"));
+    check("2002", fd5("[Y]", "()", "'AD'"));
+    // a namespaced calendar EQName is implementation-defined territory: unsupported here
+    check("[Calendar: AD]2002", fd5("[Y]", "()", "'Q{http://example.org}cal'"));
+  }
+
+  @Test
+  public void invalidCalendarIsRejected() {
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd5("[Y]", "()", "'XYZ'"));
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd5("[Y]", "()", "'not a name'"));
+  }
+
+  @Test
+  public void placeIsAcceptedButUnused() {
+    check("2002", "format-date(xs:date('" + DATE + "'), '[Y]', (), (), 'America/New_York')");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Error conditions
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void invalidPictureSyntax() {
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Y")); // unclosed marker
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("a]b")); // lone closing bracket
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[]")); // empty marker
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Q]")); // unknown component
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fd("[Y0#1]")); // optional digit after mandatory
+    // exotic timezone presentation modifiers fail loudly instead of guessing
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fdtTz("+05:30", "[Z00000]"));
+    checkErr(ErrorCode.ERR_INVALID_DATETIME_PICTURE, fdtTz("+05:30", "[Z0:0:0]"));
+  }
+
+  @Test
+  public void componentNotAvailableInValueType() {
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, fd("[H]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, fd("[m]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, fd("[P]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, ft("[Y]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, ft("[M]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, ft("[D]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, ft("[F]"));
+    checkErr(ErrorCode.ERR_DATETIME_COMPONENT_NOT_AVAILABLE, ft("[E]"));
+  }
+}

--- a/src/test/java/io/brackit/query/function/fn/FormatIntegerTest.java
+++ b/src/test/java/io/brackit/query/function/fn/FormatIntegerTest.java
@@ -1,0 +1,162 @@
+package io.brackit.query.function.fn;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.atomic.Str;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for fn:format-integer (XQuery F&amp;O 3.1, section 4.6.1): decimal digit patterns with
+ * grouping separators, alphabetic/roman/word sequences, ordinal modifiers, and err:FODF1310.
+ */
+public class FormatIntegerTest extends XQueryBaseTest {
+
+  private void check(String expected, String query) {
+    ResultChecker.dCheck(new Str(expected), new Query(query).execute(ctx));
+  }
+
+  private static String fi(String value, String picture) {
+    // double quotes: pictures may legitimately contain apostrophes as grouping separators
+    return "format-integer(" + value + ", \"" + picture + "\")";
+  }
+
+  @Test
+  public void decimalDigitPatterns() {
+    check("123", fi("123", "1"));
+    check("00123", fi("123", "00000"));
+    // '000', '001', and '999' are equivalent: any digit is a mandatory digit sign
+    check("00123", fi("123", "00999"));
+    check("0", fi("0", "1"));
+    check("-123", fi("-123", "1"));
+    check("300", fi("300", "01")); // numbers are never truncated
+  }
+
+  @Test
+  public void groupingSeparators() {
+    check("1,000,000", fi("1000000", "#,##0"));
+    check("15", fi("15", "#,##0"));
+    check("1'000'000", fi("1000000", "0'000"));
+    check("0'015", fi("15", "0'000"));
+    check("1,234,567", fi("1234567", "1,111"));
+    // irregular separators are not extrapolated
+    check("1234-56-7", fi("1234567", "1-11-1"));
+  }
+
+  @Test
+  public void ordinalModifier() {
+    check("1st", fi("1", "1;o"));
+    check("2nd", fi("2", "1;o"));
+    check("3rd", fi("3", "1;o"));
+    check("4th", fi("4", "1;o"));
+    check("11th", fi("11", "1;o"));
+    check("12th", fi("12", "1;o"));
+    check("13th", fi("13", "1;o"));
+    check("21st", fi("21", "1;o"));
+    check("0021st", fi("21", "0001;o"));
+    // the parenthesized variation selector is accepted and ignored
+    check("1st", fi("1", "1;o(-er)"));
+    check("1", fi("1", "1;c"));
+  }
+
+  @Test
+  public void alphabetic() {
+    check("a", fi("1", "a"));
+    check("z", fi("26", "a"));
+    check("aa", fi("27", "a"));
+    check("ab", fi("28", "a"));
+    check("B", fi("2", "A"));
+    check("AA", fi("27", "A"));
+    // zero is outside the alphabetic range: falls back to format token "1"
+    check("0", fi("0", "a"));
+    check("-b", fi("-2", "a"));
+  }
+
+  @Test
+  public void roman() {
+    check("i", fi("1", "i"));
+    check("iv", fi("4", "i"));
+    check("ix", fi("9", "i"));
+    check("xiv", fi("14", "i"));
+    check("XLII", fi("42", "I"));
+    check("mcmxcix", fi("1999", "i"));
+    check("MMXXVI", fi("2026", "I"));
+    check("0", fi("0", "i"));
+  }
+
+  @Test
+  public void words() {
+    check("one", fi("1", "w"));
+    check("fifteen", fi("15", "w"));
+    check("twenty-one", fi("21", "w"));
+    check("one hundred", fi("100", "w"));
+    check("one hundred and two", fi("102", "w"));
+    check("two thousand and three", fi("2003", "w"));
+    check("one thousand two hundred and thirty-four", fi("1234", "w"));
+    check("one million", fi("1000000", "w"));
+    check("THIRTY-SIX", fi("36", "W"));
+    check("Two Thousand and Two", fi("2002", "Ww"));
+    check("minus five", fi("-5", "w"));
+    check("zero", fi("0", "w"));
+  }
+
+  @Test
+  public void ordinalWords() {
+    check("first", fi("1", "w;o"));
+    check("second", fi("2", "w;o"));
+    check("third", fi("3", "w;o"));
+    check("fourth", fi("4", "w;o"));
+    check("fifth", fi("5", "w;o"));
+    check("eighth", fi("8", "w;o"));
+    check("ninth", fi("9", "w;o"));
+    check("twelfth", fi("12", "w;o"));
+    check("twentieth", fi("20", "w;o"));
+    check("twenty-first", fi("21", "w;o"));
+    check("one hundredth", fi("100", "w;o"));
+    check("One Hundred and Second", fi("102", "Ww;o"));
+  }
+
+  @Test
+  public void unknownSequenceFallsBackToDecimal() {
+    // unsupported numbering sequences must be formatted with the format token "1"
+    check("5", fi("5", "x"));
+    check("5", fi("5", "①"));
+    // a lone "#" contains no digit, so it is a (unsupported) numbering sequence token, not an
+    // invalid decimal digit pattern
+    check("1", fi("1", "#"));
+  }
+
+  @Test
+  public void emptyValueYieldsZeroLengthString() {
+    check("", fi("()", "1"));
+  }
+
+  @Test
+  public void unsupportedLanguageIsNotAnError() {
+    // only English is supported; an unrecognized $lang falls back without error
+    check("one", "format-integer(1, 'w', 'de')");
+    check("one", "format-integer(1, 'w', ())");
+  }
+
+  @Test
+  public void invalidPictures() {
+    for (final String picture : new String[] { "", ",1", "1,", "1,,1", "#1#", "1;x", "0٠" /* mixed families */ }) {
+      final QueryException ex = assertThrows(QueryException.class,
+                                             () -> new Query(fi("1", picture)).execute(ctx),
+                                             picture);
+      assertEquals(ErrorCode.ERR_INVALID_FORMAT_INTEGER_PICTURE, ex.getCode(), picture);
+    }
+  }
+
+  @Test
+  public void nonAsciiDigitFamily() {
+    // Arabic-Indic digit family: the digit family of the pattern is used in the output
+    check("١٥", fi("15", "١"));
+    check("٠١٥", fi("15", "١١١"));
+  }
+}

--- a/src/test/java/io/brackit/query/function/fn/ResolveQNameTest.java
+++ b/src/test/java/io/brackit/query/function/fn/ResolveQNameTest.java
@@ -1,0 +1,106 @@
+package io.brackit.query.function.fn;
+
+import io.brackit.query.ErrorCode;
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.ResultChecker;
+import io.brackit.query.XQueryBaseTest;
+import io.brackit.query.atomic.AnyURI;
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Type;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for fn:resolve-QName (XQuery F&amp;O 3.1, section 10.2.2): prefix resolution against the
+ * in-scope namespaces of an element, default-namespace handling for unprefixed names (unlike the
+ * xs:QName constructor), and the err:FOCA0002/err:FONS0004 error conditions.
+ */
+public class ResolveQNameTest extends XQueryBaseTest {
+
+  private void check(Sequence expected, String query) {
+    ResultChecker.dCheck(expected, new Query(query).execute(ctx));
+  }
+
+  private static Atomic ncName(String name) {
+    return new Str(name).asType(Type.NCN);
+  }
+
+  @Test
+  public void emptyArgumentYieldsEmptySequence() {
+    check(Bool.TRUE, "empty(resolve-QName((), <a/>))");
+  }
+
+  @Test
+  public void unprefixedNameWithoutDefaultNamespace() {
+    // spec example: returns a QName with local name "hello" that is in no namespace
+    check(ncName("hello"), "local-name-from-QName(resolve-QName('hello', <a/>))");
+    check(new AnyURI(""), "namespace-uri-from-QName(resolve-QName('hello', <a/>))");
+    check(Bool.TRUE, "empty(prefix-from-QName(resolve-QName('hello', <a/>)))");
+  }
+
+  @Test
+  public void unprefixedNameUsesDefaultNamespace() {
+    // unlike the xs:QName constructor, resolve-QName DOES consult the default element namespace
+    check(new AnyURI("http://example.org/default"),
+          "namespace-uri-from-QName(resolve-QName('hello', <a xmlns='http://example.org/default'/>))");
+    check(ncName("hello"), "local-name-from-QName(resolve-QName('hello', <a xmlns='http://example.org/default'/>))");
+  }
+
+  @Test
+  public void prefixedNameResolvesAgainstInScopeNamespaces() {
+    // spec example: the namespace URI is taken from the binding of the prefix "eg"
+    check(new AnyURI("http://example.org/myFunctions"),
+          "namespace-uri-from-QName(resolve-QName('eg:myFunc', <a xmlns:eg='http://example.org/myFunctions'/>))");
+    check(ncName("myFunc"),
+          "local-name-from-QName(resolve-QName('eg:myFunc', <a xmlns:eg='http://example.org/myFunctions'/>))");
+    // the prefix is retained in the returned expanded-QName
+    check(ncName("eg"),
+          "prefix-from-QName(resolve-QName('eg:myFunc', <a xmlns:eg='http://example.org/myFunctions'/>))");
+  }
+
+  @Test
+  public void namespacesAreInheritedFromAncestors() {
+    check(new AnyURI("urn:outer"),
+          "namespace-uri-from-QName(resolve-QName('x:leaf', (<a xmlns:x='urn:outer'><b/></a>)/*:b))");
+  }
+
+  @Test
+  public void xmlPrefixIsAlwaysInScope() {
+    check(new AnyURI("http://www.w3.org/XML/1998/namespace"),
+          "namespace-uri-from-QName(resolve-QName('xml:lang', <a/>))");
+  }
+
+  @Test
+  public void whitespaceIsCollapsed() {
+    // the lexical space of xs:QName permits surrounding whitespace (whitespace facet: collapse)
+    check(ncName("hello"), "local-name-from-QName(resolve-QName('  hello  ', <a/>))");
+  }
+
+  @Test
+  public void invalidLexicalQNameRaisesFOCA0002() {
+    for (final String lexical : new String[] { "1:b", "a:b:c", ":b", "a:", "a b", "" }) {
+      final QueryException ex = assertThrows(QueryException.class,
+                                             () -> new Query("resolve-QName('" + lexical + "', <a/>)").execute(ctx),
+                                             lexical);
+      assertEquals(ErrorCode.ERR_INVALID_LEXICAL_VALUE, ex.getCode(), lexical);
+    }
+  }
+
+  @Test
+  public void unboundPrefixRaisesFONS0004() {
+    final QueryException ex = assertThrows(QueryException.class,
+                                           () -> new Query("resolve-QName('unknown:x', <a/>)").execute(ctx));
+    assertEquals(ErrorCode.ERR_NO_NAMESPACE_FOR_PREFIX, ex.getCode());
+
+    // a prefix bound on an unrelated sibling scope is not in scope either
+    final QueryException ex2 = assertThrows(QueryException.class,
+                                            () -> new Query("resolve-QName('eg:x', (<r><a xmlns:eg='urn:x'/><b/></r>)/*:b)").execute(ctx));
+    assertEquals(ErrorCode.ERR_NO_NAMESPACE_FOR_PREFIX, ex2.getCode());
+  }
+}


### PR DESCRIPTION
Closes the largest remaining F&O coverage gap (previously XPST0017 for all five). Semantics verified against the authoritative `w3c/qtspecs` sources (`xpath-functions.xml` + `function-catalog.xml`), not memory.

## fn:format-dateTime / format-date / format-time (2- and 5-arg)

Full picture-string engine (`util/format/DateTimeFormatter`): `[[`/`]]` escapes, whitespace-insensitive markers, last-comma width-modifier rule, all 17 component specifiers with spec defaults. Presentations: decimal digit patterns incl. grouping separators and non-ASCII digit families, `n/N/Nn` names, `i/I` roman, `a/A` alphabetic, `w/W/Ww` English words, `o` ordinals (`[D1o]` → `31st`); width modifiers incl. year modulo truncation (`[Y01]` → `02`) and name abbreviation (`[MN,*-3]` → `DEC`); fractional seconds per the spec's reversal algorithm; timezone forms `01`/`01:01`/`0101`/military `ZZ`/GMT-prefixed `z` with sub-hour auto-minutes and `t`→`Z` at UTC. Wrong component for the value type → FOFD1350; malformed pictures → FOFD1340 (loud, never silently-wrong output). All spec §9.8.4.8 English examples pass verbatim.

Implementation-defined choices documented in javadoc and locked by tests: English-only (`[Language: en]` prefix otherwise, per spec), AD + ISO calendars (`[Calendar: AD]` fallback prefix for others), XSD-1.0 year numbering for BC, ISO week/day numbering, $place accepted-unused.

## fn:resolve-QName

Resolves via the element's in-scope namespace `Scope` (ancestors + `xml`); the default namespace IS used for unprefixed names (the spec'd difference from `xs:QName` casts); FOCA0002 / FONS0004 errors.

## fn:format-integer (2- and 3-arg)

Decimal patterns with `#` and regular/irregular grouping, any Unicode digit family, `a A i I w W Ww`, ordinal modifiers (`1st`, `thirty-first`), `;c/;o(...)/;a/;t` modifier grammar, FODF1310 for invalid pictures.

## Tests

`mvn test`: **1,235 / 0** (master baseline 1,186/0; +49). One spec erratum noted in-test: §9.8.4.8's `[YWw]` example row says "Two Thousand and Three" against its own 2002 input date.