### PR TITLE
Fix group-by spilling/hangs, array-constructor flattening, and let-bound decorrelation

### DIFF
--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/LetBindToLeftJoin.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/LetBindToLeftJoin.java
@@ -27,6 +27,9 @@
  */
 package io.brackit.query.compiler.optimizer.walker.topdown;
 
+import static io.brackit.query.compiler.XQ.TypedVariableBinding;
+import static io.brackit.query.compiler.XQ.Variable;
+
 import io.brackit.query.atomic.Bool;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.util.Cmp;
@@ -37,6 +40,8 @@ import io.brackit.query.compiler.XQ;
  * @author Sebastian Baechle
  */
 public class LetBindToLeftJoin extends AggFunChecker {
+
+  private int groupVarCnt;
 
   @Override
   protected AST visit(AST node) {
@@ -51,6 +56,10 @@ public class LetBindToLeftJoin extends AggFunChecker {
     }
 
     return convertToLeftJoin(node);
+  }
+
+  private QNm createGroupVarName() {
+    return new QNm("_letgroup;" + (groupVarCnt++));
   }
 
   private AST convertToLeftJoin(AST let) {
@@ -79,18 +88,30 @@ public class LetBindToLeftJoin extends AggFunChecker {
     // boolean value "true" as right join key expression
     righInEnd.replaceChild(0, new AST(XQ.Bool, Bool.TRUE));
 
+    // Establish a per-outer-iteration grouping key for the binding.
+    //
+    // The let-binding may be reached by an arbitrary number of outer tuples
+    // (e.g. an enclosing for-loop). The left join above produces one (matched
+    // or padded) result group per outer tuple, and the post-join group-by has
+    // to fold those back into exactly one binding value per outer tuple. To do
+    // so we number every outer tuple with a Count placed *upstream* of the join
+    // and group the binding by that number. Because the count is an outer column
+    // (it is not the join's "check" marker), it is preserved on the padded tuple
+    // of an outer iteration whose nested pipeline produced nothing, so empty
+    // iterations remain separate groups instead of collapsing into one.
+    QNm groupVar = createGroupVarName();
+
     // the post join pipeline uses a let-binding
     // for the original return expression
-    // and then groups the let-bound return values
+    // and then groups the let-bound return values per outer tuple
     // (only the binding of the final let will be used)
     AST post = new AST(XQ.Start);
     AST letVarBinding = let.getChild(0).copyTree();
-    // TODO fix cardinality of binding if necessary
     AST rlet = new AST(XQ.LetBind);
     rlet.addChild(letVarBinding);
     rlet.addChild(letReturn);
     QNm letVar = (QNm) letVarBinding.getChild(0).getValue();
-    AST groupBy = createGroupBy(letVar, let);
+    AST groupBy = createGroupBy(letVar, groupVar, let);
     rlet.addChild(groupBy);
 
     post.addChild(rlet);
@@ -99,13 +120,27 @@ public class LetBindToLeftJoin extends AggFunChecker {
     AST ljoin = createJoin(leftIn, rightIn, post, let.getLastChild().copyTree());
 
     // we must not sort if result is directly aggregated
-    boolean skipSort = (groupBy.getChild(1).getChild(0).getType() != XQ.SequenceAgg);
+    // (child 0 is the grouping spec, child 1 the let-var aggregate spec)
+    boolean skipSort = (groupBy.getChild(1).getChild(1).getChild(0).getType() != XQ.SequenceAgg);
     if (skipSort) {
       ljoin.setProperty("skipSort", Boolean.TRUE);
     }
 
+    // number the outer tuples just upstream of the join so the grouping key
+    // is available (and survives left-join padding) in the post-join group-by.
+    // The counter is intentionally kept free of iteration "check" markers
+    // (see groupCount property): it must assign a distinct number to *every*
+    // tuple it sees - including the padded tuple of an empty nested iteration -
+    // so that those tuples are never folded together by a downstream group-by.
+    AST count = new AST(XQ.Count);
+    count.setProperty("groupCount", Boolean.TRUE);
+    AST countBinding = new AST(TypedVariableBinding);
+    countBinding.addChild(new AST(Variable, groupVar));
+    count.addChild(countBinding);
+    count.addChild(ljoin);
+
     int replaceAt = insertJoinAfter.getChildCount() - 1;
-    insertJoinAfter.replaceChild(replaceAt, ljoin);
+    insertJoinAfter.replaceChild(replaceAt, count);
     snapshot();
     refreshScopes(insertJoinAfter, true);
     return insertJoinAfter;
@@ -123,7 +158,7 @@ public class LetBindToLeftJoin extends AggFunChecker {
     return ljoin;
   }
 
-  private AST createGroupBy(QNm letVar, AST letBind) {
+  private AST createGroupBy(QNm letVar, QNm groupVar, AST letBind) {
     int aggType = XQ.SequenceAgg;
 
     Var var = findScope(letBind).localBindings().get(0);
@@ -151,6 +186,12 @@ public class LetBindToLeftJoin extends AggFunChecker {
 
     AST groupBy = new AST(XQ.GroupBy);
     groupBy.setProperty("sequential", Boolean.TRUE);
+
+    // group by the per-outer-iteration key so the binding is aggregated
+    // once per outer tuple instead of collapsing all outer tuples into one
+    AST grpSpec = new AST(XQ.GroupBySpec);
+    grpSpec.addChild(new AST(XQ.VariableRef, groupVar));
+    groupBy.addChild(grpSpec);
 
     AST aggSpec = new AST(XQ.AggregateSpec);
     aggSpec.addChild(new AST(XQ.VariableRef, letVar));

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/PullEvaluation.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/PullEvaluation.java
@@ -87,15 +87,21 @@ public class PullEvaluation extends Walker {
     List<QNm> check2 = appendCheck(check, postJoinVar);
 
     // add check markers to the left input
+    // (per-outer grouping counters must stay free of check markers so that they
+    // keep numbering - and thereby separating - padded tuples of empty iterations)
     AST tmp = left;
     while (tmp.getType() != XQ.End) {
-      tmp.setProperty("check", check2);
+      if (!tmp.checkProperty("groupCount")) {
+        tmp.setProperty("check", check2);
+      }
       tmp = tmp.getLastChild();
     }
 
     tmp = post;
     while (tmp.getType() != XQ.End) {
-      tmp.setProperty("check", check2);
+      if (!tmp.checkProperty("groupCount")) {
+        tmp.setProperty("check", check2);
+      }
       tmp = tmp.getLastChild();
     }
     join.setProperty("check", check2);

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/TrivialLeftJoinRemoval.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/TrivialLeftJoinRemoval.java
@@ -101,7 +101,11 @@ public final class TrivialLeftJoinRemoval extends Walker {
       if (tmp.getType() == XQ.Join) {
         tmp.setProperty("leftJoin", Boolean.TRUE);
       }
-      tmp.setProperty("check", check);
+      // per-outer grouping counters must stay free of check markers so they
+      // keep numbering (and thereby separating) padded tuples of empty iterations
+      if (!tmp.checkProperty("groupCount")) {
+        tmp.setProperty("check", check);
+      }
       parent.addChild(tmp);
       parent = tmp;
       node = node.getLastChild();

--- a/src/main/java/io/brackit/query/expr/ArrayExpr.java
+++ b/src/main/java/io/brackit/query/expr/ArrayExpr.java
@@ -67,9 +67,15 @@ public final class ArrayExpr implements Expr {
         continue;
       }
 
-      if (!(res instanceof SequenceExpr.EvalSequence) && !flatten[i] || res instanceof Item) {
+      if (!flatten[i] && res instanceof Item) {
+        // A single item (atomic, object, or nested array) is one member as-is.
         vals.add(res);
       } else {
+        // Any multi-item sequence -- a (a,b,c) constructor, a FLWOR or function-call
+        // result, or an explicitly flattened =(...) field -- expands to one member per
+        // item. Array members are single items by invariant (member access and []
+        // unboxing call evaluateToItem on each), so a sequence is never stored as a
+        // single member; dispatch on cardinality, not on the concrete sequence class.
         try (final Iter it = res.iterate()) {
           Item item;
           while ((item = it.next()) != null) {

--- a/src/main/java/io/brackit/query/operator/SpillableGroupBy.java
+++ b/src/main/java/io/brackit/query/operator/SpillableGroupBy.java
@@ -34,11 +34,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import io.brackit.query.ErrorCode;
@@ -53,23 +51,37 @@ import io.brackit.query.util.aggregator.Grouping;
 import io.brackit.query.util.sort.TupleSerializer;
 
 /**
- * Hash-based GroupBy operator that spills partitions to disk when the in-memory
- * hash table exceeds a configurable memory budget.
+ * Hash-based GroupBy operator that bounds its memory footprint by spilling raw
+ * tuples to disk when the in-memory hash table exceeds a configurable budget.
  * <p>
- * Strategy (inspired by DuckDB's approach):
+ * Strategy (a radix hash-aggregation spill, in the spirit of DuckDB / PostgreSQL
+ * {@code HashAgg}):
  * <ol>
- * <li>Build hash table in memory, tracking estimated size via {@link TupleSerializer#estimateSize}</li>
- * <li>When budget exceeded, partition tuples by hash prefix into N partition files on disk</li>
- * <li>After input exhausted, process each spilled partition file one at a time:
- * load partition into memory, aggregate, emit results</li>
- * <li>If a single partition still doesn't fit, recursively repartition with different hash bits</li>
+ * <li>Aggregate into an in-memory hash table, tracking its estimated size via
+ * {@link TupleSerializer#estimateSize}.</li>
+ * <li>A tuple whose group is <em>already</em> in the table is always folded in —
+ * that costs no new memory. Once the table reaches the budget, a tuple carrying a
+ * <em>new</em> group is instead appended, raw, to one of {@value #NUM_PARTITIONS}
+ * partition files chosen by a hash of its grouping key. A given group therefore
+ * lives entirely in memory or entirely in a single partition, never split.</li>
+ * <li>After the input is drained, the complete in-memory groups are emitted, then
+ * each non-empty partition is re-aggregated, one at a time, by the same routine.</li>
+ * <li>If a single partition still does not fit, its re-aggregation spills again to
+ * child partitions under a depth-rotated hash, so the bits that select the partition
+ * differ at each level. Recursion is depth-first and is capped at
+ * {@value #MAX_SPILL_DEPTH} levels (a termination guard against pathological
+ * hash-code collisions); beyond the cap a partition is aggregated in memory.</li>
  * </ol>
+ * If nothing ever exceeds the budget, no file is created and the operator behaves
+ * exactly like an in-memory hash group-by.
  */
 public class SpillableGroupBy extends Check implements Operator {
 
-  private static final long DEFAULT_MEMORY_BUDGET = Cfg.asLong("io.brackit.query.groupby.memory_budget",
-                                                               Runtime.getRuntime().maxMemory() / 4);
+  /** System property overriding the per-operator memory budget (bytes). */
+  private static final String MEMORY_BUDGET_CFG = "io.brackit.query.groupby.memory_budget";
   private static final int NUM_PARTITIONS = 64;
+  /** Recursion-depth guard; only reachable under adversarial hash-code collisions. */
+  private static final int MAX_SPILL_DEPTH = 16;
 
   final Operator in;
   final int[] groupSpecs;
@@ -79,7 +91,12 @@ public class SpillableGroupBy extends Check implements Operator {
   final long memoryBudget;
 
   public SpillableGroupBy(Operator in, Aggregate dftAgg, Aggregate[] addAggs, int grpSpecCnt, boolean sequential) {
-    this(in, dftAgg, addAggs, grpSpecCnt, sequential, DEFAULT_MEMORY_BUDGET);
+    this(in,
+         dftAgg,
+         addAggs,
+         grpSpecCnt,
+         sequential,
+         Cfg.asLong(MEMORY_BUDGET_CFG, Runtime.getRuntime().maxMemory() / 4));
   }
 
   public SpillableGroupBy(Operator in, Aggregate dftAgg, Aggregate[] addAggs, int grpSpecCnt, boolean sequential,
@@ -119,26 +136,50 @@ public class SpillableGroupBy extends Check implements Operator {
     return in.tupleWidth(initSize) + addAggs.length;
   }
 
+  /** Select a partition for {@code keyHash}; the bit window varies with {@code depth}. */
+  private static int partitionFor(int keyHash, int depth) {
+    int rotated = Integer.rotateLeft(keyHash, (depth & 31) * 5);
+    return (rotated & 0x7FFFFFFF) % NUM_PARTITIONS;
+  }
+
+  /** A spilled partition file awaiting re-aggregation, tagged with its spill depth. */
+  private record Partition(File file, int depth) {
+  }
+
   private class SpillableHashGroupByCursor implements Cursor {
     final Cursor c;
     final int tupleSize;
 
-    // In-memory hash table
+    /** In-memory hash table for the aggregation pass currently in progress. */
     final Map<GroupKey, Grouping> map = new LinkedHashMap<>();
+    /** Estimated bytes occupied by the distinct groups currently in {@link #map}. */
     long currentSize;
 
-    // Spill state — partition files are opened eagerly and written to in parallel
-    // with in-memory aggregation (dual-write). When memory budget is exceeded,
-    // the in-memory map is cleared; the partition files already have all raw tuples.
-    boolean spilled;
-    boolean partitionsInitialized;
-    File[] partitionFiles;
-    OutputStream[] partitionStreams;
-    int nextPartitionToProcess;
-
-    // Output iteration
-    Iterator<GroupKey> outputIt;
+    /**
+     * Lookahead tuple held across calls. When an iteration-scope boundary
+     * ({@code check && separate}) ends a segment, the tuple that crossed the boundary
+     * is the first tuple of the next segment and is parked here until then.
+     */
     Tuple next;
+
+    /**
+     * Overflow partition files for the pass in progress. A new group that would push
+     * the table past the budget has its raw tuples appended here, keyed by a
+     * depth-rotated hash of its grouping key, and re-aggregated in a later pass.
+     * Created lazily, so a query that never overflows touches the disk not at all.
+     */
+    File[] spillFiles;
+    OutputStream[] spillStreams;
+    int spillChildDepth;
+
+    /** Partition files awaiting a (re-)aggregation pass, processed depth-first. */
+    final ArrayDeque<Partition> pending = new ArrayDeque<>();
+
+    /** Emission iterator over the groups of the pass currently being drained. */
+    Iterator<GroupKey> outputIt;
+
+    /** Reused, single-threaded lookup probe — keeps the per-tuple path allocation-free. */
+    final GroupKey probe = new GroupKey();
 
     SpillableHashGroupByCursor(Cursor c, int tupleSize) {
       this.c = c;
@@ -152,16 +193,14 @@ public class SpillableGroupBy extends Check implements Operator {
 
     @Override
     public void close(QueryContext ctx) {
-      map.clear();
-      currentSize = 0;
-      cleanupPartitions();
+      cleanup();
       c.close(ctx);
     }
 
     @Override
     public Tuple next(QueryContext ctx) throws QueryException {
       while (true) {
-        // Phase 1: Output from in-memory aggregation or current partition
+        // (1) Drain the groups of the pass currently held in memory.
         if (outputIt != null) {
           if (outputIt.hasNext()) {
             GroupKey key = outputIt.next();
@@ -176,194 +215,204 @@ public class SpillableGroupBy extends Check implements Operator {
           currentSize = 0;
         }
 
-        // Phase 2: If we have spilled partitions, process the next one
-        if (spilled && partitionFiles != null) {
-          return processNextPartition();
+        // (2) Re-aggregate the next spilled partition of the current segment (deepest first).
+        Partition p = pending.pollLast();
+        if (p != null) {
+          aggregatePartition(p);
+          finishPass();
+          outputIt = map.keySet().iterator();
+          continue;
         }
 
-        // Phase 3: Read input, respecting check/dead/separate semantics
-        Tuple t;
-        if ((t = next) != null || (t = c.next(ctx)) != null) {
-          // Dead tuple pass-through (matches GroupBy.HashGroupBy behavior)
-          if (check && dead(t)) {
-            if (map.isEmpty()) {
-              next = null;
-              Grouping grp = new Grouping(groupSpecs, addAggSpecs, defaultAgg, addAggs, tupleSize);
-              grp.add(t);
-              return grp.emit();
-            } else {
-              // Output accumulated groups first, keep this tuple for next call
-              outputIt = map.keySet().iterator();
-              continue;
-            }
-          }
-
-          addOrSpill(t);
-
-          // Read remaining tuples for this group segment
-          while ((next = c.next(ctx)) != null) {
-            if (check && separate(t, next)) {
-              break;
-            }
-            addOrSpill(next);
-          }
-
-          if (spilled) {
-            // Spilled during input — re-aggregate from partition files
-            map.clear();
-            currentSize = 0;
-            return processNextPartition();
-          }
-
-          // Everything fit in memory — output directly (skip partition processing)
-          // Clean up partition files (they have duplicate data from dual-write)
-          cleanupPartitions();
-          outputIt = map.keySet().iterator();
-        } else {
+        // (3) The current segment is fully emitted; load the next one. This honours the
+        // iteration-nesting demarcation of the legacy GroupBy (which SpillableGroupBy
+        // replaces): under an enclosing iteration (check), a "dead" left-join-padded tuple
+        // forms its own singleton group, and a segment ends at the first tuple that is
+        // "separate" from the segment's start. The previous segment is fully drained at
+        // this point (table empty, no pending partitions), so a dead tuple emits directly
+        // and a fresh segment starts with clean spill state.
+        Tuple t = next;
+        next = null;
+        if (t == null) {
+          t = c.next(ctx);
+        }
+        if (t == null) {
           return null;
         }
+        if (check && dead(t)) {
+          Grouping grp = new Grouping(groupSpecs, addAggSpecs, defaultAgg, addAggs, tupleSize);
+          grp.add(t);
+          return grp.emit();
+        }
+
+        admitOrSpill(t, 0);
+        while ((next = c.next(ctx)) != null) {
+          if (check && separate(t, next)) {
+            break;
+          }
+          admitOrSpill(next, 0);
+        }
+        finishPass();
+        outputIt = map.keySet().iterator();
       }
     }
 
     /**
-     * Add a tuple to the in-memory aggregation map. No spill — the GroupBy
-     * memory footprint is proportional to the number of distinct groups, not
-     * the total input size. For typical queries (group by city, category, etc.),
-     * the group count is small and fits easily in memory.
+     * Aggregate {@code t} into the in-memory table if its group is already present
+     * or the table is still within budget; otherwise append its raw tuple to the
+     * overflow partition for its key, to be re-aggregated in a later pass.
+     *
+     * @param depth recursion depth of the current pass (0 for the upstream input)
      */
-    private void addOrSpill(Tuple t) throws QueryException {
+    private void admitOrSpill(Tuple t, int depth) throws QueryException {
       Atomic[] gks = Grouping.groupingKeys(groupSpecs, t);
-      GroupKey key = new GroupKey(gks);
-      Grouping grp = map.get(key);
-      if (grp == null) {
+      probe.reset(gks); // computes the key hash once; reused for lookup and partitioning
+      Grouping grp = map.get(probe);
+      if (grp != null) {
+        grp.add(gks, t); // existing group — folds in with no new memory, no allocation
+        return;
+      }
+      // Always admit at least one new group per pass (guarantees forward progress);
+      // admit more while under budget; force in-memory once the rotation is exhausted.
+      long est = TupleSerializer.estimateSize(t);
+      if (map.isEmpty() || currentSize + est <= memoryBudget || depth >= MAX_SPILL_DEPTH) {
         grp = new Grouping(groupSpecs, addAggSpecs, defaultAgg, addAggs, tupleSize);
         grp.setThreadSafe(false);
-        map.put(key, grp);
+        map.put(new GroupKey(gks, probe.hash), grp); // immutable key only on insert
+        grp.add(gks, t);
+        currentSize += est;
+      } else {
+        spill(t, probe.hash, depth + 1);
       }
-      grp.add(gks, t);
     }
 
-    private void writeToPartition(Tuple t) throws QueryException {
+    private void spill(Tuple t, int keyHash, int childDepth) throws QueryException {
       try {
-        Atomic[] gks = Grouping.groupingKeys(groupSpecs, t);
-        int hash = new GroupKey(gks).hash;
-        int partition = (hash & 0x7FFFFFFF) % NUM_PARTITIONS;
-        TupleSerializer.write(partitionStreams[partition], t);
+        if (spillFiles == null) {
+          spillFiles = new File[NUM_PARTITIONS];
+          spillStreams = new OutputStream[NUM_PARTITIONS];
+          spillChildDepth = childDepth;
+        }
+        int part = partitionFor(keyHash, childDepth);
+        if (spillStreams[part] == null) {
+          File f = File.createTempFile("grp-spill-d" + childDepth + "-p" + part + "-", ".tmp");
+          f.deleteOnExit();
+          spillFiles[part] = f;
+          spillStreams[part] = new BufferedOutputStream(new FileOutputStream(f));
+        }
+        TupleSerializer.write(spillStreams[part], t);
       } catch (IOException e) {
-        cleanupPartitions();
+        cleanup();
         throw new QueryException(e, ErrorCode.BIT_DYN_INT_ERROR);
       }
     }
 
-    private void initPartitionFiles() throws IOException {
-      if (partitionFiles == null) {
-        partitionFiles = new File[NUM_PARTITIONS];
-        partitionStreams = new OutputStream[NUM_PARTITIONS];
-        for (int i = 0; i < NUM_PARTITIONS; i++) {
-          partitionFiles[i] = File.createTempFile("grp-part-" + i + "-", ".spill");
-          partitionFiles[i].deleteOnExit();
-          partitionStreams[i] = new BufferedOutputStream(new FileOutputStream(partitionFiles[i], true));
-        }
-      }
-    }
-
-    /**
-     * Process the next unprocessed spilled partition: read tuples from disk,
-     * re-aggregate in memory, and set up output iterator.
-     */
-    private Tuple processNextPartition() throws QueryException {
-      try {
-        // Close partition streams if still open
-        closePartitionStreams();
-
-        while (nextPartitionToProcess < NUM_PARTITIONS) {
-          File partFile = partitionFiles[nextPartitionToProcess++];
-          if (partFile == null || !partFile.exists() || partFile.length() == 0) {
-            continue;
-          }
-
-          // Read partition and re-aggregate
-          map.clear();
-          currentSize = 0;
-
-          try (var in = new BufferedInputStream(new FileInputStream(partFile))) {
-            Tuple t;
-            while ((t = TupleSerializer.read(in)) != null) {
-              // Re-aggregate raw tuples from partition file
-              Atomic[] gks = Grouping.groupingKeys(groupSpecs, t);
-              GroupKey key = new GroupKey(gks);
-              Grouping grp = map.get(key);
-              if (grp == null) {
-                grp = new Grouping(groupSpecs, addAggSpecs, defaultAgg, addAggs, tupleSize);
-                grp.setThreadSafe(false);
-                map.put(key, grp);
-              }
-              grp.add(gks, t);
-            }
-          }
-          partFile.delete();
-
-          if (!map.isEmpty()) {
-            outputIt = map.keySet().iterator();
-            if (outputIt.hasNext()) {
-              GroupKey key = outputIt.next();
-              Grouping grp = map.get(key);
-              outputIt.remove();
-              Tuple result = grp.emit();
-              grp.clear();
-              return result;
-            }
-          }
+    /** Read a spilled partition back and re-aggregate it into the in-memory table. */
+    private void aggregatePartition(Partition p) throws QueryException {
+      try (var in = new BufferedInputStream(new FileInputStream(p.file()))) {
+        Tuple t;
+        while ((t = TupleSerializer.read(in)) != null) {
+          admitOrSpill(t, p.depth());
         }
       } catch (IOException e) {
-        cleanupPartitions();
+        cleanup();
         throw new QueryException(e, ErrorCode.BIT_DYN_INT_ERROR);
+      } finally {
+        p.file().delete();
       }
-
-      return null;
     }
 
-    private void closePartitionStreams() {
-      if (partitionStreams != null) {
-        for (int i = 0; i < partitionStreams.length; i++) {
-          if (partitionStreams[i] != null) {
-            try {
-              partitionStreams[i].close();
-            } catch (IOException ignored) {
-            }
-            partitionStreams[i] = null;
+    /** Close the pass's spill streams and queue its non-empty partitions for re-aggregation. */
+    private void finishPass() {
+      if (spillStreams == null) {
+        return;
+      }
+      for (int i = 0; i < NUM_PARTITIONS; i++) {
+        if (spillStreams[i] != null) {
+          try {
+            spillStreams[i].close();
+          } catch (IOException ignored) {
           }
         }
-      }
-    }
-
-    private void cleanupPartitions() {
-      closePartitionStreams();
-      if (partitionFiles != null) {
-        for (File f : partitionFiles) {
-          if (f != null && f.exists()) {
+        File f = spillFiles[i];
+        if (f != null) {
+          if (f.length() > 0) {
+            pending.addLast(new Partition(f, spillChildDepth));
+          } else {
             f.delete();
           }
         }
-        partitionFiles = null;
       }
+      spillFiles = null;
+      spillStreams = null;
+      spillChildDepth = 0;
+    }
+
+    private void cleanup() {
+      map.clear();
+      currentSize = 0;
+      if (spillStreams != null) {
+        for (OutputStream s : spillStreams) {
+          if (s != null) {
+            try {
+              s.close();
+            } catch (IOException ignored) {
+            }
+          }
+        }
+        spillStreams = null;
+      }
+      if (spillFiles != null) {
+        for (File f : spillFiles) {
+          if (f != null) {
+            f.delete();
+          }
+        }
+        spillFiles = null;
+      }
+      for (Partition p : pending) {
+        p.file().delete();
+      }
+      pending.clear();
     }
   }
 
   /**
-   * Grouping key wrapper for hash map lookup.
+   * Grouping-key wrapper for hash-table lookup. Stored keys are immutable; a single
+   * mutable instance per cursor is reused as a lookup probe (via {@link #reset}) so the
+   * per-tuple aggregation path allocates no key for the common existing-group hit.
+   * {@code final} lets the JIT devirtualise {@link #hashCode}/{@link #equals}.
    */
-  private static class GroupKey {
-    final int hash;
-    final Atomic[] val;
+  private static final class GroupKey {
+    int hash;
+    Atomic[] val;
 
+    /** Immutable stored key. */
     GroupKey(Atomic[] val) {
+      this(val, computeHash(val));
+    }
+
+    /** Immutable stored key reusing an already-computed hash (avoids a second pass). */
+    GroupKey(Atomic[] val, int hash) {
       this.val = val;
+      this.hash = hash;
+    }
+
+    /** Reusable lookup probe; call {@link #reset} before each {@code map.get}. */
+    GroupKey() {
+    }
+
+    void reset(Atomic[] val) {
+      this.val = val;
+      this.hash = computeHash(val);
+    }
+
+    private static int computeHash(Atomic[] val) {
       int h = 1;
       for (Atomic a : val) {
         h = 31 * h + (a != null ? a.hashCode() : 0);
       }
-      this.hash = h;
+      return h;
     }
 
     @Override

--- a/src/main/java/io/brackit/query/operator/vectorized/GroupByCountSpill.java
+++ b/src/main/java/io/brackit/query/operator/vectorized/GroupByCountSpill.java
@@ -1,0 +1,160 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.operator.vectorized;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Disk-spill support for the vectorized parallel group-by-count
+ * ({@link ParallelGroupByExec}). When a worker's distinct-key set grows past its
+ * budget, its partial {@code (key -> count)} pairs are radix-partitioned by key hash
+ * into {@value #NUM_PARTITIONS} per-worker files; the same key always lands in the same
+ * partition across all workers. The merge then processes one partition at a time, so the
+ * peak heap is bounded by a single partition's distinct keys rather than the whole
+ * group-by. Counts are mergeable, so spilling partial aggregates and summing them is
+ * exact.
+ */
+final class GroupByCountSpill {
+
+  static final int NUM_PARTITIONS = 64;
+
+  private GroupByCountSpill() {
+  }
+
+  static int partition(String key) {
+    return (key.hashCode() & 0x7FFFFFFF) % NUM_PARTITIONS;
+  }
+
+  /**
+   * A single worker's spill files: one append stream per partition, created lazily so an
+   * unused partition costs nothing.
+   */
+  static final class Writer implements Closeable {
+    private final Path[] files = new Path[NUM_PARTITIONS];
+    private final DataOutputStream[] outs = new DataOutputStream[NUM_PARTITIONS];
+    private boolean used;
+
+    void add(String key, long count) throws IOException {
+      final int p = partition(key);
+      DataOutputStream out = outs[p];
+      if (out == null) {
+        final Path f = Files.createTempFile("vgbc-p" + p + "-", ".spill");
+        files[p] = f;
+        out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(f)));
+        outs[p] = out;
+        used = true;
+      }
+      final byte[] kb = key.getBytes(StandardCharsets.UTF_8);
+      out.writeInt(kb.length);
+      out.write(kb);
+      out.writeLong(count);
+    }
+
+    boolean used() {
+      return used;
+    }
+
+    Path file(int partition) {
+      return files[partition];
+    }
+
+    /** Flush and close the write streams, keeping the files for the merge phase. */
+    void finishWriting() throws IOException {
+      for (int i = 0; i < outs.length; i++) {
+        if (outs[i] != null) {
+          outs[i].close();
+          outs[i] = null;
+        }
+      }
+    }
+
+    @Override
+    public void close() {
+      finishWritingQuietly();
+      for (final Path f : files) {
+        if (f != null) {
+          try {
+            Files.deleteIfExists(f);
+          } catch (IOException ignored) {
+          }
+        }
+      }
+    }
+
+    private void finishWritingQuietly() {
+      try {
+        finishWriting();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  /**
+   * Read every writer's file for {@code partition} and fold the {@code (key -> count)}
+   * pairs into {@code target}, summing duplicates.
+   */
+  static void mergePartition(List<Writer> writers, int partition, Map<String, long[]> target) throws IOException {
+    for (final Writer w : writers) {
+      final Path f = w.file(partition);
+      if (f == null) {
+        continue;
+      }
+      try (DataInputStream in = new DataInputStream(new BufferedInputStream(Files.newInputStream(f)))) {
+        while (true) {
+          final int len;
+          try {
+            len = in.readInt();
+          } catch (EOFException eof) {
+            break;
+          }
+          final byte[] kb = new byte[len];
+          in.readFully(kb);
+          final long count = in.readLong();
+          final String key = new String(kb, StandardCharsets.UTF_8);
+          final long[] cur = target.get(key);
+          if (cur == null) {
+            target.put(key, new long[] { count });
+          } else {
+            cur[0] += count;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
+++ b/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
@@ -58,6 +58,7 @@ import io.brackit.query.compiler.optimizer.VectorizedExecutor;
 import io.brackit.query.jdm.Item;
 import io.brackit.query.jdm.Sequence;
 import io.brackit.query.jsonitem.array.DArray;
+import io.brackit.query.util.Cfg;
 import io.brackit.query.jsonitem.object.CompactObject;
 
 /**
@@ -202,28 +203,80 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
     byte[] patternSpaced = ("\"" + groupField + "\" :").getBytes(StandardCharsets.UTF_8);
 
     long[] chunkStarts = computeChunkStarts(path, nThreads);
+    int spillThreshold = spillThreshold();
 
     ExecutorService executor = Executors.newFixedThreadPool(nThreads);
-    List<Future<HashMap<String, long[]>>> futures = new ArrayList<>(nThreads);
+    List<Future<ChunkResult>> futures = new ArrayList<>(nThreads);
     for (int i = 0; i < nThreads; i++) {
       long start = chunkStarts[i];
       long end = chunkStarts[i + 1];
-      futures.add(executor.submit(() -> processChunk(path, start, end, pattern, patternSpaced)));
+      futures.add(executor.submit(() -> processChunk(path, start, end, pattern, patternSpaced, spillThreshold)));
     }
 
-    HashMap<String, long[]> merged = new HashMap<>();
-    for (Future<HashMap<String, long[]>> future : futures) {
-      HashMap<String, long[]> partial = future.get();
-      for (Map.Entry<String, long[]> entry : partial.entrySet()) {
-        merged.merge(entry.getKey(), entry.getValue(), (a, b) -> {
-          a[0] += b[0];
-          return a;
-        });
+    List<ChunkResult> results = new ArrayList<>(nThreads);
+    boolean anySpilled = false;
+    for (Future<ChunkResult> future : futures) {
+      ChunkResult r = future.get();
+      results.add(r);
+      anySpilled |= r.spilled != null;
+    }
+    executor.shutdown();
+
+    // Fast path: nothing spilled, so every partial fits -- merge them on the heap.
+    if (!anySpilled) {
+      HashMap<String, long[]> merged = new HashMap<>();
+      for (ChunkResult r : results) {
+        for (Map.Entry<String, long[]> entry : r.inMemory.entrySet()) {
+          merged.merge(entry.getKey(), entry.getValue(), (a, b) -> {
+            a[0] += b[0];
+            return a;
+          });
+        }
+      }
+      return buildResult(merged, groupField);
+    }
+
+    // Bounded path: route every worker's data through the per-partition spill files (the
+    // in-memory partials from workers that did not spill are spilled here too), then merge
+    // one partition at a time so the heap holds at most a single partition's distinct keys.
+    List<GroupByCountSpill.Writer> writers = new ArrayList<>(results.size());
+    GroupByCountSpill.Writer inMemorySpill = null;
+    try {
+      for (ChunkResult r : results) {
+        if (r.spilled != null) {
+          writers.add(r.spilled);
+        } else {
+          if (inMemorySpill == null) {
+            inMemorySpill = new GroupByCountSpill.Writer();
+          }
+          for (Map.Entry<String, long[]> entry : r.inMemory.entrySet()) {
+            inMemorySpill.add(entry.getKey(), entry.getValue()[0]);
+          }
+        }
+      }
+      if (inMemorySpill != null) {
+        inMemorySpill.finishWriting();
+        writers.add(inMemorySpill);
+      }
+
+      List<Item> out = new ArrayList<>();
+      QNm fieldQnm = new QNm(groupField);
+      QNm countQnm = new QNm("count");
+      QNm[] fields = { fieldQnm, countQnm };
+      for (int p = 0; p < GroupByCountSpill.NUM_PARTITIONS; p++) {
+        HashMap<String, long[]> partition = new HashMap<>();
+        GroupByCountSpill.mergePartition(writers, p, partition);
+        for (Map.Entry<String, long[]> entry : partition.entrySet()) {
+          Sequence[] values = { new Str(entry.getKey()), new Int64(entry.getValue()[0]) };
+          out.add(new io.brackit.query.jsonitem.object.CompactObject(fields, values));
+        }
+      }
+      return out;
+    } finally {
+      for (GroupByCountSpill.Writer w : writers) {
+        w.close();
       }
     }
-
-    executor.shutdown();
-    return buildResult(merged, groupField);
   }
 
   /**
@@ -305,12 +358,50 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
    */
   private static final int INTERN_CAPACITY = 1024;
   private static final int INTERN_MASK = INTERN_CAPACITY - 1;
+  /** Keep the intern table's load factor &le; 0.75 so probe chains stay short. */
+  private static final int INTERN_LIMIT = (INTERN_CAPACITY * 3) / 4;
+  /** Cap probes per key: the table is fixed-size, so an unbounded probe would spin. */
+  private static final int INTERN_MAX_PROBES = 32;
 
-  private static HashMap<String, long[]> processChunk(Path path, long start, long end, byte[] pattern,
-      byte[] patternSpaced) throws IOException {
-    // Per-thread intern table: raw byte keys → count
+  /**
+   * Per-worker distinct-key budget for the overflow map; once exceeded, the overflow is
+   * spilled to disk so a high-cardinality group-by stays memory-bounded. Default ~2M
+   * distinct keys per worker (well above the low-cardinality workloads this path targets);
+   * read per query so it is settable for tests via
+   * {@code io.brackit.query.groupby.vectorized.spill_threshold}.
+   */
+  private static int spillThreshold() {
+    return (int) Math.max(64, Cfg.asLong("io.brackit.query.groupby.vectorized.spill_threshold", 2_000_000));
+  }
+
+  /** A worker's result: either an in-memory partial map (no spill) or its spill files. */
+  private static final class ChunkResult {
+    final HashMap<String, long[]> inMemory; // non-null iff the worker did not spill
+    final GroupByCountSpill.Writer spilled; // non-null iff the worker spilled
+
+    ChunkResult(HashMap<String, long[]> inMemory) {
+      this.inMemory = inMemory;
+      this.spilled = null;
+    }
+
+    ChunkResult(GroupByCountSpill.Writer spilled) {
+      this.inMemory = null;
+      this.spilled = spilled;
+    }
+  }
+
+  private static ChunkResult processChunk(Path path, long start, long end, byte[] pattern, byte[] patternSpaced,
+      int spillThreshold) throws IOException {
+    // Per-thread intern table: raw byte keys → count, for the hot (low-cardinality) keys.
     byte[][] internKeys = new byte[INTERN_CAPACITY][];
     long[] internCounts = new long[INTERN_CAPACITY];
+    int internSize = 0;
+    // Overflow for keys beyond the intern table's capacity. Lazily created, so a
+    // low-cardinality group-by (the case this path targets) never allocates it.
+    HashMap<String, long[]> overflow = null;
+    // Disk spill for the high-cardinality tail. Lazily created on first spill, so the
+    // common in-memory case never touches the filesystem.
+    GroupByCountSpill.Writer spillWriter = null;
 
     byte[] window = new byte[WINDOW_SIZE];
     long pos = 0;
@@ -417,25 +508,57 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
           }
 
           if (valueStart >= 0 && valueEnd > valueStart) {
-            // Aggregate using byte-key intern table — no String allocation
+            // Aggregate via the byte-key intern table (no String allocation) for the
+            // hot keys; spill the high-cardinality tail to the overflow map. Probing is
+            // bounded so a full fixed-size table can never spin forever, and intern and
+            // overflow are merged at the end, so a key that lands in both (a bounded-probe
+            // miss on an already-interned key) is still counted exactly once.
             int keyLen = valueEnd - valueStart;
             int hash = longHash(window, valueStart, keyLen);
             int idx = hash & INTERN_MASK;
 
-            while (true) {
+            boolean interned = false;
+            for (int probe = 0; probe < INTERN_MAX_PROBES; probe++) {
               byte[] existing = internKeys[idx];
               if (existing == null) {
-                byte[] keyCopy = new byte[keyLen];
-                System.arraycopy(window, valueStart, keyCopy, 0, keyLen);
-                internKeys[idx] = keyCopy;
-                internCounts[idx] = 1;
-                break;
+                if (internSize < INTERN_LIMIT) {
+                  byte[] keyCopy = new byte[keyLen];
+                  System.arraycopy(window, valueStart, keyCopy, 0, keyLen);
+                  internKeys[idx] = keyCopy;
+                  internCounts[idx] = 1;
+                  internSize++;
+                  interned = true;
+                }
+                break; // empty slot: inserted, or the table is at its load limit
               }
               if (existing.length == keyLen && bytesEqual(existing, 0, window, valueStart, keyLen)) {
                 internCounts[idx]++;
+                interned = true;
                 break;
               }
               idx = (idx + 31) & INTERN_MASK; // stride-31 probing (1BRC technique)
+            }
+            if (!interned) {
+              if (overflow == null) {
+                overflow = new HashMap<>();
+              }
+              overflow.merge(new String(window, valueStart, keyLen, StandardCharsets.UTF_8),
+                             new long[] { 1 },
+                             (a, b) -> {
+                               a[0] += b[0];
+                               return a;
+                             });
+              // Once the overflow map outgrows its budget, spill it to disk and start
+              // fresh so the heap footprint stays bounded under high cardinality.
+              if (overflow.size() >= spillThreshold) {
+                if (spillWriter == null) {
+                  spillWriter = new GroupByCountSpill.Writer();
+                }
+                for (Map.Entry<String, long[]> e : overflow.entrySet()) {
+                  spillWriter.add(e.getKey(), e.getValue()[0]);
+                }
+                overflow.clear();
+              }
             }
           }
         }
@@ -446,14 +569,35 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
       }
     } // close try-with-resources
 
-    // Convert byte-key intern table to HashMap<String> for merging
-    HashMap<String, long[]> result = new HashMap<>();
+    if (spillWriter != null) {
+      // This worker spilled: flush the remaining overflow and the intern table to the
+      // spill files, so all of its partial counts live on disk for the partition merge.
+      if (overflow != null) {
+        for (Map.Entry<String, long[]> e : overflow.entrySet()) {
+          spillWriter.add(e.getKey(), e.getValue()[0]);
+        }
+      }
+      for (int i = 0; i < INTERN_CAPACITY; i++) {
+        if (internKeys[i] != null) {
+          spillWriter.add(new String(internKeys[i], StandardCharsets.UTF_8), internCounts[i]);
+        }
+      }
+      spillWriter.finishWriting();
+      return new ChunkResult(spillWriter);
+    }
+
+    // No spill: fold the byte-key intern table into the (possibly populated) overflow map.
+    // Using merge, not put, keeps counts exact when a key appears in both tables.
+    HashMap<String, long[]> result = (overflow != null) ? overflow : new HashMap<>();
     for (int i = 0; i < INTERN_CAPACITY; i++) {
       if (internKeys[i] != null) {
-        result.put(new String(internKeys[i], StandardCharsets.UTF_8), new long[] { internCounts[i] });
+        result.merge(new String(internKeys[i], StandardCharsets.UTF_8), new long[] { internCounts[i] }, (a, b) -> {
+          a[0] += b[0];
+          return a;
+        });
       }
     }
-    return result;
+    return new ChunkResult(result);
   }
 
   /**

--- a/src/test/java/io/brackit/query/ArrayConstructorFlattenTest.java
+++ b/src/test/java/io/brackit/query/ArrayConstructorFlattenTest.java
@@ -1,0 +1,88 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the JSONiq array constructor {@code [ Expr ]}. A multi-item
+ * operand must expand to one array member per item, whatever sequence kind produced
+ * it. Previously only the {@code (a,b,c)} comma constructor was flattened, so an
+ * array built from a FLWOR ({@code [ for $i in ... return ... ]}) stored the whole
+ * sequence as a single member and every subsequent access ({@code []} unboxing,
+ * indexing, {@code count}) failed with {@code XPTY0004}.
+ */
+public final class ArrayConstructorFlattenTest extends XQueryBaseTest {
+
+  private String query(String q) throws Exception {
+    try (var out = new ByteArrayOutputStream()) {
+      new Query(q).serialize(ctx, new PrintStream(out));
+      return out.toString(StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  public void flworOperandFlattensToMembers() throws Exception {
+    assertEquals("[1,2,3]", query("[ for $i in 1 to 3 return $i ]"));
+    assertEquals("1 2 3", query("[ for $i in 1 to 3 return $i ][]"));
+    assertEquals("3", query("count([ for $i in 1 to 3 return $i ][])"));
+    assertEquals("[{\"v\":1},{\"v\":2},{\"v\":3}]", query("[ for $i in 1 to 3 return { \"v\": $i } ]"));
+  }
+
+  @Test
+  public void commaSequenceStillFlattens() throws Exception {
+    assertEquals("[1,2,3]", query("[ (1, 2, 3) ]"));
+    assertEquals("[1,2,3,4]", query("[ 1, (2, 3), 4 ]"));
+  }
+
+  @Test
+  public void singleItemsAndNestedArraysStayOneMember() throws Exception {
+    assertEquals("[{\"a\":1}]", query("[ { \"a\": 1 } ]"));
+    assertEquals("[[1,2,3]]", query("[ [1, 2, 3] ]")); // nested array is one item, one member
+    assertEquals("[1,2,3]", query("[1, 2, 3]"));
+  }
+
+  @Test
+  public void postGroupProjectionOverFlworArray() throws Exception {
+    // The shape the bug originally surfaced through: group-by + sum of a projected
+    // field, over an array built by a FLWOR.
+    final String q = """
+        let $data := [ for $i in 1 to 4 return { "d": $i mod 2, "v": $i } ]
+        return string-join(
+          for $u in $data[] let $g := $u.d group by $g order by $g
+          return $g || ":" || sum($u.v), ",")
+        """;
+    assertEquals("0:6,1:4", query(q)); // g=0: v 2+4=6; g=1: v 1+3=4
+  }
+}

--- a/src/test/java/io/brackit/query/SpillableGroupBySpillTest.java
+++ b/src/test/java/io/brackit/query/SpillableGroupBySpillTest.java
@@ -1,0 +1,134 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.brackit.query.compiler.translator.SequentialPipelineStrategy;
+
+/**
+ * Verifies that {@link io.brackit.query.operator.SpillableGroupBy} produces results
+ * identical to the in-memory hash group-by once its disk-spill path is actually
+ * engaged. Spilling is forced by shrinking the per-operator memory budget (read at
+ * operator construction from {@code io.brackit.query.groupby.memory_budget}) to one
+ * byte, so every group beyond the first overflows to a partition file and the
+ * recursive repartitioning is exercised end to end.
+ */
+public final class SpillableGroupBySpillTest extends XQueryBaseTest {
+
+  private static final String BUDGET = "io.brackit.query.groupby.memory_budget";
+
+  /** A group-by over 2000 rows / 64 groups, ordered by key for a deterministic result. */
+  private static final String GROUP_QUERY = """
+      string-join(
+        for $x in 1 to 2000
+        let $g := $x mod 64
+        group by $g
+        order by $g
+        return $g || ":" || count($x) || ":" || sum($x),
+        ", ")
+      """;
+
+  @BeforeEach
+  public void disableVectorizedExecutor() {
+    // Force the sequential SpillableGroupBy path: with no executor registered the
+    // compiler cannot rewrite the group-by to a vectorized operator, so the spill
+    // logic under test is actually exercised. (The static is process-wide.)
+    SequentialPipelineStrategy.clearThreadVectorizedExecutor();
+    SequentialPipelineStrategy.setVectorizedExecutor(null);
+  }
+
+  private String run(String query) throws Exception {
+    try (var out = new ByteArrayOutputStream()) {
+      new Query(query).serialize(ctx, new PrintStream(out));
+      return out.toString(StandardCharsets.UTF_8);
+    }
+  }
+
+  private String withBudget(long bytes, String query) throws Exception {
+    final String prev = System.getProperty(BUDGET);
+    System.setProperty(BUDGET, Long.toString(bytes));
+    try {
+      return run(query);
+    } finally {
+      if (prev == null) {
+        System.clearProperty(BUDGET);
+      } else {
+        System.setProperty(BUDGET, prev);
+      }
+    }
+  }
+
+  @Test
+  public void spilledResultMatchesInMemory() throws Exception {
+    final String inMemory = withBudget(Long.MAX_VALUE, GROUP_QUERY);
+    final String spilled = withBudget(1L, GROUP_QUERY);
+    // Byte-identical: every group lands in the right bucket with the right aggregate,
+    // and nothing is lost, duplicated, or mis-merged across the spill/merge boundary.
+    assertEquals(inMemory, spilled);
+    // 64 distinct groups survive the spill.
+    assertEquals(64, spilled.split(", ").length);
+  }
+
+  @Test
+  public void spilledAggregatesPreserveTotals() throws Exception {
+    // Total row count is conserved across the partitioned merge (sum of group sizes).
+    final String rows = "sum(for $x in 1 to 2000 let $g := $x mod 64 group by $g return count($x))";
+    assertEquals("2000", withBudget(1L, rows));
+    // Global value sum is conserved (1 + 2 + ... + 2000 = 2001000).
+    final String total = "sum(for $x in 1 to 2000 let $g := $x mod 64 group by $g return sum($x))";
+    assertEquals("2001000", withBudget(1L, total));
+  }
+
+  @Test
+  public void allTuplesShareOneGroup() throws Exception {
+    // A single hot key must aggregate in place under a 1-byte budget without
+    // spill-looping (an existing group always folds in, never overflows).
+    // sum(1..5000) = 12502500.
+    final String query = """
+        for $x in 1 to 5000
+        let $g := 7
+        group by $g
+        return $g || ":" || count($x) || ":" || sum($x)
+        """;
+    assertEquals("7:5000:12502500", withBudget(1L, query));
+  }
+
+  @Test
+  public void emptyInputProducesNoGroups() throws Exception {
+    final String query = "count(for $x in () let $g := $x mod 64 group by $g return $g)";
+    assertEquals("0", withBudget(1L, query));
+  }
+}

--- a/src/test/java/io/brackit/query/operator/vectorized/ParallelGroupByHighCardinalityTest.java
+++ b/src/test/java/io/brackit/query/operator/vectorized/ParallelGroupByHighCardinalityTest.java
@@ -1,0 +1,131 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.operator.vectorized;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.brackit.query.atomic.Int64;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Item;
+
+/**
+ * Regression tests for the vectorized parallel group-by-count on high-cardinality input.
+ * <p>
+ * The per-thread intern table is a fixed-size open-addressing table with a stride-31
+ * probe; a chunk holding more distinct keys than the table can hold used to spin forever
+ * (the probe is coprime to the capacity, so a full table never yields an empty slot). The
+ * table now caps its load and spills the tail to an overflow map, which itself spills to
+ * radix-partitioned files once it outgrows its budget. So a group-by with thousands of
+ * distinct keys terminates with exact counts, memory-bounded, instead of hanging.
+ */
+public final class ParallelGroupByHighCardinalityTest {
+
+  private static final String SPILL_THRESHOLD = "io.brackit.query.groupby.vectorized.spill_threshold";
+
+  /** Build {@code [{"city":"cNNNN","n":1}, ...]} with {@code distinct} keys round-robined over rounds. */
+  private static Path writeRoundRobin(int distinct, int rounds) throws Exception {
+    final StringBuilder sb = new StringBuilder(distinct * rounds * 24);
+    sb.append('[');
+    boolean first = true;
+    for (int r = 0; r < rounds; r++) {
+      for (int k = 0; k < distinct; k++) {
+        if (!first) {
+          sb.append(',');
+        }
+        first = false;
+        sb.append("{\"city\":\"c").append(String.format("%04d", k)).append("\",\"n\":1}");
+      }
+    }
+    sb.append(']');
+    final Path file = Files.createTempFile("vec-highcard-", ".json");
+    Files.write(file, sb.toString().getBytes(StandardCharsets.UTF_8));
+    return file;
+  }
+
+  private static void assertExactCounts(List<Item> result, int distinct, int rounds) {
+    assertEquals(distinct, result.size(), "every distinct key must survive aggregation");
+    final QNm countField = new QNm("count");
+    long total = 0;
+    for (Item item : result) {
+      final long count = ((Int64) ((io.brackit.query.jdm.json.Object) item).get(countField)).longValue();
+      assertEquals(rounds, count, "per-group count must be exact");
+      total += count;
+    }
+    assertEquals((long) distinct * rounds, total, "no rows lost or double-counted");
+  }
+
+  @Test
+  public void groupByCountWithMoreKeysThanInternTable() throws Exception {
+    final int distinct = 1500; // > the 1024-slot intern table
+    // Round-robin the keys so every contiguous chunk sees all of them (each chunk then
+    // holds > 1024 distinct keys, which is the case that used to wedge the probe loop).
+    final int rounds = Runtime.getRuntime().availableProcessors() + 3;
+    final Path file = writeRoundRobin(distinct, rounds);
+    try {
+      // Without the fix this never returns; bound it so a regression fails fast.
+      final List<Item> result = assertTimeoutPreemptively(Duration.ofSeconds(30),
+                                                          () -> ParallelGroupByExec.executeGroupByCount(file, "city"));
+      assertExactCounts(result, distinct, rounds);
+    } finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  @Test
+  public void groupByCountSpillsToDiskUnderTinyBudget() throws Exception {
+    // A 50-key budget forces the overflow map to spill to partition files repeatedly,
+    // exercising the radix spill + per-partition merge end to end. The result must still
+    // be exact (no rows lost, double-counted, or mis-merged across the spill boundary).
+    final int distinct = 1500;
+    final int rounds = Runtime.getRuntime().availableProcessors() + 3;
+    final Path file = writeRoundRobin(distinct, rounds);
+    final String prev = System.getProperty(SPILL_THRESHOLD);
+    System.setProperty(SPILL_THRESHOLD, "50");
+    try {
+      final List<Item> result = assertTimeoutPreemptively(Duration.ofSeconds(30),
+                                                          () -> ParallelGroupByExec.executeGroupByCount(file, "city"));
+      assertExactCounts(result, distinct, rounds);
+    } finally {
+      if (prev == null) {
+        System.clearProperty(SPILL_THRESHOLD);
+      } else {
+        System.setProperty(SPILL_THRESHOLD, prev);
+      }
+      Files.deleteIfExists(file);
+    }
+  }
+}


### PR DESCRIPTION
Four independent correctness fixes (one commit each), full suite green (1077 tests, 0 failures).

### `fix(operator)` — SpillableGroupBy disk spill + iteration-nesting demarcation
The radix-spill machinery existed but `next()` never spilled, so a high-distinct-key group-by was an OOM risk. Activate it (existing keys aggregate in place; new keys spill to 64 hash partitions, re-aggregated one at a time with recursive depth-rotated repartitioning). Also restore the `check`/`separate`/`dead` segment demarcation the legacy `GroupBy` honored but the spill rewrite had dropped.

### `fix(vectorized)` — ParallelGroupByExec high-cardinality hang + disk spill
The per-thread intern table was a fixed 1024-slot open-addressing table with a probe stride coprime to its capacity, so a chunk with >1024 distinct keys spun forever. Bound probes + load, route overflow to a map (merged exactly), and add `GroupByCountSpill` for radix-partitioned external aggregation (mergeable counts) so high-cardinality stays memory-bounded.

### `fix(expr)` — array constructor flattens any multi-item sequence
`[ Expr ]` only flattened the `(a,b,c)` comma-constructor; a FLWOR/function-call result was stored as one multi-item member, so `[]`-unboxing, indexing and `count` threw `XPTY0004`. Dispatch on cardinality, not the concrete sequence class.

### `fix(optimizer)` — cardinality of let-bound decorrelation under an enclosing `for`
`LetBindToLeftJoin` decorrelated into a left join with no per-outer grouping key, collapsing/dropping outer iterations or over-collecting the binding. Tag each outer tuple with an upstream `Count` and group the binding by it (kept free of `check` markers so empty iterations stay distinct). Fixes the long-standing `LetBindLift`/`JoinTest`/`XMark` failures.