### PR TITLE
Flatten any multi-item sequence in array constructor; bound the group-by intern table

### DIFF
--- a/src/main/java/io/brackit/query/expr/ArrayExpr.java
+++ b/src/main/java/io/brackit/query/expr/ArrayExpr.java
@@ -67,7 +67,14 @@ public final class ArrayExpr implements Expr {
         continue;
       }
 
-      if (!(res instanceof SequenceExpr.EvalSequence) && !flatten[i] || res instanceof Item) {
+      // A bracket-constructor entry contributes one array member per item of its
+      // sequence value. Only a single Item (incl. a nested array/object, which must
+      // stay intact) is added as-is; every multi-item sequence kind — comma sequence,
+      // FLWOR, function call, … — and every explicitly flattened ('=') entry is
+      // iterated so its items become individual members. Guarding on EvalSequence
+      // alone missed non-comma multi-item sequences (e.g. a FLWOR), which were stored
+      // as a single member and then failed XPTY0004 on access.
+      if (!flatten[i] && res instanceof Item) {
         vals.add(res);
       } else {
         try (final Iter it = res.iterate()) {

--- a/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
+++ b/src/main/java/io/brackit/query/operator/vectorized/ParallelGroupByExec.java
@@ -307,12 +307,26 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
    */
   private static final int INTERN_CAPACITY = 1024;
   private static final int INTERN_MASK = INTERN_CAPACITY - 1;
+  /**
+   * Occupancy cap for the fixed-size open-addressing intern table. Past this many
+   * distinct keys the table stops accepting new entries and the surplus is counted in
+   * an overflow {@link HashMap}. This keeps at least {@code CAPACITY - MAX_FILL} slots
+   * permanently free, so the stride-31 probe is guaranteed to hit a {@code null} slot
+   * and terminate — without the cap, a chunk with more than {@code CAPACITY} distinct
+   * keys fills every slot and the probe loop spins forever.
+   */
+  private static final int INTERN_MAX_FILL = (INTERN_CAPACITY * 3) / 4;
 
   private static HashMap<String, long[]> processChunk(Path path, long start, long end, byte[] pattern,
       byte[] patternSpaced) throws IOException {
     // Per-thread intern table: raw byte keys → count
     byte[][] internKeys = new byte[INTERN_CAPACITY][];
     long[] internCounts = new long[INTERN_CAPACITY];
+    int internSize = 0;
+    // High-cardinality fallback: distinct keys beyond INTERN_MAX_FILL are counted here
+    // so the intern table never fills (keeping the probe bounded). Stays null — and the
+    // hot path untouched — for the common low-cardinality case.
+    HashMap<String, long[]> overflow = null;
 
     byte[] window = new byte[WINDOW_SIZE];
     long pos = 0;
@@ -424,20 +438,38 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
             int hash = longHash(window, valueStart, keyLen);
             int idx = hash & INTERN_MASK;
 
+            boolean counted = false;
             while (true) {
               byte[] existing = internKeys[idx];
               if (existing == null) {
-                byte[] keyCopy = new byte[keyLen];
-                System.arraycopy(window, valueStart, keyCopy, 0, keyLen);
-                internKeys[idx] = keyCopy;
-                internCounts[idx] = 1;
+                // Free slot: intern the key only while under the occupancy cap. Past it
+                // we leave the slot free (so the probe always terminates) and fall through
+                // to the overflow map below.
+                if (internSize < INTERN_MAX_FILL) {
+                  byte[] keyCopy = new byte[keyLen];
+                  System.arraycopy(window, valueStart, keyCopy, 0, keyLen);
+                  internKeys[idx] = keyCopy;
+                  internCounts[idx] = 1;
+                  internSize++;
+                  counted = true;
+                }
                 break;
               }
               if (existing.length == keyLen && bytesEqual(existing, 0, window, valueStart, keyLen)) {
                 internCounts[idx]++;
+                counted = true;
                 break;
               }
               idx = (idx + 31) & INTERN_MASK; // stride-31 probing (1BRC technique)
+            }
+            if (!counted) {
+              // High-cardinality tail: more distinct keys than the table holds. Count the
+              // surplus key in a fallback map so the result stays exact (and bounded).
+              if (overflow == null) {
+                overflow = new HashMap<>();
+              }
+              overflow.computeIfAbsent(new String(window, valueStart, keyLen, StandardCharsets.UTF_8),
+                                       k -> new long[1])[0]++;
             }
           }
         }
@@ -453,6 +485,16 @@ public final class ParallelGroupByExec implements VectorizedExecutor {
     for (int i = 0; i < INTERN_CAPACITY; i++) {
       if (internKeys[i] != null) {
         result.put(new String(internKeys[i], StandardCharsets.UTF_8), new long[] { internCounts[i] });
+      }
+    }
+    // Fold in the high-cardinality overflow (disjoint keys by construction, but merge
+    // defensively in case a key first appeared after the table reached the cap).
+    if (overflow != null) {
+      for (Map.Entry<String, long[]> e : overflow.entrySet()) {
+        result.merge(e.getKey(), e.getValue(), (a, b) -> {
+          a[0] += b[0];
+          return a;
+        });
       }
     }
     return result;

--- a/src/test/java/io/brackit/query/ArrayConstructorFlattenTest.java
+++ b/src/test/java/io/brackit/query/ArrayConstructorFlattenTest.java
@@ -1,0 +1,88 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the JSONiq array constructor {@code [ Expr ]}. A multi-item
+ * operand must expand to one array member per item, whatever sequence kind produced
+ * it. Previously only the {@code (a,b,c)} comma constructor was flattened, so an
+ * array built from a FLWOR ({@code [ for $i in ... return ... ]}) stored the whole
+ * sequence as a single member and every subsequent access ({@code []} unboxing,
+ * indexing, {@code count}) failed with {@code XPTY0004}.
+ */
+public final class ArrayConstructorFlattenTest extends XQueryBaseTest {
+
+  private String query(String q) throws Exception {
+    try (var out = new ByteArrayOutputStream()) {
+      new Query(q).serialize(ctx, new PrintStream(out));
+      return out.toString(StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  public void flworOperandFlattensToMembers() throws Exception {
+    assertEquals("[1,2,3]", query("[ for $i in 1 to 3 return $i ]"));
+    assertEquals("1 2 3", query("[ for $i in 1 to 3 return $i ][]"));
+    assertEquals("3", query("count([ for $i in 1 to 3 return $i ][])"));
+    assertEquals("[{\"v\":1},{\"v\":2},{\"v\":3}]", query("[ for $i in 1 to 3 return { \"v\": $i } ]"));
+  }
+
+  @Test
+  public void commaSequenceStillFlattens() throws Exception {
+    assertEquals("[1,2,3]", query("[ (1, 2, 3) ]"));
+    assertEquals("[1,2,3,4]", query("[ 1, (2, 3), 4 ]"));
+  }
+
+  @Test
+  public void singleItemsAndNestedArraysStayOneMember() throws Exception {
+    assertEquals("[{\"a\":1}]", query("[ { \"a\": 1 } ]"));
+    assertEquals("[[1,2,3]]", query("[ [1, 2, 3] ]")); // nested array is one item, one member
+    assertEquals("[1,2,3]", query("[1, 2, 3]"));
+  }
+
+  @Test
+  public void postGroupProjectionOverFlworArray() throws Exception {
+    // The shape the bug originally surfaced through: group-by + sum of a projected
+    // field, over an array built by a FLWOR.
+    final String q = """
+        let $data := [ for $i in 1 to 4 return { "d": $i mod 2, "v": $i } ]
+        return string-join(
+          for $u in $data[] let $g := $u.d group by $g order by $g
+          return $g || ":" || sum($u.v), ",")
+        """;
+    assertEquals("0:6,1:4", query(q)); // g=0: v 2+4=6; g=1: v 1+3=4
+  }
+}

--- a/src/test/java/io/brackit/query/operator/vectorized/ParallelGroupByHighCardinalityTest.java
+++ b/src/test/java/io/brackit/query/operator/vectorized/ParallelGroupByHighCardinalityTest.java
@@ -1,0 +1,111 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query.operator.vectorized;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import io.brackit.query.atomic.Int64;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jsonitem.object.CompactObject;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the fixed-size byte-key intern table in {@link ParallelGroupByExec}.
+ *
+ * <p>The per-thread open-addressing table ({@code INTERN_CAPACITY = 1024}, stride-31
+ * probing) had no occupancy bound. A chunk holding more than 1024 distinct group keys
+ * filled every slot, after which the {@code while (true)} probe for the next new key found
+ * neither a free slot nor a match and spun forever — a CPU-bound hang on any
+ * high-cardinality grouping. (The 1BRC source it was modelled on tops out at ~413 distinct
+ * keys, so the ceiling was never reached there.)
+ *
+ * <p>The fix caps occupancy and counts the high-cardinality tail in an overflow map, which
+ * keeps free slots in the table so the probe always terminates. This test drives far more
+ * than 1024 distinct keys per chunk and asserts the path both TERMINATES (preemptive
+ * timeout) and stays exact (one group per key, counts preserved).
+ */
+final class ParallelGroupByHighCardinalityTest {
+
+  @Test
+  void highCardinalityGroupByCountTerminatesAndStaysExact() throws Exception {
+    // One chunk per core; size the data so every chunk sees > 1024 distinct keys (the
+    // count that used to overflow the 1024-slot table into an infinite probe).
+    final int cores = Runtime.getRuntime().availableProcessors();
+    final int distinct = Math.max(4096, 1400 * cores);
+    final int repeats = 2; // each key written twice → expected count per group = 2
+
+    final Path file = Files.createTempFile("pgb-highcard-", ".json");
+    try {
+      writeDataset(file, distinct, repeats);
+
+      final List<Item> groups = assertTimeoutPreemptively(Duration.ofSeconds(120),
+                                                          () -> ParallelGroupByExec.executeGroupByCount(file, "city"),
+                                                          "high-cardinality group-by-count must terminate (intern-table probe must stay bounded)");
+
+      // A group map is keyed by the (unique) city string, so size == distinct already
+      // proves every key produced exactly one group — none dropped, none duplicated.
+      assertEquals(distinct, groups.size(), "one group per distinct key");
+
+      final QNm countQnm = new QNm("count");
+      long total = 0;
+      for (final Item item : groups) {
+        final long count = ((Int64) ((CompactObject) item).get(countQnm)).longValue();
+        assertEquals(repeats, count, "each distinct key must be counted exactly " + repeats + " times");
+        total += count;
+      }
+      assertEquals((long) distinct * repeats, total, "total record count must be preserved");
+    } finally {
+      Files.deleteIfExists(file);
+    }
+  }
+
+  /** Write a JSON array of {@code distinct} flat objects, each emitted {@code repeats} times. */
+  private static void writeDataset(final Path file, final int distinct, final int repeats) throws IOException {
+    try (BufferedWriter w = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+      w.write("[\n");
+      for (int i = 0; i < distinct; i++) {
+        // Repeat each key consecutively so the surplus (overflowed) keys are also
+        // incremented in the overflow map, exercising that path too.
+        final String record = "{\"city\":\"c" + String.format("%07d", i) + "\"}\n";
+        for (int r = 0; r < repeats; r++) {
+          w.write(record);
+        }
+      }
+      w.write("]\n");
+    }
+  }
+}


### PR DESCRIPTION
Two independent correctness/robustness fixes, branched fresh off current `master` (1.0-alpha6-SNAPSHOT). Supersedes #105, which was based on a five-release-stale base and whose other two fixes already landed on master via #98–#101.

## 1. Array constructor flattens every multi-item sequence (`fix(expr)`)
A bracket array-constructor entry must contribute one member per item of its sequence value. The old guard only flattened comma sequences (`EvalSequence`) and explicit `=` entries, so a **FLWOR operand** stored its whole sequence as a single member:

```
[ for $i in 1 to 3 return $i ]        (: was: one ill-typed member :)
[ for $i in 1 to 3 return $i ][]      (: then XPTY0004 on access :)
```

Now an entry is added as-is only when it is a single `Item` (nested arrays/objects stay intact); otherwise the sequence is iterated and each item becomes a member. Covered by `ArrayConstructorFlattenTest` (FLWOR operand, comma sequence, single item / nested array, and the post-group projection shape that first surfaced the bug).

## 2. Bound the group-by intern table (`fix(vectorized)`)
`ParallelGroupByExec` aggregates keys in a fixed 1024-slot open-addressing table (stride-31 probing) with **no occupancy bound**. Once a chunk holds >1024 distinct keys, every slot is filled and the `while(true)` probe for a new key never terminates — a CPU-bound hang on any high-cardinality grouping. (The 1BRC workload it was modelled on tops out at ~413 distinct keys, so this was never hit.)

Occupancy is capped at 3/4 of capacity; the high-cardinality tail is counted in an overflow `HashMap`, leaving ≥1/4 of the slots permanently free so the probe always reaches a `null` slot. The common low-cardinality path is untouched (overflow stays `null`; one extra comparison per key). Counts stay exact. Covered by `ParallelGroupByHighCardinalityTest`, which drives >1024 distinct keys per chunk and asserts both termination (preemptive timeout) and exact counts.

## Validation
- Full suite: **1240 tests, 0 failures, 0 errors, 4 skipped**.
- Both new bugs reproduce on current `master` and are fixed here.