### PR TITLE
Claim two predicate/aggregate shapes backends can serve: array membership and binary arithmetic aggregates

### DIFF
--- a/src/main/java/io/brackit/query/compiler/optimizer/PredicateNode.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/PredicateNode.java
@@ -30,7 +30,7 @@ import java.util.List;
  * leave the annotation off the AST so the generic Volcano pipeline handles
  * the query.
  */
-public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNode.FpCmp, PredicateNode.DecCmp, PredicateNode.StrEq, PredicateNode.BoolRef, PredicateNode.And, PredicateNode.Or, PredicateNode.Not, PredicateNode.AlwaysTrue, PredicateNode.AlwaysFalse {
+public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNode.FpCmp, PredicateNode.DecCmp, PredicateNode.StrEq, PredicateNode.ArrayContains, PredicateNode.BoolRef, PredicateNode.And, PredicateNode.Or, PredicateNode.Not, PredicateNode.AlwaysTrue, PredicateNode.AlwaysFalse {
 
   /**
    * Numeric comparison {@code $u.field <op> literal}. {@code op} is one of
@@ -87,6 +87,22 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
 
   /** String equality {@code $u.field eq "literal"}. */
   record StrEq(String field, String value) implements PredicateNode {
+  }
+
+  /**
+   * Membership in an array-valued field: {@code some $g in $u.field[] satisfies $g eq "literal"}.
+   *
+   * <p>Distinct from {@link StrEq} because the field holds a SEQUENCE, and a backend answering it
+   * must test every element rather than one value — a difference that decides which column, and
+   * which linkage, it has to read.
+   *
+   * <p>Soundly anchorable on {@code field}, and for the ordinary reason: a record that does not
+   * carry the field carries no element either, so it cannot satisfy the quantifier. An empty array
+   * likewise satisfies nothing, which is what makes the existential the anchorable direction and
+   * a universal ({@code every ... satisfies}) not — that one is TRUE on a record with no array at
+   * all, so it is not expressed here.
+   */
+  record ArrayContains(String field, String value) implements PredicateNode {
   }
 
   /**
@@ -160,6 +176,7 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
       case FpCmp f -> into.add(f.field);
       case DecCmp d -> into.add(d.field);
       case StrEq s -> into.add(s.field);
+      case ArrayContains c -> into.add(c.field);
       case BoolRef b -> into.add(b.field);
       case And a -> {
         for (PredicateNode c : a.children)
@@ -203,6 +220,10 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
       case NumCmp n -> n.field.equals(field);
       case FpCmp f -> f.field.equals(field);
       case DecCmp d -> d.field.equals(field);
+      // A record without the field has no element to satisfy the quantifier — and an EMPTY
+      // array satisfies nothing either, which is what makes the existential form the
+      // anchorable one.
+      case ArrayContains c -> c.field.equals(field);
       case StrEq s -> s.field.equals(field);
       case BoolRef b -> b.field.equals(field);
       case And a -> {
@@ -237,6 +258,7 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
       case NumCmp n -> false;
       case FpCmp f -> false;
       case DecCmp d -> false;
+      case ArrayContains c -> false;
       case StrEq s -> false;
       case BoolRef b -> false;
       case And a -> {
@@ -310,6 +332,7 @@ public sealed interface PredicateNode permits PredicateNode.NumCmp, PredicateNod
       case NumCmp n -> true;
       case FpCmp f -> true;
       case DecCmp d -> true;
+      case ArrayContains c -> true;
       case StrEq s -> true;
       case BoolRef b -> true;
       // A conjunction is claimable only on a GLOBAL anchor: one conjunct whose field every

--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedExecutor.java
@@ -119,6 +119,34 @@ public interface VectorizedExecutor {
    *
    * @param field the field's local name to count distinct values of
    */
+  /**
+   * Whether {@link #executeBinaryAggregate} is actually implemented. Declared up front for the same
+   * reason as {@link #supportsSortedScan()}: the dispatcher decides at TRANSLATE time.
+   */
+  default boolean supportsBinaryAggregate() {
+    return false;
+  }
+
+  /**
+   * Aggregate over an ARITHMETIC expression of two fields — {@code sum($m.width * $m.height)} —
+   * rather than over one field's values.
+   *
+   * <p>The single-field {@link #executeAggregate} cannot express it, and a backend that extracted
+   * one operand from the expression would aggregate the wrong values, so the walker refuses to
+   * claim the shape at all unless a backend says it can serve it. Columnar backends can: both
+   * operands are columns, and the product is one fused pass over the two.
+   *
+   * @param func one of {@code sum}, {@code avg}, {@code min}, {@code max}
+   * @param op   {@code "*"}, {@code "+"} or {@code "-"} — the operators for which a
+   *             record-at-a-time evaluation and a column-at-a-time one agree exactly on the
+   *             integers and doubles a JSON document holds
+   * @return the aggregate, or {@code null} for "unsupported" (the caller keeps its generic path)
+   */
+  default Sequence executeBinaryAggregate(QueryContext ctx, String[] sourcePath, String func, String leftField,
+      String op, String rightField) throws QueryException {
+    return null;
+  }
+
   default Sequence executeCountDistinct(QueryContext ctx, String[] sourcePath, String field) throws QueryException {
     return null;
   }

--- a/src/main/java/io/brackit/query/compiler/optimizer/VectorizedScanAnnotation.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/VectorizedScanAnnotation.java
@@ -104,6 +104,18 @@ public final class VectorizedScanAnnotation {
   /** Aggregate field name (String). */
   public static final String AGGREGATE_FIELD = "VECTORIZED_AGGREGATE_FIELD";
 
+  /**
+   * The two operand fields and the operator of an aggregate over an ARITHMETIC return expression —
+   * {@code sum(for $m in ... return $m.a * $m.b)} — as {@code {left, op, right}}, where {@code op}
+   * is one of {@code "*"}, {@code "+"}, {@code "-"}.
+   *
+   * <p>Set INSTEAD of {@link #AGGREGATE_FIELD}, never beside it: the two say different things about
+   * what the executor must compute, and a backend reading the wrong one aggregates a single column
+   * where the query asked for a product. A backend that does not implement the shape declines via
+   * {@code VectorizedExecutor#supportsBinaryAggregate} and the generic pipeline answers.
+   */
+  public static final String AGGREGATE_BINARY = "VECTORIZED_AGGREGATE_BINARY";
+
   /** Count-distinct target field (local-name String). */
   public static final String COUNT_DISTINCT_FIELD = "VECTORIZED_COUNT_DISTINCT_FIELD";
 

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
@@ -199,6 +199,11 @@ public final class VectorizedGroupByDetection implements Stage {
     // would turn `return $u.a + $u.b` into an aggregate over field `a` alone.
     final String returnField = directLoopVarDerefField(returnExpr, loopVar);
 
+    // ... or an ARITHMETIC expression over two of the loop variable's fields. Kept strictly apart
+    // from returnField: `return $u.a * $u.b` must never be claimed as an aggregate over `a`, which
+    // is what descending into the subtree for a field name would produce.
+    final String[] returnBinary = binaryLoopVarDeref(returnExpr, loopVar);
+
     // ---- Annotate based on detected pattern ----
 
     if (!chainUnderstood) {
@@ -326,6 +331,12 @@ public final class VectorizedGroupByDetection implements Stage {
     if (!hasGroupBy && !hasOrderBy && predicateStrictlyAnchored && returnField != null) {
       pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE, Boolean.TRUE);
       pipeExpr.setProperty(VectorizedScanAnnotation.AGGREGATE_FIELD, returnField);
+    } else if (!hasGroupBy && !hasOrderBy && predicateStrictlyAnchored && returnBinary != null) {
+      // Same claim, arithmetic return. AGGREGATE_FIELD stays unset — the two properties are
+      // alternatives and a backend reading the wrong one would aggregate one column where the
+      // query asked for a product.
+      pipeExpr.setProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE, Boolean.TRUE);
+      pipeExpr.setProperty(VectorizedScanAnnotation.AGGREGATE_BINARY, returnBinary);
     }
 
     // Count-distinct candidate: a single-key group-by whose return expression is
@@ -359,6 +370,35 @@ public final class VectorizedGroupByDetection implements Stage {
     if (base.getType() != XQ.VariableRef || !loopVar.equals(base.getValue() instanceof QNm qnm ? qnm : null))
       return null;
     return qnmLocalName(expr.getChild(expr.getChildCount() - 1).getValue());
+  }
+
+  /**
+   * {@code {left, op, right}} iff {@code expr} is {@code $loopVar.a OP $loopVar.b} for an operator
+   * whose column-at-a-time evaluation is exactly its record-at-a-time one; {@code null} otherwise.
+   *
+   * <p>Multiplication, addition and subtraction only. Division is excluded deliberately: over the
+   * integers a JSON document holds it is not closed, and {@code sum(a div b)} over a column of
+   * exact decimals is not the sum of the doubles a columnar kernel would produce — a difference the
+   * generic pipeline would not have. Both operands must be DIRECT derefs of the loop variable, for
+   * the reason {@link #directLoopVarDerefField} gives: anything else computes over other values
+   * than the query names.
+   */
+  private String[] binaryLoopVarDeref(final AST expr, final QNm loopVar) {
+    if (expr == null || expr.getType() != XQ.ArithmeticExpr || expr.getChildCount() != 3) {
+      return null;
+    }
+    final String op = switch (expr.getChild(0).getType()) {
+      case XQ.MultiplyOp -> "*";
+      case XQ.AddOp -> "+";
+      case XQ.SubtractOp -> "-";
+      default -> null;
+    };
+    if (op == null) {
+      return null;
+    }
+    final String left = directLoopVarDerefField(expr.getChild(1), loopVar);
+    final String right = directLoopVarDerefField(expr.getChild(2), loopVar);
+    return left == null || right == null ? null : new String[] { left, op, right };
   }
 
   /**

--- a/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
+++ b/src/main/java/io/brackit/query/compiler/optimizer/walker/topdown/VectorizedGroupByDetection.java
@@ -851,6 +851,11 @@ public final class VectorizedGroupByDetection implements Stage {
       return negated == null ? null : new PredicateNode.Not(negated);
     }
 
+    // some $g in $u.field[] satisfies $g eq "literal" — membership in an array-valued field.
+    if (type == XQ.QuantifiedExpr) {
+      return arrayContains(node, loopVar);
+    }
+
     if (type == XQ.AndExpr) {
       List<PredicateNode> kids = new ArrayList<>(node.getChildCount());
       for (int i = 0; i < node.getChildCount(); i++) {
@@ -917,6 +922,84 @@ public final class VectorizedGroupByDetection implements Stage {
         return new PredicateNode.StrEq(field, sv);
     }
     return null;
+  }
+
+  /**
+   * {@code some $g in $u.field[] satisfies $g eq "literal"} as a {@link PredicateNode.ArrayContains}.
+   *
+   * <p>EXISTENTIAL only. {@code every $g in ... satisfies ...} is vacuously TRUE on a record whose
+   * array is empty — and on one that has no such field at all — so it cannot anchor on that field,
+   * which is the property every backend here relies on to visit candidate records at all.
+   *
+   * <p>The index must be the EMPTY sequence: {@code $u.f[]} iterates every element, while
+   * {@code $u.f[[1]]} names one, and reading the second as the first would test a different value.
+   */
+  private PredicateNode arrayContains(final AST node, final QNm loopVar) {
+    if (!ARRAY_CONTAINS_CLAIMED) {
+      return null;
+    }
+    if (node.getChildCount() != 3 || node.getChild(0).getType() != XQ.SomeQuantifier) {
+      return null;
+    }
+    final AST binding = node.getChild(1);
+    if (binding.getType() != XQ.QuantifiedBinding || binding.getChildCount() != 2) {
+      return null;
+    }
+    final AST typedBinding = binding.getChild(0);
+    if (typedBinding.getType() != XQ.TypedVariableBinding || typedBinding.getChildCount() < 1) {
+      return null;
+    }
+    final AST variable = typedBinding.getChild(0);
+    if (variable.getType() != XQ.Variable || !(variable.getValue() instanceof QNm boundVar)) {
+      return null;
+    }
+    final AST access = binding.getChild(1);
+    if (access.getType() != XQ.ArrayAccess || access.getChildCount() != 2) {
+      return null;
+    }
+    final AST index = access.getChild(1);
+    if (index.getType() != XQ.SequenceExpr || index.getChildCount() != 0) {
+      return null;
+    }
+    final String field = directLoopVarDerefField(access.getChild(0), loopVar);
+    if (field == null) {
+      return null;
+    }
+    final AST comparison = node.getChild(2);
+    if (comparison.getType() != XQ.ComparisonExpr || comparison.getChildCount() != 3) {
+      return null;
+    }
+    final int cmp = comparison.getChild(0).getType();
+    if (cmp != XQ.ValueCompEQ && cmp != XQ.GeneralCompEQ) {
+      return null;
+    }
+    String value = literalComparedToBoundVar(comparison.getChild(1), comparison.getChild(2), boundVar);
+    if (value == null) {
+      value = literalComparedToBoundVar(comparison.getChild(2), comparison.getChild(1), boundVar);
+    }
+    return value == null ? null : new PredicateNode.ArrayContains(field, value);
+  }
+
+  /**
+   * Whether the array-membership shape is claimed for backends at all.
+   *
+   * <p>On, with a kill switch. The claim was not free to make: an anchored backend reaches
+   * candidate records through the anchor field's slots, and a field whose value is an ARRAY was not
+   * returned by that lookup at all — measured, the scan visited nothing and counted zero where the
+   * interpreter counted 686. That gap is closed on the storage side (the name-key column now uses
+   * the field-name ROLE predicate rather than the primitive-layout one); the switch stays so the
+   * claim can be taken back without a rebuild if a shape turns up that a backend mishandles.
+   */
+  private static final boolean ARRAY_CONTAINS_CLAIMED = !"false".equalsIgnoreCase(System.getProperty(
+                                                                                                     "brackit.predicate.arrayContains",
+                                                                                                     "true"));
+
+  /** The string literal, when {@code varSide} IS the quantifier's bound variable. */
+  private String literalComparedToBoundVar(final AST varSide, final AST literalSide, final QNm boundVar) {
+    if (varSide.getType() != XQ.VariableRef || !boundVar.equals(varSide.getValue())) {
+      return null;
+    }
+    return extractStringLiteral(literalSide);
   }
 
   private String getComparisonOp(int type) {

--- a/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
+++ b/src/main/java/io/brackit/query/compiler/translator/SequentialPipelineStrategy.java
@@ -36,6 +36,7 @@ import io.brackit.query.compiler.optimizer.SourceRef;
 import io.brackit.query.compiler.optimizer.VectorizedExecutor;
 import io.brackit.query.compiler.optimizer.VectorizedScanAnnotation;
 import io.brackit.query.expr.PipeExpr;
+import io.brackit.query.expr.FallbackOnNullExpr;
 import io.brackit.query.expr.RuntimeSourceGatedExpr;
 import io.brackit.query.expr.VectorizedGroupByExpr;
 import io.brackit.query.operator.Count;
@@ -225,7 +226,19 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
       GenericExprSupplier generic) throws QueryException {
     final SourceRef sourceRef = (SourceRef) pipe.getProperty(VectorizedScanAnnotation.SOURCE_REF);
     if (sourceRef == null) {
-      return vectorized.get(executor);
+      final Expr unannotated = vectorized.get(executor);
+      if (unannotated == null || pipe.getProperty(VectorizedScanAnnotation.AGGREGATE_BINARY) == null || generic
+          == null) {
+        return unannotated;
+      }
+      return new FallbackOnNullExpr(unannotated, generic.get());
+    }
+    // An aggregate over an arithmetic expression declines per EVALUATION, so it may only be
+    // substituted where a generic compilation is still available to fall back to.
+    final boolean binaryAggregate = pipe.getProperty(VectorizedScanAnnotation.AGGREGATE_BINARY) != null && Boolean.TRUE
+                                                                                                                       .equals(pipe.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE));
+    if (binaryAggregate && generic == null) {
+      return null;
     }
     if (sourceRef.kind() == SourceRef.Kind.VARIABLE) {
       if (generic == null) {
@@ -237,7 +250,11 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
       if (vec == null) {
         return null;
       }
-      return new RuntimeSourceGatedExpr(executor, sourceRef, vec, generic.get());
+      final Expr genericExpr = generic.get();
+      return new RuntimeSourceGatedExpr(executor,
+                                        sourceRef,
+                                        binaryAggregate ? new FallbackOnNullExpr(vec, genericExpr) : vec,
+                                        genericExpr);
     }
     if (!executor.acceptsSource(sourceRef)) {
       return null;
@@ -245,7 +262,11 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
     // Build against the executor bound to THIS source, which for a single-resource executor is the
     // same object and for a multi-resource one is the instance that reads the right document.
     final VectorizedExecutor boundToSource = executor.executorForSource(sourceRef);
-    return vectorized.get(boundToSource == null ? executor : boundToSource);
+    final Expr vec = vectorized.get(boundToSource == null ? executor : boundToSource);
+    if (vec == null || !binaryAggregate) {
+      return vec;
+    }
+    return new FallbackOnNullExpr(vec, generic.get());
   }
 
   /** The pattern matcher proper: builds the vectorized expression for an ACCEPTED source. */
@@ -342,6 +363,16 @@ public class SequentialPipelineStrategy implements PipelineStrategy {
     if (Boolean.TRUE.equals(node.getProperty(VectorizedScanAnnotation.VECTORIZED_AGGREGATE))) {
       String func = (String) node.getProperty(VectorizedScanAnnotation.AGGREGATE_FUNC);
       String field = (String) node.getProperty(VectorizedScanAnnotation.AGGREGATE_FIELD);
+      String[] binary = (String[]) node.getProperty(VectorizedScanAnnotation.AGGREGATE_BINARY);
+      if (func != null && binary != null) {
+        // An arithmetic return. No predicate variant: a filtered product has no kernel yet, and
+        // claiming one the backend does not have would substitute an expression that returns null
+        // at evaluate time — past the point where a generic pipeline is still available.
+        if (!executor.supportsBinaryAggregate() || node.getProperty(VectorizedScanAnnotation.PREDICATE_TREE) != null) {
+          return null;
+        }
+        return VectorizedGroupByExpr.binaryAggregate(executor, sourcePath, func, binary);
+      }
       if (func != null) {
         PredicateNode predicate = (PredicateNode) node.getProperty(VectorizedScanAnnotation.PREDICATE_TREE);
         if (predicate != null) {

--- a/src/main/java/io/brackit/query/expr/FallbackOnNullExpr.java
+++ b/src/main/java/io/brackit/query/expr/FallbackOnNullExpr.java
@@ -1,0 +1,57 @@
+package io.brackit.query.expr;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.Tuple;
+import io.brackit.query.jdm.Expr;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Sequence;
+
+/**
+ * Runs a vectorized expression and falls back to the generic one when it answers {@code null}.
+ *
+ * <p>Most vectorized substitutions decide at COMPILE time whether a backend can serve them, which
+ * is why the dispatcher normally treats a {@code null} at evaluate time as an error: there is no
+ * generic pipeline left by then. One shape cannot be decided that early. Whether a columnar store
+ * covers BOTH operand columns of {@code sum($m.a * $m.b)} depends on the document the query is
+ * finally run against — an externally bound variable resolves per evaluation, and a commit can
+ * invalidate the store between two runs of one compiled query.
+ *
+ * <p>So that shape keeps its generic compilation and chooses per evaluation. {@code null} means
+ * "not served" and nothing else: an empty aggregate is an empty SEQUENCE, never null.
+ */
+public final class FallbackOnNullExpr implements Expr {
+
+  private final Expr vectorized;
+  private final Expr generic;
+
+  public FallbackOnNullExpr(final Expr vectorized, final Expr generic) {
+    if (vectorized == null || generic == null) {
+      throw new IllegalArgumentException("both expressions are required");
+    }
+    this.vectorized = vectorized;
+    this.generic = generic;
+  }
+
+  @Override
+  public Sequence evaluate(final QueryContext ctx, final Tuple tuple) throws QueryException {
+    final Sequence served = vectorized.evaluate(ctx, tuple);
+    return served != null ? served : generic.evaluate(ctx, tuple);
+  }
+
+  @Override
+  public Item evaluateToItem(final QueryContext ctx, final Tuple tuple) throws QueryException {
+    final Item served = vectorized.evaluateToItem(ctx, tuple);
+    return served != null ? served : generic.evaluateToItem(ctx, tuple);
+  }
+
+  @Override
+  public boolean isUpdating() {
+    return vectorized.isUpdating() || generic.isUpdating();
+  }
+
+  @Override
+  public boolean isVacuous() {
+    return vectorized.isVacuous() && generic.isVacuous();
+  }
+}

--- a/src/main/java/io/brackit/query/expr/VectorizedGroupByExpr.java
+++ b/src/main/java/io/brackit/query/expr/VectorizedGroupByExpr.java
@@ -42,7 +42,7 @@ import io.brackit.query.jdm.Sequence;
 public final class VectorizedGroupByExpr implements Expr {
 
   public enum Mode {
-    GROUP_BY, GROUP_BY_MULTI, SORTED_SCAN, AGGREGATE, COUNT_DISTINCT, GENERIC_PREDICATE_COUNT, GENERIC_PREDICATE_GROUPBY, GENERIC_PREDICATE_AGGREGATE
+    GROUP_BY, GROUP_BY_MULTI, SORTED_SCAN, AGGREGATE, BINARY_AGGREGATE, COUNT_DISTINCT, GENERIC_PREDICATE_COUNT, GENERIC_PREDICATE_GROUPBY, GENERIC_PREDICATE_AGGREGATE
   }
 
   private final VectorizedExecutor executor;
@@ -192,6 +192,31 @@ public final class VectorizedGroupByExpr implements Expr {
                                      field);
   }
 
+  /**
+   * Aggregate over an arithmetic expression of two fields, e.g. {@code sum($m.width * $m.height)}.
+   *
+   * <p>{@code binary} is {@code {left, op, right}}. Held as an array rather than three fields
+   * because every other mode leaves it null, and a constructor that already carries nine arguments
+   * should not grow three more for one of them.
+   */
+  public static VectorizedGroupByExpr binaryAggregate(VectorizedExecutor executor, String[] sourcePath, String func,
+      String[] binary) {
+    final VectorizedGroupByExpr expr = new VectorizedGroupByExpr(executor,
+                                                                 Mode.BINARY_AGGREGATE,
+                                                                 sourcePath,
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 null,
+                                                                 func,
+                                                                 null);
+    expr.binaryOperands = binary;
+    return expr;
+  }
+
+  /** {@code {left, op, right}} for {@link Mode#BINARY_AGGREGATE}; null for every other mode. */
+  private String[] binaryOperands;
+
   /** Which vectorized path this expression dispatches to. Exposed for dispatch-correctness tests. */
   public Mode getMode() {
     return mode;
@@ -219,6 +244,16 @@ public final class VectorizedGroupByExpr implements Expr {
                                            "sorted scan");
       case AGGREGATE -> requireSupported(executor.executeAggregate(ctx, sourcePath, aggregateFunc, aggregateField),
                                          "aggregate");
+      // Deliberately NOT requireSupported: this is the one mode whose backend may decline per
+      // EVALUATION rather than per compile — whether a columnar store covers both operand columns
+      // is not knowable when the capability is declared. FallbackOnNullExpr keeps the generic
+      // pipeline behind it and uses it when the answer is null.
+      case BINARY_AGGREGATE -> executor.executeBinaryAggregate(ctx,
+                                                               sourcePath,
+                                                               aggregateFunc,
+                                                               binaryOperands[0],
+                                                               binaryOperands[1],
+                                                               binaryOperands[2]);
       case COUNT_DISTINCT -> requireSupported(executor.executeCountDistinct(ctx, sourcePath, groupField),
                                               "count-distinct");
       case GENERIC_PREDICATE_COUNT -> requireSupported(executor.executePredicateCount(ctx, sourcePath, predicate),


### PR DESCRIPTION
Two shapes the vectorized vocabulary could not express, so no backend was ever offered them and both fell to the generic pipeline. Measured on a 3.48M-record JSON corpus in SirixDB, they were the two worst shapes of a DuckDB comparison.

## `sum(for $m in ... return $m.a * $m.b)` — aggregate over an arithmetic expression

`VectorizedGroupByDetection` only claimed a bare `$loopVar.field` return, and its own comment names the hazard in doing otherwise: descending into the subtree for a field name would turn `return $u.a + $u.b` into an aggregate over `a`. So a product of two fields was not claimed at all, and the record pipeline materialized every record to reach two of its fields — ~150 ns per record against the ~3 ns a fused pass over two columns costs. SirixDB: **530 ms → 24.9 ms**.

- `AGGREGATE_BINARY` carries `{left, op, right}` and is set **instead of** `AGGREGATE_FIELD`, never beside it — the two say different things about what the executor must compute.
- Operators are closed to `*`, `+`, `-`. Division is excluded deliberately: over the integers a JSON document holds it is not closed, so a columnar fold and the interpreter would not agree.
- `FallbackOnNullExpr` is the other half. This is the one mode whose backend must be able to decline per **evaluation** rather than per compile — whether a columnar store covers both operand columns depends on the document the query is finally run against, and a commit can invalidate that store between two runs of one compiled query. The shape therefore keeps its generic compilation and chooses per evaluation, and is not substituted at all where no generic compilation is available to fall back to.

## `some $g in $u.field[] satisfies $g eq "literal"` — array membership

`PredicateNode` had no quantified form. `ArrayContains` is distinct from `StrEq` because the field holds a **sequence**: a backend must test every element rather than one value, which decides which column and which linkage it reads. SirixDB: **1,726 ms → 192.9 ms**.

- **Existential only.** `every $g in ... satisfies ...` is vacuously true on a record whose array is empty, and on one with no such field at all, so it cannot anchor on that field — which is the property anchored backends rely on to visit candidate records. It is not expressed here.
- Soundly anchorable on its field for the ordinary reason: a record that does not carry the field carries no element either.
- Detection requires the index to be the **empty** sequence: `$u.f[]` iterates every element while `$u.f[[1]]` names one, and reading the second as the first would test a different value.
- `brackit.predicate.arrayContains=false` takes the claim back without a rebuild.

Both additions are opt-in for backends: `supportsBinaryAggregate()` defaults to false, and a backend that does not recognise `ArrayContains` simply never receives it.