### PR TITLE
Don't atomize item()* args of subsequence/reverse/remove/insert-before

### DIFF
--- a/src/main/java/io/brackit/query/module/Functions.java
+++ b/src/main/java/io/brackit/query/module/Functions.java
@@ -646,27 +646,13 @@ public final class Functions {
     predefine(new Distinct(FN_DISTINCT,
                            new Signature(new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
                                          new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany))));
-    predefine(new InsertBefore(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "insert-before"),
-                               new Signature(new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                             new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                             new SequenceType(AtomicType.INR, Cardinality.One),
-                                             new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany))));
-    predefine(new Remove(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "remove"),
-                         new Signature(new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                       new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                       new SequenceType(AtomicType.INR, Cardinality.One))));
-    predefine(new Reverse(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "reverse"),
-                          new Signature(new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                        new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany))));
-    predefine(new Subsequence(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "subsequence"),
-                              new Signature(new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                            new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                            new SequenceType(AtomicType.DBL, Cardinality.One))));
-    predefine(new Subsequence(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "subsequence"),
-                              new Signature(new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                            new SequenceType(AtomicType.ANA, Cardinality.ZeroOrMany),
-                                            new SequenceType(AtomicType.DBL, Cardinality.One),
-                                            new SequenceType(AtomicType.DBL, Cardinality.One))));
+    // fn:insert-before, fn:remove, fn:reverse and fn:subsequence operate on item()* and must NOT
+    // atomize their input (XPath F&O §14). They were previously also predefined with an
+    // xs:anyAtomicType* ($arg as ANA*) signature that took precedence and made the function
+    // conversion atomize each item — so a sequence of objects/arrays failed with FOTY0012
+    // ("atomized value of record items is undefined"). The item()*-typed registrations below are
+    // the correct ones; the atomizing duplicates are removed. (fn:index-of and fn:distinct-values
+    // keep ANA* deliberately — they compare atomized values by definition.)
     predefine(new Subsequence(new QNm(Namespaces.FN_NSURI, Namespaces.FN_PREFIX, "subsequence"),
                               new Signature(new SequenceType(AnyItemType.ANY, Cardinality.ZeroOrMany),
                                             new SequenceType(AnyItemType.ANY, Cardinality.ZeroOrMany),

--- a/src/test/java/io/brackit/query/SequenceFunctionsOverJsonTest.java
+++ b/src/test/java/io/brackit/query/SequenceFunctionsOverJsonTest.java
@@ -1,0 +1,94 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.brackit.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The general sequence functions fn:subsequence, fn:reverse, fn:remove and fn:insert-before operate
+ * on {@code item()*} (XPath F&amp;O §14) and must NOT atomize their input. They used to be predefined
+ * with an additional {@code xs:anyAtomicType*} signature that took precedence, so the function
+ * conversion atomized every item — a sequence of objects or arrays then failed with
+ * {@code FOTY0012 ("The atomized value of record items is undefined")}. These tests pin that the
+ * functions now pass structured items through untouched, while atomic inputs still work.
+ */
+public final class SequenceFunctionsOverJsonTest extends XQueryBaseTest {
+
+  /** An unboxed array of three objects: {@code ({"a":1}, {"a":2}, {"a":3})}. */
+  private static final String OBJS = "([{\"a\":1},{\"a\":2},{\"a\":3}][])";
+
+  private String query(String q) throws Exception {
+    try (var out = new ByteArrayOutputStream()) {
+      new Query(q).serialize(ctx, new PrintStream(out));
+      return out.toString(StandardCharsets.UTF_8);
+    }
+  }
+
+  @Test
+  public void subsequenceOverObjects() throws Exception {
+    assertEquals("2", query("count(subsequence(" + OBJS + ", 1, 2))"));
+    assertEquals("2 3", query("for $x in subsequence(" + OBJS + ", 2, 2) return $x.a"));
+    // two-arg form (no length) keeps the rest of the sequence
+    assertEquals("2 3", query("for $x in subsequence(" + OBJS + ", 2) return $x.a"));
+  }
+
+  @Test
+  public void reverseOverObjects() throws Exception {
+    assertEquals("3 2 1", query("for $x in reverse(" + OBJS + ") return $x.a"));
+  }
+
+  @Test
+  public void removeOverObjects() throws Exception {
+    assertEquals("1 3", query("for $x in remove(" + OBJS + ", 2) return $x.a"));
+  }
+
+  @Test
+  public void insertBeforeOverObjects() throws Exception {
+    assertEquals("1 9 2 3", query("for $x in insert-before(" + OBJS + ", 2, {\"a\":9}) return $x.a"));
+  }
+
+  @Test
+  public void overArrayItems() throws Exception {
+    // arrays are also non-atomizable; subsequence must pass them through
+    assertEquals("2", query("count(subsequence(([[1],[2],[3]][]), 1, 2))"));
+  }
+
+  @Test
+  public void atomicInputsStillWork() throws Exception {
+    // regression guard: the item()* signature must not change atomic behaviour
+    assertEquals("20 30", query("subsequence((10,20,30,40,50), 2, 2)"));
+    assertEquals("5 4 3 2 1", query("reverse((1,2,3,4,5))"));
+    assertEquals("1 3 4", query("remove((1,2,3,4), 2)"));
+  }
+}


### PR DESCRIPTION
`fn:subsequence`, `fn:reverse`, `fn:remove` and `fn:insert-before` operate on `item()*` (XPath F&O §14) and must not atomize their input. Each was predefined **twice** — once correctly as `item()*` and once, **registered first**, as `xs:anyAtomicType*`. The atomic signature won, so the function-conversion layer atomized every argument item, and a sequence of objects/arrays failed:

```
subsequence(($objects[]), 1, 20)
  => err:FOTY0012: The atomized value of record items is undefined
```

This removes the stale atomizing duplicates (the `item()*` registrations remain). `fn:index-of` / `fn:distinct-values` keep `xs:anyAtomicType*` deliberately — they compare atomized values by definition.

**Verified:** new `SequenceFunctionsOverJsonTest` (objects, arrays, and atomic-input regression guards) + full suite **1246 / 0 failures**.