### PR TITLE
Fix DerefExpr sequence dispatch and iterator sharing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.sirix</groupId>
     <artifactId>brackit</artifactId>
-    <version>1.0-alpha8-SNAPSHOT</version>
+    <version>1.0-alpha9-SNAPSHOT</version>
     <name>Brackit Engine</name>
     <description>A retargetable JSONiq query engine for semi-structured data</description>
     <url>https://github.com/sirixdb/brackit</url>

--- a/src/main/java/io/brackit/query/expr/DerefExpr.java
+++ b/src/main/java/io/brackit/query/expr/DerefExpr.java
@@ -61,29 +61,46 @@ public class DerefExpr implements Expr {
   public Sequence evaluate(QueryContext ctx, Tuple tuple) {
     Sequence sequence = object.evaluate(ctx, tuple);
 
+    if (sequence == null) {
+      return null;
+    }
+
     if (sequence instanceof ItemSequence itemSequence) {
-      return getLazySequence(ctx, tuple, itemSequence.iterate());
+      return getLazySequence(ctx, tuple, itemSequence);
     }
 
     if (sequence instanceof LazySequence lazySequence) {
-      return getLazySequence(ctx, tuple, lazySequence.iterate());
+      return getLazySequence(ctx, tuple, lazySequence);
     }
 
-    if (!(sequence instanceof Object obj)) {
+    if (sequence instanceof Object obj) {
+      Item itemField = field.evaluateToItem(ctx, tuple);
+      if (itemField == null) {
+        return null;
+      }
+      return getSequenceByRecordField(obj, itemField);
+    }
+
+    if (sequence instanceof Item) {
+      // A single non-record item (atomic, array): deref is the empty sequence.
       return null;
     }
 
-    Item itemField = field.evaluateToItem(ctx, tuple);
-    if (itemField == null) {
-      return null;
-    }
-    return getSequenceByRecordField(obj, itemField);
+    // Any other multi-item sequence implementation — e.g. the FlatteningSequence a
+    // parenthesized expression (SequenceExpr) evaluates to — is mapped per item just like
+    // the ItemSequence/LazySequence cases. Dispatching only on those two concrete classes
+    // made (for $x in ... return {"a": $x}).a evaluate to empty without ever running the
+    // pipeline.
+    return getLazySequence(ctx, tuple, sequence);
   }
 
-  private LazySequence getLazySequence(final QueryContext ctx, final Tuple tuple, final Iter iter) {
+  private LazySequence getLazySequence(final QueryContext ctx, final Tuple tuple, final Sequence base) {
     return new LazySequence() {
       @Override
       public Iter iterate() {
+        // A fresh base iterator per iterate() call: sharing one across calls would resume
+        // an exhausted iterator on the second pass.
+        final Iter iter = base.iterate();
         return new BaseIter() {
           @Override
           public Item next() {

--- a/src/test/java/io/brackit/query/JsonTest.java
+++ b/src/test/java/io/brackit/query/JsonTest.java
@@ -753,6 +753,50 @@ public final class JsonTest extends XQueryBaseTest {
   }
 
   @Test
+  public void derefExprOverParenthesizedFlwor() throws IOException {
+    // Regression: DerefExpr dispatched on the concrete ItemSequence/LazySequence classes
+    // only, so the FlatteningSequence a parenthesized expression evaluates to derefed to
+    // the EMPTY sequence without ever evaluating the pipeline — this used to return 0.
+    final String query = """
+          count((for $i in 1 to 3 return {"a": $i}).a)
+        """;
+    final var result = query(query);
+    assertEquals("3", result);
+  }
+
+  @Test
+  public void derefExprOverParenthesizedFlworSkipsRecordsWithoutField() throws IOException {
+    // Per-item mapping must skip records lacking the field (empty deref), not emit nulls.
+    final String query = """
+          count((for $i in 1 to 3 return if ($i eq 2) then {"b": $i} else {"a": $i}).a)
+        """;
+    final var result = query(query);
+    assertEquals("2", result);
+  }
+
+  @Test
+  public void derefExprOverParenthesizedSequenceOfRecords() throws IOException {
+    // Plain parenthesized record sequence — also a non-ItemSequence base before the fix.
+    final String query = """
+          ({"a": 1}, {"b": 2}, {"a": 3}).a
+        """;
+    final var result = query(query);
+    assertEquals("1 3", result);
+  }
+
+  @Test
+  public void derefExprLazySequenceIteratesFreshlyPerPass() throws IOException {
+    // Each iterate() on the deref result must open a fresh base iterator; a shared one
+    // resumed exhausted on the second pass and returned 3 instead of 6.
+    final String query = """
+          let $s := (for $i in 1 to 3 return {"a": $i}).a
+          return count($s) + count($s)
+        """;
+    final var result = query(query);
+    assertEquals("6", result);
+  }
+
+  @Test
   public void arrayUnboxing2() throws IOException {
     final String query = """
           let $array := [{"foo": 0}, "bar", {"baz": true}]


### PR DESCRIPTION
## Problem

`DerefExpr` dispatched on the concrete `ItemSequence`/`LazySequence` classes and silently derefed every other `Sequence` implementation to the **empty sequence** — notably `FlatteningSequence`, which is what a parenthesized expression (`SequenceExpr`) evaluates to. As a result:

```xquery
count((for $x in 1 to 3 return {"a": $x}).a)
```

returned `0` **without ever evaluating the pipeline**.

A second latent issue: the lazy mapping sequence captured **one shared base iterator**, so a second `iterate()` call resumed the exhausted first iteration (`count($s) + count($s)` over a let-bound deref returned 3 instead of 6).

## Fix

- Keep every original dispatch branch bit-identical, and add the missing tail: any other non-item `Sequence` is mapped lazily per item (non-record items still deref to empty, exactly like the original's per-item mapping).
- Open a fresh base iterator per `iterate()` call on the returned lazy sequence.

## Tests

Four regressions in `JsonTest`:
- parenthesized-FLWOR deref: `count((for $i in 1 to 3 return {"a": $i}).a)` → `3` (was `0`)
- records lacking the field are skipped: → `2`
- plain parenthesized record sequence: `({"a": 1}, {"b": 2}, {"a": 3}).a` → `1 3`
- double iteration is fresh: `count($s) + count($s)` → `6` (was `3`)

Full suite: 1262 tests, 0 failures, 0 errors.

Also bumps the version to `1.0-alpha9-SNAPSHOT` so downstream consumers (sirix) can pin a snapshot version that provably contains this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PavdHDQDnmk42QwygZE7Bq)_