### PR TITLE
Stop copying the tuple array twice on every pipeline row

### DIFF
--- a/src/main/java/io/brackit/query/operator/TupleImpl.java
+++ b/src/main/java/io/brackit/query/operator/TupleImpl.java
@@ -51,7 +51,37 @@ public final class TupleImpl implements Tuple {
   }
 
   public TupleImpl(Sequence[] t) {
+    // Defensive: the caller keeps its array and array() below hands ours straight out, so sharing
+    // one would let a caller mutate a live tuple.
     sequences = Arrays.copyOf(t, t.length);
+  }
+
+  /**
+   * Marker selecting the constructor that adopts its array instead of copying it.
+   *
+   * <p>A marker rather than a boolean so the call sites read as what they are, and so the adopting
+   * form cannot be selected by accident from outside.
+   */
+  private enum Adopted {
+    ADOPTED
+  }
+
+  /**
+   * Takes ownership of {@code t} rather than copying it.
+   *
+   * <p>Private, and sound only for an array this class has just built and no one else can reach.
+   * Every operation below allocates its result array locally and then discards the reference, so
+   * the public constructor's defensive copy was pure waste on each of them — it made every tuple
+   * derivation allocate TWO arrays and keep one.
+   *
+   * <p>This is the whole per-row cost of a pipeline. Allocation-profiled on a 290,184-record
+   * {@code count(for $m in $doc[] where $m.year > 1990 return $m)}, 99.7 % of everything the query
+   * allocated came from {@code ForBind.emit -> concat}: a width 0 -> 1 tuple cost 24 B for the
+   * array, 24 B for its immediate copy and 16 B for the tuple, i.e. 64 B per row of which a third
+   * was garbage on arrival.
+   */
+  private TupleImpl(Sequence[] t, Adopted adopted) {
+    sequences = t;
   }
 
   @Override
@@ -61,7 +91,7 @@ public final class TupleImpl implements Tuple {
     for (int pos : positions) {
       projected[targetPos++] = get(pos);
     }
-    return new TupleImpl(projected);
+    return new TupleImpl(projected, Adopted.ADOPTED);
   }
 
   @Override
@@ -72,7 +102,7 @@ public final class TupleImpl implements Tuple {
     if ((end < start) || (end >= sequences.length)) {
       throw new QueryException(ErrorCode.BIT_DYN_RT_OUT_OF_BOUNDS_ERROR, end);
     }
-    return new TupleImpl(Arrays.copyOfRange(sequences, start, end));
+    return new TupleImpl(Arrays.copyOfRange(sequences, start, end), Adopted.ADOPTED);
   }
 
   @Override
@@ -82,21 +112,21 @@ public final class TupleImpl implements Tuple {
     }
     Sequence[] tmp = Arrays.copyOf(sequences, sequences.length);
     tmp[position] = s;
-    return new TupleImpl(tmp);
+    return new TupleImpl(tmp, Adopted.ADOPTED);
   }
 
   @Override
   public Tuple concat(Sequence s) {
     Sequence[] tmp = Arrays.copyOf(sequences, sequences.length + 1);
     tmp[sequences.length] = s;
-    return new TupleImpl(tmp);
+    return new TupleImpl(tmp, Adopted.ADOPTED);
   }
 
   @Override
   public Tuple concat(Sequence[] s) {
     Sequence[] tmp = Arrays.copyOf(sequences, sequences.length + s.length);
     System.arraycopy(s, 0, tmp, sequences.length, s.length);
-    return new TupleImpl(tmp);
+    return new TupleImpl(tmp, Adopted.ADOPTED);
   }
 
   @Override
@@ -108,7 +138,7 @@ public final class TupleImpl implements Tuple {
     Sequence[] tmp = Arrays.copyOf(sequences, nLen);
     tmp[sequences.length] = s;
     tmp[position] = s;
-    return new TupleImpl(tmp);
+    return new TupleImpl(tmp, Adopted.ADOPTED);
   }
 
   @Override
@@ -120,7 +150,7 @@ public final class TupleImpl implements Tuple {
     Sequence[] tmp = Arrays.copyOf(sequences, nLen);
     System.arraycopy(con, 0, tmp, sequences.length, con.length);
     tmp[position] = s;
-    return new TupleImpl(tmp);
+    return new TupleImpl(tmp, Adopted.ADOPTED);
   }
 
   @Override


### PR DESCRIPTION
## What this does

`TupleImpl` derives a new tuple by building a fresh array and handing it to the public constructor — which copies it again:

```java
public Tuple concat(Sequence s) {
  Sequence[] tmp = Arrays.copyOf(sequences, sequences.length + 1);
  tmp[sequences.length] = s;
  return new TupleImpl(tmp);          // ctor: Arrays.copyOf(t, t.length)
}
```

So every `concat`/`project`/`replace`/`conreplace` allocated **two** arrays and kept one.

The constructor's defensive copy is correct for a caller-owned array — `array()` hands the internal one straight out, so sharing would let a caller mutate a live tuple — but every call site *inside* this class passes an array it just built and then drops, where the copy is pure waste. Those seven sites now go through a private constructor that adopts its array. The public constructor is unchanged, so no caller outside the class is affected.

## Why it matters

This is the whole per-row cost of a pipeline. Allocation-profiled with async-profiler through SirixDB on a 290,184-record

```
count(for $m in $doc[] where $m.year > 1990 return $m)
```

**99.7% of everything the query allocated came from one site**, `ForBind.emit -> TupleImpl.concat`:

| share | type |
|---|---|
| 74.25% | `Sequence[]` (the two arrays) |
| 25.42% | `TupleImpl` |
| 0.33% | everything else |

A width 0→1 tuple costs 24 B for the array, 24 B for its immediate copy, and 16 B for the tuple — 64 B per row, a third of it garbage on arrival.

Measured end to end, JMH `gc` profiler, 3 warmup + 5 measurement iterations:

| query | alloc before | alloc after | delta |
|---|---|---|---|
| `filterCountYear` | 18,631,304 B/op | 11,666,824 B/op | **−37.4%** |
| `titleLookup` | 18,631,600 B/op | 11,667,146 B/op | **−37.4%** |

64.2 → 40.2 B per record — exactly the 24 B of the duplicated array. Allocation rate falls from 810 to 596 MB/s.

## Wall clock does not move, and my first measurement said otherwise

At 5 iterations `filterCountYear` read 21.9 → 18.7 ms/op, which looks like 15%. At **2 forks × 15 iterations** it is **21.010 ± 0.578 ms/op before and 20.656 ± 0.701 after** — intervals that overlap, so there is no speedup to claim. The allocations are TLAB-cheap and GC was keeping up (46 ms of GC across the run).

What this buys is 7 MB less garbage per query, which is worth having under concurrency and at larger scale — not a faster single query.

## Testing

- brackit suite: **1266 tests, 0 failures, 0 errors, 4 skipped**.
- Consuming project (SirixDB) built against this jar: core **9709 tests**, query **1009 tests**, 0 failures, 0 errors.

No new tests: this changes no observable behaviour: `array()`, `get`, `getSize` and every derivation return exactly what they did before. What changed is how many arrays are allocated to get there, which the allocation numbers above cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHohFkejFK1XLhfQTb8icb)_