### PR TITLE
Runtime-checkable VARIABLE source refs for vectorized serving

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.sirix</groupId>
     <artifactId>brackit</artifactId>
-    <version>1.0-alpha9-SNAPSHOT</version>
+    <version>1.0-alpha10-SNAPSHOT</version>
     <name>Brackit Engine</name>
     <description>A retargetable JSONiq query engine for semi-structured data</description>
     <url>https://github.com/sirixdb/brackit</url>

--- a/src/main/java/io/brackit/query/compiler/optimizer/SourceRef.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/SourceRef.java
@@ -5,6 +5,8 @@
  */
 package io.brackit.query.compiler.optimizer;
 
+import io.brackit.query.atomic.QNm;
+
 /**
  * Immutable identity of the document a vectorized scan reads from, lifted from the loop variable's
  * source expression by {@link io.brackit.query.compiler.optimizer.walker.topdown.VectorizedGroupByDetection}
@@ -18,7 +20,7 @@ package io.brackit.query.compiler.optimizer;
  * inspects it in {@link VectorizedExecutor#acceptsSource(SourceRef)} and declines a scan it is not
  * bound to serve, so the translator falls back to the generic (always-correct) pipeline.
  *
- * <p>Three kinds, matching what the detection can prove from the AST:
+ * <p>Four kinds, matching what the detection can prove from the AST:
  * <ul>
  * <li>{@link Kind#DOCUMENT} — the scan opens a concrete {@code jn:doc}/{@code jn:open} with literal
  * database/resource arguments; {@link #databaseName()}, {@link #resourceName()} and {@link #revision()}
@@ -26,9 +28,14 @@ package io.brackit.query.compiler.optimizer;
  * i.e. it opens the most-recent one).</li>
  * <li>{@link Kind#CONTEXT_ITEM} — the scan ranges over the query's context item (the caller's own bound
  * read transaction); no database/resource is named.</li>
+ * <li>{@link Kind#VARIABLE} — the scan ranges over a variable with no resolvable binding inside the
+ * query tree (typically {@code declare variable $doc external}, bound at execution time);
+ * {@link #variableName()} is populated. Compile-time gates should fail closed, but an executor can
+ * verify the actual runtime binding via
+ * {@link VectorizedExecutor#acceptsSource(SourceRef, io.brackit.query.QueryContext)}.</li>
  * <li>{@link Kind#UNKNOWN} — the source could not be proven to be a single concrete document (a dynamic
- * {@code jn:doc}, a collection/multi-revision opener, an unresolved variable, or a non-document
- * source). A resource-bound executor should fail closed on this.</li>
+ * {@code jn:doc}, a collection/multi-revision opener, or a non-document source). A resource-bound
+ * executor should fail closed on this.</li>
  * </ul>
  */
 public final class SourceRef {
@@ -38,22 +45,25 @@ public final class SourceRef {
 
   /** What the optimizer could prove about the scan's source document. */
   public enum Kind {
-    DOCUMENT, CONTEXT_ITEM, UNKNOWN
+    DOCUMENT, CONTEXT_ITEM, VARIABLE, UNKNOWN
   }
 
-  private static final SourceRef CONTEXT_ITEM = new SourceRef(Kind.CONTEXT_ITEM, null, null, LATEST_REVISION);
-  private static final SourceRef UNKNOWN = new SourceRef(Kind.UNKNOWN, null, null, LATEST_REVISION);
+  private static final SourceRef CONTEXT_ITEM = new SourceRef(Kind.CONTEXT_ITEM, null, null, LATEST_REVISION, null);
+  private static final SourceRef UNKNOWN = new SourceRef(Kind.UNKNOWN, null, null, LATEST_REVISION, null);
 
   private final Kind kind;
   private final String databaseName;
   private final String resourceName;
   private final int revision;
+  private final QNm variableName;
 
-  private SourceRef(final Kind kind, final String databaseName, final String resourceName, final int revision) {
+  private SourceRef(final Kind kind, final String databaseName, final String resourceName, final int revision,
+      final QNm variableName) {
     this.kind = kind;
     this.databaseName = databaseName;
     this.resourceName = resourceName;
     this.revision = revision;
+    this.variableName = variableName;
   }
 
   /**
@@ -68,7 +78,7 @@ public final class SourceRef {
     if (databaseName == null || resourceName == null) {
       throw new IllegalArgumentException("databaseName and resourceName must not be null");
     }
-    return new SourceRef(Kind.DOCUMENT, databaseName, resourceName, revision);
+    return new SourceRef(Kind.DOCUMENT, databaseName, resourceName, revision, null);
   }
 
   /** The query's context item — the caller's own bound read transaction. */
@@ -79,6 +89,24 @@ public final class SourceRef {
   /** An unprovable / non-single-document source; resource-bound executors should fail closed. */
   public static SourceRef unknown() {
     return UNKNOWN;
+  }
+
+  /**
+   * A scan whose source is a variable the optimizer could not resolve to a binding inside the
+   * query tree — typically an external variable bound at execution time via the query context.
+   * Unlike {@link Kind#UNKNOWN} this ref is verifiable at RUNTIME: an executor can resolve
+   * {@code variableName} through the {@code QueryContext}, inspect the actually-bound item, and
+   * accept or decline based on the concrete document it denotes (see
+   * {@link VectorizedExecutor#acceptsSource(SourceRef, io.brackit.query.QueryContext)}).
+   * Compile-time-only consumers should keep treating it like {@link Kind#UNKNOWN} (fail closed).
+   *
+   * @param variableName the referenced variable's name (must not be {@code null})
+   */
+  public static SourceRef variable(final QNm variableName) {
+    if (variableName == null) {
+      throw new IllegalArgumentException("variableName must not be null");
+    }
+    return new SourceRef(Kind.VARIABLE, null, null, LATEST_REVISION, variableName);
   }
 
   public Kind kind() {
@@ -105,6 +133,11 @@ public final class SourceRef {
     return resourceName;
   }
 
+  /** The referenced variable's name for a {@link Kind#VARIABLE} ref, else {@code null}. */
+  public QNm variableName() {
+    return variableName;
+  }
+
   /**
    * The explicit revision of a {@link Kind#DOCUMENT} ref, or {@link #LATEST_REVISION} when it opens the
    * most-recent revision. Always {@link #LATEST_REVISION} for the other kinds.
@@ -125,6 +158,7 @@ public final class SourceRef {
           ? ""
           : "@" + revision) + "]";
       case CONTEXT_ITEM -> "SourceRef[context-item]";
+      case VARIABLE -> "SourceRef[variable $" + variableName + "]";
       case UNKNOWN -> "SourceRef[unknown]";
     };
   }

--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
@@ -199,4 +199,24 @@ public interface VectorizedExecutor {
   default boolean acceptsSource(SourceRef source) {
     return true;
   }
+
+  /**
+   * Runtime-capable variant of {@link #acceptsSource(SourceRef)} for gates that run at
+   * EVALUATION time, when the {@link QueryContext} — and with it the actual binding of a
+   * {@link SourceRef.Kind#VARIABLE} source (an external variable such as
+   * {@code declare variable $doc external}) — is available. An executor can resolve
+   * {@code source.variableName()} through {@code ctx}, inspect the concrete item actually bound,
+   * and accept iff it denotes the executor's own resource/revision. Compile-time consumers keep
+   * calling the single-argument overload, which must stay fail-closed for VARIABLE refs.
+   *
+   * <p>The default delegates to {@link #acceptsSource(SourceRef)}, so existing executors keep
+   * their exact behaviour unless they opt in.
+   *
+   * @param source the scan's source identity; never {@code null} when the optimizer annotated the scan
+   * @param ctx    the evaluating query context (carries external-variable bindings)
+   * @return {@code true} to allow vectorized serving of this source, {@code false} to fall back
+   */
+  default boolean acceptsSource(SourceRef source, QueryContext ctx) {
+    return acceptsSource(source);
+  }
 }

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
@@ -638,7 +638,12 @@ public final class VectorizedGroupByDetection implements Stage {
           }
           final AST resolved = variableBindings.get(varKey);
           if (resolved == null) {
-            return SourceRef.unknown(); // a for-loop / outer variable, not a document binding
+            // No binding inside the query tree — typically an EXTERNAL variable bound at
+            // execution time (or a for-loop/outer variable). The document identity is not
+            // provable at compile time, but it IS verifiable at runtime by resolving the name
+            // through the QueryContext — so classify as VARIABLE (runtime-checkable), not
+            // UNKNOWN (hopeless). Compile-time gates still fail closed on VARIABLE.
+            return varKey instanceof QNm variableName ? SourceRef.variable(variableName) : SourceRef.unknown();
           }
           current = resolved;
         }

--- a/src/main/java/io/brackit/query/compiler/translator/BlockPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/BlockPipelineStrategy.java
@@ -81,11 +81,18 @@ public class BlockPipelineStrategy implements PipelineStrategy {
 
   @Override
   public Expr compilePipeExpr(AST node, Compiler compiler) throws QueryException {
-    // Check for vectorized scan annotations — delegates to shared logic
-    Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(node);
+    // Vectorized substitution (shared logic); VARIABLE sources decide per evaluation with the
+    // generic block pipeline as the runtime fallback — see RuntimeSourceGatedExpr.
+    Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(node,
+                                                                   false,
+                                                                   () -> compileGenericPipeExpr(node, compiler));
     if (vectorized != null)
       return vectorized;
+    return compileGenericPipeExpr(node, compiler);
+  }
 
+  /** The generic block pipeline compilation — the always-correct path/fallback. */
+  protected Expr compileGenericPipeExpr(AST node, Compiler compiler) throws QueryException {
     int initialBindSize = compiler.table.bound().length;
 
     // Collect blocks

--- a/src/main/java/io/brackit/query/compiler/translator/Compiler.java
+++ b/src/main/java/io/brackit/query/compiler/translator/Compiler.java
@@ -735,7 +735,9 @@ public class Compiler implements Translator {
     // The vectorized executor returns the count as a scalar Int64, so we replace the
     // entire count(PipeExpr) with the vectorized expression directly.
     if (COUNT_FN.equals(name.getLocalName()) && childCount == 1 && node.getChild(0).getType() == XQ.PipeExpr) {
-      Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(node.getChild(0), true);
+      Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(node.getChild(0),
+                                                                     true,
+                                                                     () -> resolveFunctionCall(node, name, childCount));
       if (vectorized != null) {
         return vectorized;
       }
@@ -759,7 +761,21 @@ public class Compiler implements Translator {
           final String[] sourcePath = (String[]) pipe.getProperty(VectorizedScanAnnotation.SOURCE_PATH_PREFIX);
           final var executor = SequentialPipelineStrategy.getVectorizedExecutor();
           if (field != null && executor != null) {
-            return VectorizedGroupByExpr.countDistinct(executor, sourcePath, field);
+            // Routed through the shared source gate (it previously built the expression with NO
+            // acceptsSource check — a resource-bound executor could serve a foreign document's
+            // count-distinct from its own columns). A decline falls through to the generic
+            // function resolution below; a VARIABLE source decides per evaluation.
+            Expr vectorized = SequentialPipelineStrategy.gateBySource(pipe,
+                                                                      executor,
+                                                                      () -> VectorizedGroupByExpr.countDistinct(executor,
+                                                                                                                sourcePath,
+                                                                                                                field),
+                                                                      () -> resolveFunctionCall(node,
+                                                                                                name,
+                                                                                                childCount));
+            if (vectorized != null) {
+              return vectorized;
+            }
           }
         }
       }
@@ -773,7 +789,11 @@ public class Compiler implements Translator {
         AST pipe = node.getChild(0);
         if (Boolean.TRUE.equals(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE))) {
           pipe.setProperty(VectorizedScanAnnotation.AGGREGATE_FUNC, fn);
-          Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(pipe);
+          Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(pipe,
+                                                                         false,
+                                                                         () -> resolveFunctionCall(node,
+                                                                                                   name,
+                                                                                                   childCount));
           if (vectorized != null) {
             return vectorized;
           }
@@ -788,7 +808,11 @@ public class Compiler implements Translator {
       if (COUNT_FN.equals(fn)) {
         AST pipe = node.getChild(0);
         if (Boolean.TRUE.equals(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_COUNT_DISTINCT))) {
-          Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(pipe, /*countWrapped=*/true);
+          Expr vectorized = SequentialPipelineStrategy.tryVectorizedExpr(pipe,
+                                                                         /*countWrapped=*/true,
+                                                                         () -> resolveFunctionCall(node,
+                                                                                                   name,
+                                                                                                   childCount));
           if (vectorized != null) {
             return vectorized;
           }
@@ -796,6 +820,15 @@ public class Compiler implements Translator {
       }
     }
 
+    return resolveFunctionCall(node, name, childCount);
+  }
+
+  /**
+   * Generic function-call resolution/compilation — the tail of {@link #functionCall(AST)},
+   * extracted so vectorized interceptions over a VARIABLE source can compile it as the
+   * runtime fallback of a {@link io.brackit.query.expr.RuntimeSourceGatedExpr}.
+   */
+  private Expr resolveFunctionCall(AST node, QNm name, int childCount) throws QueryException {
     Function function = ctx.getFunctions().resolve(name, childCount);
 
     final var signature = function.getSignature();

--- a/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
@@ -36,6 +36,7 @@ import io.brackit.query.compiler.optimizer.SourceRef;
 import io.brackit.query.compiler.optimizer.VectorizedExecutor;
 import io.brackit.query.compiler.optimizer.VectorizedScanAnnotation;
 import io.brackit.query.expr.PipeExpr;
+import io.brackit.query.expr.RuntimeSourceGatedExpr;
 import io.brackit.query.expr.VectorizedGroupByExpr;
 import io.brackit.query.operator.Count;
 import io.brackit.query.operator.ForBind;
@@ -154,11 +155,26 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
    * are only intercepted when wrapped in {@code count()}, because the
    * vectorized executor returns a scalar count — not the filtered items.
    */
-  public static Expr tryVectorizedExpr(AST node) {
+  public static Expr tryVectorizedExpr(AST node) throws QueryException {
     return tryVectorizedExpr(node, false);
   }
 
-  public static Expr tryVectorizedExpr(AST node, boolean countWrapped) {
+  public static Expr tryVectorizedExpr(AST node, boolean countWrapped) throws QueryException {
+    return tryVectorizedExpr(node, countWrapped, null);
+  }
+
+  /**
+   * Supplies the generic (always-correct) compilation of the SAME query fragment, for call sites
+   * able to compile both sides so a {@link SourceRef.Kind#VARIABLE} source can be decided per
+   * evaluation (see {@link RuntimeSourceGatedExpr}). May run the compiler, hence may throw.
+   */
+  @FunctionalInterface
+  public interface GenericExprSupplier {
+    Expr get() throws QueryException;
+  }
+
+  public static Expr tryVectorizedExpr(AST node, boolean countWrapped, GenericExprSupplier generic)
+      throws QueryException {
     // Thread-local override takes precedence — the SirixCompileChain
     // installs a per-compile executor here without touching the static.
     VectorizedExecutor executor = threadLocalExecutor.get();
@@ -174,10 +190,54 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
     // vectorized expression; a decline falls through to the generic (correct) pipeline.
     // The annotation is present on every walker-annotated scan; when absent (legacy
     // callers / hand-built ASTs) the executor's default accept-all applies unchanged.
-    final SourceRef sourceRef = (SourceRef) node.getProperty(VectorizedScanAnnotation.SOURCE_REF);
-    if (sourceRef != null && !executor.acceptsSource(sourceRef)) {
+    final VectorizedExecutor boundExecutor = executor;
+    return gateBySource(node, boundExecutor, () -> buildVectorizedExpr(node, countWrapped, boundExecutor), generic);
+  }
+
+  /** Lazily builds a vectorized expression once the source gate admits it (may yield {@code null}). */
+  @FunctionalInterface
+  public interface VectorizedExprSupplier {
+    Expr get();
+  }
+
+  /**
+   * SINGLE AUTHORITY for the source-identity gate. Every site that substitutes a vectorized
+   * expression for a scan MUST route through here — a site with its own (or no) gate is how a
+   * resource-bound executor ends up serving a scan over a document it is not bound to
+   * (wrong results). Semantics, by the annotated {@link SourceRef}:
+   * <ul>
+   * <li>no annotation — legacy/hand-built ASTs: the executor's default applies, admit;</li>
+   * <li>{@link SourceRef.Kind#VARIABLE} — unverifiable at compile time: when the caller can
+   * supply the generic compilation, substitute a {@link RuntimeSourceGatedExpr} deciding per
+   * evaluation against the actual binding; otherwise fail closed ({@code null});</li>
+   * <li>anything else — ask {@link VectorizedExecutor#acceptsSource(SourceRef)}; a decline
+   * returns {@code null} and the caller falls through to its generic compilation.</li>
+   * </ul>
+   */
+  public static Expr gateBySource(AST pipe, VectorizedExecutor executor, VectorizedExprSupplier vectorized,
+      GenericExprSupplier generic) throws QueryException {
+    final SourceRef sourceRef = (SourceRef) pipe.getProperty(VectorizedScanAnnotation.SOURCE_REF);
+    if (sourceRef == null) {
+      return vectorized.get();
+    }
+    if (sourceRef.kind() == SourceRef.Kind.VARIABLE) {
+      if (generic == null) {
+        return null;
+      }
+      final Expr vec = vectorized.get();
+      if (vec == null) {
+        return null;
+      }
+      return new RuntimeSourceGatedExpr(executor, sourceRef, vec, generic.get());
+    }
+    if (!executor.acceptsSource(sourceRef)) {
       return null;
     }
+    return vectorized.get();
+  }
+
+  /** The pattern matcher proper: builds the vectorized expression for an ACCEPTED source. */
+  private static Expr buildVectorizedExpr(AST node, boolean countWrapped, VectorizedExecutor executor) {
 
     // Source-path prefix (from the loop variable's IN clause). Threaded through
     // every vectorized Expr so the executor can combine it with per-predicate
@@ -273,11 +333,17 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
 
   @Override
   public Expr compilePipeExpr(AST node, Compiler compiler) throws QueryException {
-    // Check for vectorized scan annotations from the optimizer
-    Expr vectorized = tryVectorizedExpr(node);
+    // Vectorized substitution. For a VARIABLE source (an external variable, unverifiable at
+    // compile time) the generic pipeline is compiled as well and the choice is made per
+    // evaluation against the actual binding — see RuntimeSourceGatedExpr.
+    Expr vectorized = tryVectorizedExpr(node, false, () -> compileGenericPipeExpr(node, compiler));
     if (vectorized != null)
       return vectorized;
+    return compileGenericPipeExpr(node, compiler);
+  }
 
+  /** The generic (Volcano) pipeline compilation — the always-correct path/fallback. */
+  protected Expr compileGenericPipeExpr(AST node, Compiler compiler) throws QueryException {
     final int initialBindSize = compiler.table.bound().length;
     // AST-level pre-scan: decide whether morsel wrapping is safe BEFORE compilation
     // (avoids traversing a not-yet-built Operator graph whose upstream API varies).

--- a/src/main/java/io/brackit/query/expr/RuntimeSourceGatedExpr.java
+++ b/src/main/java/io/brackit/query/expr/RuntimeSourceGatedExpr.java
@@ -1,0 +1,76 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>
+ * All rights reserved.
+ */
+package io.brackit.query.expr;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.compiler.optimizer.SourceRef;
+import io.brackit.query.compiler.optimizer.VectorizedExecutor;
+import io.brackit.query.jdm.Expr;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.Tuple;
+import io.brackit.query.util.ExprUtil;
+
+/**
+ * Per-evaluation switch between a vectorized expression and its generic (always-correct)
+ * equivalent, for scans whose source is a {@link SourceRef.Kind#VARIABLE} — a variable with no
+ * binding inside the query tree, typically {@code declare variable $doc external} bound through
+ * the {@link QueryContext} at execution time.
+ *
+ * <p>Such a source is unverifiable when the translator must choose an expression (compile time),
+ * but fully verifiable once a context is in hand: the executor resolves the variable's actual
+ * binding via {@link VectorizedExecutor#acceptsSource(SourceRef, QueryContext)} and serves only
+ * a scan over its own bound resource/revision. A foreign or unresolvable binding evaluates the
+ * generic expression instead — same result, generic cost — so the vectorized fast path can never
+ * change an answer, only its speed (the same fail-closed contract as the compile-time gate).
+ */
+public final class RuntimeSourceGatedExpr implements Expr {
+
+  private final VectorizedExecutor executor;
+  private final SourceRef sourceRef;
+  private final Expr vectorized;
+  private final Expr generic;
+
+  public RuntimeSourceGatedExpr(final VectorizedExecutor executor, final SourceRef sourceRef, final Expr vectorized,
+      final Expr generic) {
+    if (executor == null || sourceRef == null || vectorized == null || generic == null) {
+      throw new IllegalArgumentException("executor, sourceRef, vectorized and generic must not be null");
+    }
+    this.executor = executor;
+    this.sourceRef = sourceRef;
+    this.vectorized = vectorized;
+    this.generic = generic;
+  }
+
+  @Override
+  public Sequence evaluate(final QueryContext ctx, final Tuple tuple) throws QueryException {
+    return executor.acceptsSource(sourceRef, ctx) ? vectorized.evaluate(ctx, tuple) : generic.evaluate(ctx, tuple);
+  }
+
+  @Override
+  public Item evaluateToItem(final QueryContext ctx, final Tuple tuple) throws QueryException {
+    return executor.acceptsSource(sourceRef, ctx)
+        ? ExprUtil.asItem(vectorized.evaluate(ctx, tuple))
+        : generic.evaluateToItem(ctx, tuple);
+  }
+
+  @Override
+  public boolean isUpdating() {
+    // Both branches compile the same query; the generic expression is authoritative.
+    return generic.isUpdating();
+  }
+
+  @Override
+  public boolean isVacuous() {
+    return generic.isVacuous();
+  }
+
+  @Override
+  public String toString() {
+    return "RuntimeSourceGatedExpr[" + sourceRef + "]";
+  }
+}

--- a/src/test/java/io/brackit/query/compiler/optimizer/VectorizedSourceRefTest.java
+++ b/src/test/java/io/brackit/query/compiler/optimizer/VectorizedSourceRefTest.java
@@ -13,6 +13,7 @@ import io.brackit.query.compiler.AST;
 import io.brackit.query.compiler.XQ;
 import io.brackit.query.compiler.optimizer.walker.topdown.VectorizedGroupByDetection;
 import io.brackit.query.compiler.translator.SequentialPipelineStrategy;
+import io.brackit.query.expr.RuntimeSourceGatedExpr;
 import io.brackit.query.expr.VectorizedGroupByExpr;
 import io.brackit.query.function.json.JSONFun;
 import io.brackit.query.jdm.Expr;
@@ -264,12 +265,18 @@ public class VectorizedSourceRefTest {
   }
 
   @Test
-  void unresolvedVariableSourceYieldsUnknown() {
-    // for $u in $mystery[] ... — $mystery is bound nowhere the walker can see.
+  void unresolvedVariableSourceYieldsRuntimeCheckableVariableRef() {
+    // for $u in $mystery[] ... — $mystery is bound nowhere the walker can see (typically an
+    // EXTERNAL variable bound at execution time). The identity is unprovable at compile time
+    // but verifiable at runtime by resolving the name through the QueryContext, so the walker
+    // classifies it VARIABLE (carrying the name) rather than the hopeless UNKNOWN. Compile-time
+    // gates still fail closed on VARIABLE; only runtime-capable call sites may serve it.
     AST pipe = groupByPipe("u", "c", "city", arrayAccess(varRef("mystery")), null, null);
     stage.rewrite(null, root(pipe));
 
-    assertEquals(SourceRef.Kind.UNKNOWN, sourceRefOf(pipe).kind());
+    SourceRef ref = sourceRefOf(pipe);
+    assertEquals(SourceRef.Kind.VARIABLE, ref.kind());
+    assertEquals(new QNm("mystery"), ref.variableName());
   }
 
   // ==================== translate-time gate: acceptsSource ====================
@@ -334,6 +341,70 @@ public class VectorizedSourceRefTest {
   // ==================== stubs ====================
 
   /** Executor that records the source it was asked about and answers a fixed accept/decline. */
+  // ==================== gateBySource: the single source-gate authority ====================
+
+  @Test
+  void gateAdmitsWhenNoSourceAnnotationIsPresent() throws QueryException {
+    AST pipe = new AST(XQ.PipeExpr);   // no SOURCE_REF property at all (legacy/hand-built AST)
+    RecordingExecutor executor = new RecordingExecutor(false);
+    Expr vec = dummyExpr();
+    assertEquals(vec, SequentialPipelineStrategy.gateBySource(pipe, executor, () -> vec, null));
+  }
+
+  @Test
+  void gateDeclinesAndReturnsNullWhenExecutorRefuses() throws QueryException {
+    AST pipe = new AST(XQ.PipeExpr);
+    pipe.setProperty(VectorizedScanAnnotation.SOURCE_REF, SourceRef.document("db", "res", -1));
+    RecordingExecutor executor = new RecordingExecutor(false);
+    assertNull(SequentialPipelineStrategy.gateBySource(pipe, executor, this::dummyExpr, null),
+               "a declined source must fall through to the caller's generic compilation");
+    assertTrue(executor.lastSource.isDocument());
+  }
+
+  @Test
+  void gateWrapsVariableSourceWhenGenericIsAvailable() throws QueryException {
+    AST pipe = new AST(XQ.PipeExpr);
+    pipe.setProperty(VectorizedScanAnnotation.SOURCE_REF, SourceRef.variable(new QNm("doc")));
+    RecordingExecutor executor = new RecordingExecutor(false);   // compile-time answer is irrelevant
+    Expr gated = SequentialPipelineStrategy.gateBySource(pipe, executor, this::dummyExpr, this::dummyExpr);
+    assertInstanceOf(RuntimeSourceGatedExpr.class,
+                     gated,
+                     "a VARIABLE source with a generic fallback must decide per evaluation");
+  }
+
+  @Test
+  void gateFailsClosedOnVariableSourceWithoutGenericFallback() throws QueryException {
+    AST pipe = new AST(XQ.PipeExpr);
+    pipe.setProperty(VectorizedScanAnnotation.SOURCE_REF, SourceRef.variable(new QNm("doc")));
+    RecordingExecutor executor = new RecordingExecutor(true);
+    assertNull(SequentialPipelineStrategy.gateBySource(pipe, executor, this::dummyExpr, null),
+               "no generic to fall back to at runtime -> must not substitute the vectorized expr");
+  }
+
+  private Expr dummyExpr() {
+    return new Expr() {
+      @Override
+      public io.brackit.query.jdm.Sequence evaluate(io.brackit.query.QueryContext ctx, io.brackit.query.Tuple tuple) {
+        return null;
+      }
+
+      @Override
+      public io.brackit.query.jdm.Item evaluateToItem(io.brackit.query.QueryContext ctx, io.brackit.query.Tuple tuple) {
+        return null;
+      }
+
+      @Override
+      public boolean isUpdating() {
+        return false;
+      }
+
+      @Override
+      public boolean isVacuous() {
+        return false;
+      }
+    };
+  }
+
   private static final class RecordingExecutor implements VectorizedExecutor {
     private final boolean accept;
     private SourceRef lastSource;


### PR DESCRIPTION
## Problem

External variables (`declare variable $doc external`) annotated their vectorized source as `SourceRef.Kind.UNKNOWN`. The fail-closed `acceptsSource` gate therefore declined **every** such query to the generic pipeline — a large regression for a common query shape (an external-variable document bound at execution time cannot be judged at compile time, and UNKNOWN means "decline").

## Change

Make an external-variable source *runtime-checkable* instead of unconditionally declined:

- **`SourceRef`** gains a `VARIABLE` kind carrying the variable's `QNm`. `VectorizedGroupByDetection` emits it for an unresolved variable source instead of `UNKNOWN` (a genuinely cyclic/unresolvable source still degrades to `UNKNOWN`).
- **`VectorizedExecutor`** gains a runtime `acceptsSource(SourceRef, QueryContext)` overload. New **`RuntimeSourceGatedExpr`** switches per evaluation between the vectorized expression and its generic equivalent once the actual binding is in hand — a foreign or unresolvable binding evaluates the generic side, so the fast path can never change an answer, only its speed (the same fail-closed contract as the compile-time gate).
- **`SequentialPipelineStrategy.gateBySource`** becomes the single admission authority, shared by `tryVectorizedExpr` and the previously-ungated `Compiler` `count(distinct-values(...))` interception: a `VARIABLE` ref compiles the vectorized expression alongside the generic and wraps them in `RuntimeSourceGatedExpr`; every other ref keeps the compile-time gate.
- **`BlockPipelineStrategy`** and the `Compiler` dispatch sites compile the generic fallback alongside for the runtime switch.

Version bumped to `1.0-alpha10-SNAPSHOT`.

## Tests

`VectorizedSourceRefTest` updated: an unresolved variable source now yields a runtime-checkable `VARIABLE` ref (was: `UNKNOWN`), plus four new `gateBySource` cases (admit-unannotated, decline-returns-null, VARIABLE-wraps-with-generic, VARIABLE-fails-closed-without-generic). Full suite green locally (1,266 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQXnze7z8t7P3GUZXKowyp)_