### PR TITLE
Add source-document identity to the VectorizedExecutor contract

### DIFF
--- a/src/main/java/io/brackit/query/compiler/optimizer/SourceRef.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/SourceRef.java
@@ -1,0 +1,131 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ */
+package io.brackit.query.compiler.optimizer;
+
+/**
+ * Immutable identity of the document a vectorized scan reads from, lifted from the loop variable's
+ * source expression by {@link io.brackit.query.compiler.optimizer.walker.topdown.VectorizedGroupByDetection}
+ * and carried on the annotated {@code PipeExpr} via {@link VectorizedScanAnnotation#SOURCE_REF}.
+ *
+ * <p>{@link VectorizedScanAnnotation#SOURCE_PATH_PREFIX} tells an executor <em>which path</em> inside
+ * a document a scan walks, but never <em>which document</em> it dereferences. A {@link VectorizedExecutor}
+ * is typically bound to a single physical resource/revision (e.g. SirixDB's
+ * {@code SirixVectorizedExecutor}), so a same-shaped query over a <em>different</em> document would be
+ * answered with the bound resource's data — wrong results. This ref closes that gap: the executor
+ * inspects it in {@link VectorizedExecutor#acceptsSource(SourceRef)} and declines a scan it is not
+ * bound to serve, so the translator falls back to the generic (always-correct) pipeline.
+ *
+ * <p>Three kinds, matching what the detection can prove from the AST:
+ * <ul>
+ * <li>{@link Kind#DOCUMENT} — the scan opens a concrete {@code jn:doc}/{@code jn:open} with literal
+ * database/resource arguments; {@link #databaseName()}, {@link #resourceName()} and {@link #revision()}
+ * are populated ({@code revision == } {@link #LATEST_REVISION} when the call names no explicit revision,
+ * i.e. it opens the most-recent one).</li>
+ * <li>{@link Kind#CONTEXT_ITEM} — the scan ranges over the query's context item (the caller's own bound
+ * read transaction); no database/resource is named.</li>
+ * <li>{@link Kind#UNKNOWN} — the source could not be proven to be a single concrete document (a dynamic
+ * {@code jn:doc}, a collection/multi-revision opener, an unresolved variable, or a non-document
+ * source). A resource-bound executor should fail closed on this.</li>
+ * </ul>
+ */
+public final class SourceRef {
+
+  /** Sentinel {@link #revision()} value: the source names no explicit revision (opens the latest). */
+  public static final int LATEST_REVISION = -1;
+
+  /** What the optimizer could prove about the scan's source document. */
+  public enum Kind {
+    DOCUMENT, CONTEXT_ITEM, UNKNOWN
+  }
+
+  private static final SourceRef CONTEXT_ITEM = new SourceRef(Kind.CONTEXT_ITEM, null, null, LATEST_REVISION);
+  private static final SourceRef UNKNOWN = new SourceRef(Kind.UNKNOWN, null, null, LATEST_REVISION);
+
+  private final Kind kind;
+  private final String databaseName;
+  private final String resourceName;
+  private final int revision;
+
+  private SourceRef(final Kind kind, final String databaseName, final String resourceName, final int revision) {
+    this.kind = kind;
+    this.databaseName = databaseName;
+    this.resourceName = resourceName;
+    this.revision = revision;
+  }
+
+  /**
+   * A concrete document scan.
+   *
+   * @param databaseName the literal database name (must not be {@code null})
+   * @param resourceName the literal resource name (must not be {@code null})
+   * @param revision     the explicit revision, or {@link #LATEST_REVISION} when the source opens the
+   *                     most-recent revision
+   */
+  public static SourceRef document(final String databaseName, final String resourceName, final int revision) {
+    if (databaseName == null || resourceName == null) {
+      throw new IllegalArgumentException("databaseName and resourceName must not be null");
+    }
+    return new SourceRef(Kind.DOCUMENT, databaseName, resourceName, revision);
+  }
+
+  /** The query's context item — the caller's own bound read transaction. */
+  public static SourceRef contextItem() {
+    return CONTEXT_ITEM;
+  }
+
+  /** An unprovable / non-single-document source; resource-bound executors should fail closed. */
+  public static SourceRef unknown() {
+    return UNKNOWN;
+  }
+
+  public Kind kind() {
+    return kind;
+  }
+
+  /** {@code true} iff this ref opens a concrete literal document. */
+  public boolean isDocument() {
+    return kind == Kind.DOCUMENT;
+  }
+
+  /** {@code true} iff this ref is the query's context item. */
+  public boolean isContextItem() {
+    return kind == Kind.CONTEXT_ITEM;
+  }
+
+  /** The literal database name for a {@link Kind#DOCUMENT} ref, else {@code null}. */
+  public String databaseName() {
+    return databaseName;
+  }
+
+  /** The literal resource name for a {@link Kind#DOCUMENT} ref, else {@code null}. */
+  public String resourceName() {
+    return resourceName;
+  }
+
+  /**
+   * The explicit revision of a {@link Kind#DOCUMENT} ref, or {@link #LATEST_REVISION} when it opens the
+   * most-recent revision. Always {@link #LATEST_REVISION} for the other kinds.
+   */
+  public int revision() {
+    return revision;
+  }
+
+  /** {@code true} iff a {@link Kind#DOCUMENT} ref names no explicit revision (opens the latest). */
+  public boolean opensLatestRevision() {
+    return revision == LATEST_REVISION;
+  }
+
+  @Override
+  public String toString() {
+    return switch (kind) {
+      case DOCUMENT -> "SourceRef[doc " + databaseName + "/" + resourceName + (revision == LATEST_REVISION
+          ? ""
+          : "@" + revision) + "]";
+      case CONTEXT_ITEM -> "SourceRef[context-item]";
+      case UNKNOWN -> "SourceRef[unknown]";
+    };
+  }
+}

--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
@@ -172,4 +172,31 @@ public interface VectorizedExecutor {
 
   /** Check if this executor can handle the current query context. */
   boolean canExecute(QueryContext ctx);
+
+  /**
+   * Whether this executor may serve a scan over the given source document.
+   *
+   * <p>{@code sourcePath} tells an executor which path inside a document a scan walks, but never which
+   * document. An executor bound to a single physical resource/revision (e.g. SirixDB's
+   * {@code SirixVectorizedExecutor}) would otherwise answer a same-shaped query over a <em>different</em>
+   * document from its own columns — wrong results. The optimizer therefore lifts the scan's source
+   * identity into a {@link SourceRef} (see {@link VectorizedScanAnnotation#SOURCE_REF}) and asks here,
+   * at TRANSLATE time, before substituting the vectorized expression.
+   *
+   * <p>Returning {@code false} is not an error: the translator simply builds the generic (always-correct)
+   * pipeline instead, so declining only ever costs the fast path. A resource-bound executor should fail
+   * closed — accept {@link SourceRef.Kind#DOCUMENT} refs that match its binding (and the query's
+   * {@link SourceRef.Kind#CONTEXT_ITEM}, the caller's own transaction), and decline everything else,
+   * including {@link SourceRef.Kind#UNKNOWN}.
+   *
+   * <p>The default accepts every source — correct for executors that are not bound to one resource
+   * (e.g. bjq's file-backed {@code ParallelGroupByExec}), so the added contract is opt-in and does not
+   * change their behaviour.
+   *
+   * @param source the scan's source identity; never {@code null} when the optimizer annotated the scan
+   * @return {@code true} to allow vectorized serving of this source, {@code false} to fall back
+   */
+  default boolean acceptsSource(SourceRef source) {
+    return true;
+  }
 }

--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedScanAnnotation.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedScanAnnotation.java
@@ -79,6 +79,19 @@ public final class VectorizedScanAnnotation {
    */
   public static final String SOURCE_PATH_PREFIX = "VECTORIZED_SOURCE_PATH_PREFIX";
 
+  /**
+   * Identity of the document the scan reads from. Value is a {@link SourceRef}. Where
+   * {@link #SOURCE_PATH_PREFIX} captures <em>which path</em> a scan walks, this captures <em>which
+   * document</em> it dereferences — the concrete {@code jn:doc}/{@code jn:open} resource/revision, the
+   * query's context item, or {@link SourceRef.Kind#UNKNOWN} when identity can't be proven.
+   *
+   * <p>Set on every vectorizable {@code PipeExpr} the walker annotates. The translator hands it to
+   * {@link VectorizedExecutor#acceptsSource(SourceRef)} so a resource-bound executor can decline a scan
+   * over a document it is not bound to — falling back to the generic pipeline rather than answering with
+   * the wrong resource's data. Executors that are not resource-bound (the default) accept every source.
+   */
+  public static final String SOURCE_REF = "VECTORIZED_SOURCE_REF";
+
   // ---- Order-by ----
   /** Order field name (String). */
   public static final String ORDER_FIELD = "VECTORIZED_ORDER_FIELD";

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
@@ -9,12 +9,18 @@ import io.brackit.query.atomic.QNm;
 import io.brackit.query.compiler.AST;
 import io.brackit.query.compiler.XQ;
 import io.brackit.query.compiler.optimizer.PredicateNode;
+import io.brackit.query.compiler.optimizer.SourceRef;
 import io.brackit.query.compiler.optimizer.Stage;
 import io.brackit.query.compiler.optimizer.VectorizedScanAnnotation;
+import io.brackit.query.function.json.JSONFun;
 import io.brackit.query.module.StaticContext;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Optimizer stage that detects FLWOR patterns eligible for vectorized execution.
@@ -43,26 +49,34 @@ import java.util.List;
  */
 public final class VectorizedGroupByDetection implements Stage {
 
+  /** Guard against pathological ASTs when resolving a scan source through variable bindings. */
+  private static final int MAX_UNWRAP_STEPS = 64;
+
   @Override
   public AST rewrite(StaticContext sctx, AST ast) {
-    walkAndAnnotate(ast);
+    // Resolve a scan's source document (a `for $u in $doc[]` reaches its `jn:doc(...)` only through the
+    // `let $doc := ...` binding), so collect every visible for/let binding once up front and thread the
+    // map into the per-PipeExpr annotation.
+    final Map<Object, AST> variableBindings = new HashMap<>();
+    collectVariableBindings(ast, variableBindings);
+    walkAndAnnotate(ast, variableBindings);
     return ast;
   }
 
-  private void walkAndAnnotate(AST node) {
+  private void walkAndAnnotate(AST node, Map<Object, AST> variableBindings) {
     if (node == null)
       return;
     if (node.getType() == XQ.PipeExpr) {
-      tryAnnotate(node);
+      tryAnnotate(node, variableBindings);
     }
     for (int i = 0; i < node.getChildCount(); i++) {
-      walkAndAnnotate(node.getChild(i));
+      walkAndAnnotate(node.getChild(i), variableBindings);
     }
   }
 
   // ==================== Main pattern matcher ====================
 
-  private void tryAnnotate(AST pipeExpr) {
+  private void tryAnnotate(AST pipeExpr, Map<Object, AST> variableBindings) {
     if (pipeExpr.getChildCount() < 1)
       return;
     AST chain = pipeExpr.getChild(0);
@@ -237,6 +251,11 @@ public final class VectorizedGroupByDetection implements Stage {
       if (sourcePath != null) {
         pipeExpr.setProperty(VectorizedScanAnnotation.SOURCE_PATH_PREFIX, sourcePath);
       }
+      // Document identity of the scan source. Set unconditionally (the translator only consults it once
+      // a vectorized claim exists) so a resource-bound executor can decline a scan over a document it is
+      // not bound to — see VectorizedExecutor#acceptsSource.
+      pipeExpr.setProperty(VectorizedScanAnnotation.SOURCE_REF,
+                           resolveSourceRef(forBind.getChild(1), variableBindings));
     }
 
     // Sorted scan emits FULL RECORDS sorted by ONE direct `$loopVar.field` key — only
@@ -562,6 +581,124 @@ public final class VectorizedGroupByDetection implements Stage {
       return s;
     }
     return null;
+  }
+
+  // ==================== Source-document identity extraction ====================
+
+  /**
+   * Collect every {@link XQ#ForBind}/{@link XQ#LetBind} binding in the tree into {@code out}, keyed by
+   * the declared variable's QNm. First (outermost) binding wins on shadowing — a heuristic that only
+   * ever costs precision (a misresolved source yields {@link SourceRef#unknown()}, which fails closed).
+   */
+  private static void collectVariableBindings(final AST node, final Map<Object, AST> out) {
+    if ((node.getType() == XQ.ForBind || node.getType() == XQ.LetBind) && node.getChildCount() >= 2) {
+      final Object varKey = bindingVariableKey(node.getChild(0));
+      if (varKey != null) {
+        out.putIfAbsent(varKey, node.getChild(1));
+      }
+    }
+    for (int i = 0, n = node.getChildCount(); i < n; i++) {
+      collectVariableBindings(node.getChild(i), out);
+    }
+  }
+
+  /**
+   * The variable QNm bound by a {@code For}/{@code LetBind}'s first child (a
+   * {@link XQ#TypedVariableBinding} whose own first child, the {@code Variable}, carries the QNm that a
+   * {@link XQ#VariableRef} later resolves against). Falls back to the node's own value defensively.
+   */
+  private static Object bindingVariableKey(final AST typedVariableBinding) {
+    if (typedVariableBinding.getChildCount() > 0) {
+      return typedVariableBinding.getChild(0).getValue();
+    }
+    return typedVariableBinding.getValue();
+  }
+
+  /**
+   * Resolve a loop variable's source expression down to the document it reads from, following
+   * deref/array/filter layers and variable bindings, and classify it as a {@link SourceRef}. Never
+   * {@code null}: an unresolvable, dynamic, cyclic, collection, or non-document source resolves to
+   * {@link SourceRef#unknown()} so a resource-bound executor fails closed.
+   */
+  private SourceRef resolveSourceRef(final AST binding, final Map<Object, AST> variableBindings) {
+    final Set<Object> resolvingVars = new HashSet<>(4);
+    AST current = binding;
+    for (int step = 0; current != null && step < MAX_UNWRAP_STEPS; step++) {
+      switch (current.getType()) {
+        case XQ.DerefExpr, XQ.ArrayAccess, XQ.FilterExpr -> {
+          if (current.getChildCount() < 1) {
+            return SourceRef.unknown();
+          }
+          current = current.getChild(0);
+        }
+        case XQ.VariableRef -> {
+          final Object varKey = current.getValue();
+          if (varKey == null || !resolvingVars.add(varKey)) {
+            return SourceRef.unknown(); // unresolved or cyclic — cannot prove a single document
+          }
+          final AST resolved = variableBindings.get(varKey);
+          if (resolved == null) {
+            return SourceRef.unknown(); // a for-loop / outer variable, not a document binding
+          }
+          current = resolved;
+        }
+        case XQ.ContextItemExpr -> {
+          return SourceRef.contextItem(); // the caller's own bound read transaction
+        }
+        case XQ.FunctionCall -> {
+          return functionCallSourceRef(current);
+        }
+        default -> {
+          return SourceRef.unknown();
+        }
+      }
+    }
+    return SourceRef.unknown();
+  }
+
+  /**
+   * Classify a {@link XQ#FunctionCall} scan source. A {@code jn:doc}/{@code jn:open} with literal
+   * database and resource arguments (and, if present, a literal integer revision) yields a concrete
+   * {@link SourceRef#document}; a dynamic argument, any other {@code jn:} opener (collection /
+   * multi-revision — it spans more than one resource/revision), or a non-JSON function yields
+   * {@link SourceRef#unknown()}.
+   */
+  private SourceRef functionCallSourceRef(final AST call) {
+    if (!(call.getValue() instanceof QNm qnm) || !JSONFun.JSON_NSURI.equals(qnm.getNamespaceURI())) {
+      return SourceRef.unknown();
+    }
+    final String local = qnm.getLocalName();
+    if (!"doc".equals(local) && !"open".equals(local)) {
+      return SourceRef.unknown();
+    }
+    if (call.getChildCount() < 2) {
+      return SourceRef.unknown();
+    }
+    final String databaseName = stringLiteralValue(call.getChild(0));
+    final String resourceName = stringLiteralValue(call.getChild(1));
+    if (databaseName == null || resourceName == null) {
+      return SourceRef.unknown(); // dynamic (non-literal) database/resource — unprovable
+    }
+    if (call.getChildCount() == 2) {
+      return SourceRef.document(databaseName, resourceName, SourceRef.LATEST_REVISION);
+    }
+    final Integer revision = literalRevision(call.getChild(2));
+    if (revision == null) {
+      return SourceRef.unknown(); // dynamic revision — unprovable
+    }
+    return SourceRef.document(databaseName, resourceName, revision);
+  }
+
+  /** The exact int of a literal integer revision argument; {@code null} for anything non-literal/lossy. */
+  private static Integer literalRevision(final AST node) {
+    if (node == null || node.getType() != XQ.Int) {
+      return null;
+    }
+    final Long lv = exactLongOf(node.getValue());
+    if (lv == null || lv < Integer.MIN_VALUE || lv > Integer.MAX_VALUE) {
+      return null;
+    }
+    return lv.intValue();
   }
 
   // ==================== Generic predicate-tree extraction ====================

--- a/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.compiler.optimizer.PredicateNode;
+import io.brackit.query.compiler.optimizer.SourceRef;
 import io.brackit.query.compiler.optimizer.VectorizedExecutor;
 import io.brackit.query.compiler.optimizer.VectorizedScanAnnotation;
 import io.brackit.query.expr.PipeExpr;
@@ -166,6 +167,17 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
     }
     if (executor == null)
       return null;
+
+    // Source-document identity (from the loop variable's IN clause). A resource-bound
+    // executor answers a scan from ITS columns, so serving a scan over a document it is
+    // not bound to would return the wrong resource's data. Ask before substituting any
+    // vectorized expression; a decline falls through to the generic (correct) pipeline.
+    // The annotation is present on every walker-annotated scan; when absent (legacy
+    // callers / hand-built ASTs) the executor's default accept-all applies unchanged.
+    final SourceRef sourceRef = (SourceRef) node.getProperty(VectorizedScanAnnotation.SOURCE_REF);
+    if (sourceRef != null && !executor.acceptsSource(sourceRef)) {
+      return null;
+    }
 
     // Source-path prefix (from the loop variable's IN clause). Threaded through
     // every vectorized Expr so the executor can combine it with per-predicate

--- a/src/test/java/io/brackit/query/compiler/optimizer/VectorizedSourceRefTest.java
+++ b/src/test/java/io/brackit/query/compiler/optimizer/VectorizedSourceRefTest.java
@@ -1,0 +1,376 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ */
+package io.brackit.query.compiler.optimizer;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.compiler.AST;
+import io.brackit.query.compiler.XQ;
+import io.brackit.query.compiler.optimizer.walker.topdown.VectorizedGroupByDetection;
+import io.brackit.query.compiler.translator.SequentialPipelineStrategy;
+import io.brackit.query.expr.VectorizedGroupByExpr;
+import io.brackit.query.function.json.JSONFun;
+import io.brackit.query.jdm.Expr;
+import io.brackit.query.jdm.Sequence;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the source-document identity contract: {@link VectorizedGroupByDetection} lifts the scan's
+ * source into a {@link SourceRef} under {@link VectorizedScanAnnotation#SOURCE_REF}, and
+ * {@link SequentialPipelineStrategy#tryVectorizedExpr(AST, boolean)} hands it to
+ * {@link VectorizedExecutor#acceptsSource(SourceRef)} so a resource-bound executor can decline a scan
+ * over a document it is not bound to (falling back to the generic pipeline) rather than answering with
+ * the wrong resource's data.
+ */
+public class VectorizedSourceRefTest {
+
+  private VectorizedGroupByDetection stage;
+
+  @BeforeEach
+  void setUp() {
+    stage = new VectorizedGroupByDetection();
+    SequentialPipelineStrategy.setThreadVectorizedExecutor(null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SequentialPipelineStrategy.clearThreadVectorizedExecutor();
+    SequentialPipelineStrategy.setVectorizedExecutor(null);
+  }
+
+  // ==================== AST builders ====================
+
+  private AST varRef(String name) {
+    return new AST(XQ.VariableRef, new QNm(name));
+  }
+
+  private AST deref(String varName, String fieldName) {
+    AST deref = new AST(XQ.DerefExpr);
+    deref.addChild(varRef(varName));
+    deref.addChild(new AST(XQ.DerefExpr, new QNm(fieldName)));
+    return deref;
+  }
+
+  private AST strLit(String value) {
+    return new AST(XQ.Str, value);
+  }
+
+  private AST arrayAccess(AST subject) {
+    AST aa = new AST(XQ.ArrayAccess);
+    aa.addChild(subject);
+    return aa;
+  }
+
+  /** {@code jn:doc('db','res')} or {@code jn:doc('db','res',rev)} when {@code rev != null}. */
+  private AST jnDoc(String db, String res, Integer rev) {
+    AST call = new AST(XQ.FunctionCall, new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "doc"));
+    call.addChild(strLit(db));
+    call.addChild(strLit(res));
+    if (rev != null) {
+      call.addChild(new AST(XQ.Int, new Int32(rev)));
+    }
+    return call;
+  }
+
+  /** A {@code jn:}-namespaced call to an arbitrary function of the given local name. */
+  private AST jnCall(String local, AST... args) {
+    AST call = new AST(XQ.FunctionCall, new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, local));
+    for (AST arg : args) {
+      call.addChild(arg);
+    }
+    return call;
+  }
+
+  private AST end(AST returnExpr) {
+    AST end = new AST(XQ.End);
+    end.addChild(returnExpr);
+    return end;
+  }
+
+  /** The canonical single-key group-by return: {@code {"city": $c, "count": count($u)}}. */
+  private AST groupByReturn(String loopVar, String keyVar, String field) {
+    AST obj = new AST(XQ.ObjectConstructor);
+    AST keyField = new AST(XQ.KeyValueField);
+    keyField.addChild(strLit(field));
+    keyField.addChild(varRef(keyVar));
+    obj.addChild(keyField);
+    AST countField = new AST(XQ.KeyValueField);
+    countField.addChild(strLit("count"));
+    AST countCall = new AST(XQ.FunctionCall, new QNm("count"));
+    countCall.addChild(varRef(loopVar));
+    countField.addChild(countCall);
+    obj.addChild(countField);
+    return end(obj);
+  }
+
+  /** GroupBy on {@code keyVar} then the canonical return. */
+  private AST groupByChain(String loopVar, String keyVar, String field) {
+    AST gb = new AST(XQ.GroupBy);
+    AST spec = new AST(XQ.GroupBySpec);
+    spec.addChild(varRef(keyVar));
+    gb.addChild(spec);
+    gb.addChild(new AST(XQ.DftAggregateSpec));
+    gb.addChild(groupByReturn(loopVar, keyVar, field));
+    return gb;
+  }
+
+  /**
+   * {@code for $u in <source> let $c := $u.<field> group by $c return {"<field>": $c, "count": count($u)}},
+   * optionally wrapped in an outer {@code let $doc := <docBinding>}. Wrapped in PipeExpr → Start.
+   */
+  private AST groupByPipe(String loopVar, String keyVar, String field, AST source, String outerVar, AST docBinding) {
+    AST letC = new AST(XQ.LetBind);
+    AST cBinding = new AST(XQ.TypedVariableBinding);
+    cBinding.addChild(new AST(XQ.Variable, new QNm(keyVar)));
+    letC.addChild(cBinding);
+    letC.addChild(deref(loopVar, field));
+    letC.addChild(groupByChain(loopVar, keyVar, field));
+
+    AST forBind = new AST(XQ.ForBind);
+    AST uBinding = new AST(XQ.TypedVariableBinding);
+    uBinding.addChild(new AST(XQ.Variable, new QNm(loopVar)));
+    forBind.addChild(uBinding);
+    forBind.addChild(source);
+    forBind.addChild(letC);
+
+    AST chainRoot = forBind;
+    if (outerVar != null) {
+      AST letDoc = new AST(XQ.LetBind);
+      AST docTvb = new AST(XQ.TypedVariableBinding);
+      docTvb.addChild(new AST(XQ.Variable, new QNm(outerVar)));
+      letDoc.addChild(docTvb);
+      letDoc.addChild(docBinding);
+      letDoc.addChild(forBind);
+      chainRoot = letDoc;
+    }
+
+    AST start = new AST(XQ.Start);
+    start.addChild(chainRoot);
+    AST pipe = new AST(XQ.PipeExpr);
+    pipe.addChild(start);
+    return pipe;
+  }
+
+  private AST root(AST pipe) {
+    AST root = new AST(XQ.Start);
+    root.addChild(pipe);
+    return root;
+  }
+
+  private SourceRef sourceRefOf(AST pipe) {
+    return (SourceRef) pipe.getProperty(VectorizedScanAnnotation.SOURCE_REF);
+  }
+
+  // ==================== detection: SOURCE_REF extraction ====================
+
+  @Test
+  void jnDocThroughLetBindResolvesToDocument() {
+    // let $doc := jn:doc('mydb','res') for $u in $doc[] let $c := $u.city group by $c return {...}
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(varRef("doc")), "doc", jnDoc("mydb", "res", null));
+    stage.rewrite(null, root(pipe));
+
+    SourceRef ref = sourceRefOf(pipe);
+    assertNotNull(ref, "SOURCE_REF must be set on a vectorizable scan");
+    assertTrue(ref.isDocument());
+    assertEquals("mydb", ref.databaseName());
+    assertEquals("res", ref.resourceName());
+    assertTrue(ref.opensLatestRevision(), "no explicit revision → opens latest");
+    assertEquals(SourceRef.LATEST_REVISION, ref.revision());
+    // The claim itself must still fire — SOURCE_REF is additive metadata.
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+  }
+
+  @Test
+  void jnDocDirectSourceResolvesToDocument() {
+    // for $u in jn:doc('mydb','res')[] ... — the doc call is the direct for-source root.
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(jnDoc("mydb", "res", null)), null, null);
+    stage.rewrite(null, root(pipe));
+
+    SourceRef ref = sourceRefOf(pipe);
+    assertNotNull(ref);
+    assertTrue(ref.isDocument());
+    assertEquals("mydb", ref.databaseName());
+    assertEquals("res", ref.resourceName());
+  }
+
+  @Test
+  void jnDocWithExplicitRevisionCarriesRevision() {
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(jnDoc("mydb", "res", 2)), "doc", jnDoc("mydb", "res", 2));
+    stage.rewrite(null, root(pipe));
+
+    SourceRef ref = sourceRefOf(pipe);
+    assertTrue(ref.isDocument());
+    assertEquals(2, ref.revision());
+    assertTrue(!ref.opensLatestRevision());
+  }
+
+  @Test
+  void dynamicResourceArgYieldsUnknown() {
+    // jn:doc('mydb', $r) — the resource is a variable, not a literal: identity unprovable.
+    AST dynamicDoc = new AST(XQ.FunctionCall, new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "doc"));
+    dynamicDoc.addChild(strLit("mydb"));
+    dynamicDoc.addChild(varRef("r"));
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(dynamicDoc), null, null);
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(SourceRef.Kind.UNKNOWN, sourceRefOf(pipe).kind());
+  }
+
+  @Test
+  void dynamicRevisionArgYieldsUnknown() {
+    // jn:doc('mydb','res', $rev) — the revision is dynamic, so the exact revision is unprovable.
+    AST dynamicRev = new AST(XQ.FunctionCall, new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "doc"));
+    dynamicRev.addChild(strLit("mydb"));
+    dynamicRev.addChild(strLit("res"));
+    dynamicRev.addChild(varRef("rev"));
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(dynamicRev), null, null);
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(SourceRef.Kind.UNKNOWN, sourceRefOf(pipe).kind());
+  }
+
+  @Test
+  void collectionOpenerYieldsUnknown() {
+    // jn:collection('mydb') spans more than one (resource, revision): not a single document.
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(jnCall("collection", strLit("mydb"))), null, null);
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(SourceRef.Kind.UNKNOWN, sourceRefOf(pipe).kind());
+  }
+
+  @Test
+  void contextItemSourceResolvesToContextItem() {
+    // for $u in .[] ... — the query's own context item (the caller's bound transaction).
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(new AST(XQ.ContextItemExpr)), null, null);
+    stage.rewrite(null, root(pipe));
+
+    SourceRef ref = sourceRefOf(pipe);
+    assertTrue(ref.isContextItem());
+    assertEquals(SourceRef.Kind.CONTEXT_ITEM, ref.kind());
+  }
+
+  @Test
+  void unresolvedVariableSourceYieldsUnknown() {
+    // for $u in $mystery[] ... — $mystery is bound nowhere the walker can see.
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(varRef("mystery")), null, null);
+    stage.rewrite(null, root(pipe));
+
+    assertEquals(SourceRef.Kind.UNKNOWN, sourceRefOf(pipe).kind());
+  }
+
+  // ==================== translate-time gate: acceptsSource ====================
+
+  @Test
+  void declinedSourceFallsBackToGenericPipeline() {
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(jnDoc("mydb", "res", null)), null, null);
+    stage.rewrite(null, root(pipe));
+    assertEquals(Boolean.TRUE, pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY));
+
+    RecordingExecutor executor = new RecordingExecutor(false);
+    SequentialPipelineStrategy.setThreadVectorizedExecutor(executor);
+
+    Expr result = SequentialPipelineStrategy.tryVectorizedExpr(pipe, false);
+    assertNull(result, "a declined source must fall back to the generic pipeline");
+    assertNotNull(executor.lastSource, "the executor must be consulted about the source");
+    assertTrue(executor.lastSource.isDocument());
+    assertEquals("res", executor.lastSource.resourceName());
+  }
+
+  @Test
+  void acceptedSourceStillServes() {
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(jnDoc("mydb", "res", null)), null, null);
+    stage.rewrite(null, root(pipe));
+
+    RecordingExecutor executor = new RecordingExecutor(true);
+    SequentialPipelineStrategy.setThreadVectorizedExecutor(executor);
+
+    Expr result = SequentialPipelineStrategy.tryVectorizedExpr(pipe, false);
+    assertInstanceOf(VectorizedGroupByExpr.class, result, "an accepted source must serve the vectorized expr");
+    assertSame(SourceRef.Kind.DOCUMENT, executor.lastSource.kind());
+  }
+
+  @Test
+  void absentSourceRefIsNotGated() {
+    // A hand-built annotated node with no SOURCE_REF (legacy callers): the gate must be skipped so the
+    // executor's default accept-all behaviour is preserved, even for an otherwise-declining executor.
+    AST pipe = new AST(XQ.PipeExpr);
+    pipe.setProperty(VectorizedScanAnnotation.VECTORIZED_GROUPBY, Boolean.TRUE);
+    pipe.setProperty(VectorizedScanAnnotation.GROUPBY_FIELD, "city");
+
+    RecordingExecutor executor = new RecordingExecutor(false);
+    SequentialPipelineStrategy.setThreadVectorizedExecutor(executor);
+
+    Expr result = SequentialPipelineStrategy.tryVectorizedExpr(pipe, false);
+    assertInstanceOf(VectorizedGroupByExpr.class, result, "no SOURCE_REF → gate skipped, executor serves");
+    assertNull(executor.lastSource, "acceptsSource must not be consulted when SOURCE_REF is absent");
+  }
+
+  @Test
+  void defaultAcceptsSourceServesEveryDocument() {
+    // The default acceptsSource (accept-all) leaves non-resource-bound executors unaffected.
+    AST pipe = groupByPipe("u", "c", "city", arrayAccess(jnDoc("mydb", "res", null)), null, null);
+    stage.rewrite(null, root(pipe));
+
+    SequentialPipelineStrategy.setThreadVectorizedExecutor(new DefaultExecutor());
+
+    Expr result = SequentialPipelineStrategy.tryVectorizedExpr(pipe, false);
+    assertInstanceOf(VectorizedGroupByExpr.class, result);
+  }
+
+  // ==================== stubs ====================
+
+  /** Executor that records the source it was asked about and answers a fixed accept/decline. */
+  private static final class RecordingExecutor implements VectorizedExecutor {
+    private final boolean accept;
+    private SourceRef lastSource;
+
+    RecordingExecutor(boolean accept) {
+      this.accept = accept;
+    }
+
+    @Override
+    public boolean acceptsSource(SourceRef source) {
+      this.lastSource = source;
+      return accept;
+    }
+
+    @Override
+    public boolean canExecute(QueryContext ctx) {
+      return true;
+    }
+
+    @Override
+    public Sequence executeGroupByCount(QueryContext ctx, String[] sourcePath, String groupField)
+        throws QueryException {
+      return null;
+    }
+  }
+
+  /** Executor relying entirely on the default {@code acceptsSource}. */
+  private static final class DefaultExecutor implements VectorizedExecutor {
+    @Override
+    public boolean canExecute(QueryContext ctx) {
+      return true;
+    }
+
+    @Override
+    public Sequence executeGroupByCount(QueryContext ctx, String[] sourcePath, String groupField)
+        throws QueryException {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

A `VectorizedExecutor` is typically bound to a single physical resource/revision (e.g. SirixDB's `SirixVectorizedExecutor`, constructed against one `(session, revision)`). `VectorizedGroupByDetection` captured the scan's source **path** (`SOURCE_PATH_PREFIX`) but never **which document** it dereferences. So a same-shaped analytical query over a *different* resource — same `[]`/field shape — could be served from the bound resource's projection/columns and return the wrong resource's data.

This is the upstream, right-altitude fix for that resource-blindness: the executor contract itself now carries the source-document identity and lets an executor self-verify it, instead of every embedder having to bolt a resource-scoping optimizer stage on top.

## Change

- **`SourceRef`** — immutable identity of a scan's source document: a concrete `jn:doc`/`jn:open` (database, resource, revision), the query's **context item** (the caller's own bound transaction), or **UNKNOWN** when identity can't be proven from the AST.
- **`VectorizedGroupByDetection`** lifts the source identity from the loop variable's `IN` clause — resolving through visible `let`/`for` bindings down to the opening `jn:doc`/`jn:open` — and sets it on the annotated `PipeExpr` under `VectorizedScanAnnotation.SOURCE_REF`. Fails **closed** to `UNKNOWN` for dynamic (non-literal) arguments, dynamic revisions, collection / multi-revision openers, and unresolvable/cyclic variable sources.
- **`VectorizedExecutor.acceptsSource(SourceRef)`** — new default method (accept-all) letting a resource-bound executor decline a scan over a document it isn't bound to. Non-resource-bound executors (e.g. bjq's file-backed `ParallelGroupByExec`) are unaffected.
- **`SequentialPipelineStrategy.tryVectorizedExpr`** consults `acceptsSource` at **translate time**, before substituting any vectorized expression. A decline falls back to the generic (always-correct) pipeline.

Declining only ever costs the fast path, never correctness. When `SOURCE_REF` is absent (legacy callers / hand-built ASTs) the gate is skipped, preserving the accept-all default.

## Tests

New `VectorizedSourceRefTest` (12 tests): identity extraction (jn:doc via let-bind, direct source, explicit revision, dynamic resource/revision → UNKNOWN, collection opener → UNKNOWN, context item, unresolved variable → UNKNOWN) and the translate-time gate (declined → generic pipeline, accepted → serves, absent SOURCE_REF → not gated, default accept-all serves).

Full suite: **1258 tests, 0 failures, 0 errors** (4 pre-existing skips).

## Downstream

Enables SirixDB (sirixdb/sirix#1125) to implement `SirixVectorizedExecutor.acceptsSource` (compare against its bound `(database, resource, revision)`, accept the context item, decline everything else) and retire the interim in-repo resource-scoping optimizer stage once a Brackit release ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSTM7PdhRXfK1tCoT9LyeR)_